### PR TITLE
Game Window Class clean up

### DIFF
--- a/Examples/GameloopExamples.cs
+++ b/Examples/GameloopExamples.cs
@@ -168,7 +168,7 @@ namespace Examples
                 {
                     Undecorated = false,
                     Focused = true,
-                    WindowDisplayState = WindowDisplayState.Normal,
+                    // WindowDisplayState = WindowDisplayState.Normal,
                     WindowBorder = WindowBorder.Resizabled,
                     WindowMinSize = new(480, 270),
                     WindowSize = new(960, 540),
@@ -515,26 +515,24 @@ namespace Examples
             UIRects.UpdateRect(ui.Area);
             UIRects.Update(time.Delta, ui.MousePos);
 
-            //int gamepadIndex = CurGamepad?.Index ?? -1;
             InputAction.UpdateActions(time.Delta, CurGamepad, inputActions);
 
             var fullscreenState = InputActionFullscreen.Consume();
             if (fullscreenState is { Consumed: false, Pressed: true })
             {
-                Window.DisplayState = Window.DisplayState == WindowDisplayState.Fullscreen ? WindowDisplayState.Normal : WindowDisplayState.Fullscreen;
+                GAMELOOP.Window.ToggleBorderlessFullscreen();
             }
 
             var maximizeState = InputActionMaximize.Consume();
             if (maximizeState is { Consumed: false, Pressed: true })
             {
-                Window.DisplayState = Window.DisplayState == WindowDisplayState.Maximized ? WindowDisplayState.Normal : WindowDisplayState.Maximized;
-                // GAMELOOP.Maximized = !GAMELOOP.Maximized;
+                GAMELOOP.Window.ToggleMaximizeWindow();
             }
 
             var nextMonitorState = InputActionNextMonitor.Consume();
             if (nextMonitorState is { Consumed: false, Pressed: true })
             {
-               Window.NextMonitor(); // GAMELOOP.NextMonitor();
+               Window.NextMonitor();
             }
 
             if (Paused) return;

--- a/Examples/GameloopExamples.cs
+++ b/Examples/GameloopExamples.cs
@@ -164,7 +164,27 @@ namespace Examples
         public GameloopExamples() : base
             (
                 GameSettings.StretchMode, 
-                WindowSettings.Default
+                new WindowSettings()
+                {
+                    Undecorated = false,
+                    Focused = true,
+                    WindowDisplayState = WindowDisplayState.Normal,
+                    WindowBorder = WindowBorder.Resizabled,
+                    WindowMinSize = new(480, 270),
+                    WindowSize = new(960, 540),
+                    Monitor = 0,
+                    Vsync = false,
+                    FrameRateLimit = 60,
+                    MinFramerate = 30,
+                    MaxFramerate = 240,
+                    WindowOpacity = 1f,
+                    MouseEnabled = true,
+                    MouseVisible = false,
+                    Msaa4x = true,
+                    HighDPI = false,
+                    FramebufferTransparent = false
+                }
+                // WindowSettings.Default
             )
         {
 
@@ -301,14 +321,7 @@ namespace Examples
 
             fpsLabel = new(FontDefault, Colors.PcCold, Colors.PcText, Colors.PcHighlight);
             
-            // HideOSCursor();
-            Window.MouseVisible = false;
-            Window.MouseEnabled = true;
-            
-            // SwitchCursor(new SimpleCursorUI());
-
             paletteInfoBox = new();
-
         }
 
         protected override Vector2 ChangeMousePos(float dt, Vector2 mousePos, Rect screenArea)

--- a/Examples/GameloopExamples.cs
+++ b/Examples/GameloopExamples.cs
@@ -166,9 +166,9 @@ namespace Examples
                 GameSettings.StretchMode, 
                 new WindowSettings()
                 {
-                    Undecorated = false,
-                    Focused = true,
-                    // WindowDisplayState = WindowDisplayState.Normal,
+                    Title = "Shape Engine Examples",
+                    Topmost = false,
+                    FullscreenAutoRestoring = true,
                     WindowBorder = WindowBorder.Resizabled,
                     WindowMinSize = new(480, 270),
                     WindowSize = new(960, 540),

--- a/Examples/Scenes/ExampleScenes/EndlessSpaceCollision.cs
+++ b/Examples/Scenes/ExampleScenes/EndlessSpaceCollision.cs
@@ -10,7 +10,6 @@ using ShapeEngine.Core.Interfaces;
 using ShapeEngine.Core.Structs;
 using ShapeEngine.Core.Shapes;
 using ShapeEngine.Input;
-using Color = System.Drawing.Color;
 using Size = ShapeEngine.Core.Structs.Size;
 
 namespace Examples.Scenes.ExampleScenes;

--- a/Examples/Scenes/ExampleScenes/ShapeDrawingExample.cs
+++ b/Examples/Scenes/ExampleScenes/ShapeDrawingExample.cs
@@ -1,5 +1,6 @@
 using System.Numerics;
 using ShapeEngine.Color;
+using ShapeEngine.Core;
 using ShapeEngine.Core.Shapes;
 using ShapeEngine.Core.Structs;
 using ShapeEngine.Input;
@@ -419,7 +420,16 @@ public class ShapeDrawingExample : ExampleScene
         if (shapeIndex == 5) return "Polygon";
         return "Polyline";
     }
-   
+
+    protected override void OnActivate(Scene oldScene)
+    {
+        GAMELOOP.Window.MouseVisible = true;
+    }
+
+    protected override void OnDeactivate()
+    {
+        GAMELOOP.Window.MouseVisible = false;
+    }
 }
 
 

--- a/Examples/Scenes/ExampleScenes/ShapeDrawingExample.cs
+++ b/Examples/Scenes/ExampleScenes/ShapeDrawingExample.cs
@@ -421,15 +421,6 @@ public class ShapeDrawingExample : ExampleScene
         return "Polyline";
     }
 
-    protected override void OnActivate(Scene oldScene)
-    {
-        GAMELOOP.Window.MouseVisible = true;
-    }
-
-    protected override void OnDeactivate()
-    {
-        GAMELOOP.Window.MouseVisible = false;
-    }
 }
 
 

--- a/Examples/Scenes/MainScene.cs
+++ b/Examples/Scenes/MainScene.cs
@@ -221,8 +221,8 @@ namespace Examples.Scenes
             
             titleFont.FontSpacing = 1f;
             titleFont.ColorRgba = Colors.Medium;
-            titleFont.DrawTextWrapNone($"Window Focused: {GameWindow.IsWindowFocused} | [{pi}%]", infoAreaRects.top, new Vector2(1f, 1f));
-            titleFont.DrawTextWrapNone($"Cursor On Screen: {GameWindow.IsMouseOnScreen}", infoAreaRects.bottom, new Vector2(1f, 1f));
+            titleFont.DrawTextWrapNone($"Window Focused: {GameWindow.CurrentGameWindowInstance.IsWindowFocused} | [{pi}%]", infoAreaRects.top, new Vector2(1f, 1f));
+            titleFont.DrawTextWrapNone($"Cursor On Screen: {GameWindow.CurrentGameWindowInstance.MouseOnScreen}", infoAreaRects.bottom, new Vector2(1f, 1f));
 
 
             var inputInfoRect = ui.Area.ApplyMargins(0.75f, 0.01f, 0.75f, 0.01f);

--- a/Examples/Scenes/MainScene.cs
+++ b/Examples/Scenes/MainScene.cs
@@ -98,20 +98,17 @@ namespace Examples.Scenes
             var maximizedState = GAMELOOP.InputActionMaximize.Consume();
             if (maximizedState is { Consumed: false, Pressed: true })
             { 
-                // GAMELOOP.Maximized = !GAMELOOP.Maximized;
-                GAMELOOP.Window.DisplayState = GAMELOOP.Window.DisplayState == WindowDisplayState.Maximized ? WindowDisplayState.Normal : WindowDisplayState.Maximized;
+                GAMELOOP.Window.ToggleMaximizeWindow();
             }
             var minimizeState = GAMELOOP.InputActionMinimize.Consume();
             if (minimizeState is { Consumed: false, Pressed: true })
             { 
-                // GAMELOOP.Maximized = !GAMELOOP.Maximized;
-                GAMELOOP.Window.DisplayState = GAMELOOP.Window.DisplayState == WindowDisplayState.Minimized ? WindowDisplayState.Normal : WindowDisplayState.Minimized;
+                GAMELOOP.Window.ToggleMinimizeWindow();
             }
             var fullscreenState = GAMELOOP.InputActionFullscreen.Consume();
             if (fullscreenState is { Consumed: false, Pressed: true })
             { 
-                // GAMELOOP.Fullscreen = !GAMELOOP.Fullscreen;
-                GAMELOOP.Window.DisplayState = GAMELOOP.Window.DisplayState == WindowDisplayState.Fullscreen ? WindowDisplayState.Normal : WindowDisplayState.Fullscreen;
+                GAMELOOP.Window.ToggleBorderlessFullscreen();
             }
 
             var prevTabState = GAMELOOP.InputActionUIPrevTab.Consume();

--- a/Examples/Scenes/MainScene.cs
+++ b/Examples/Scenes/MainScene.cs
@@ -224,7 +224,7 @@ namespace Examples.Scenes
             
             titleFont.FontSpacing = 1f;
             titleFont.ColorRgba = Colors.Medium;
-            titleFont.DrawTextWrapNone($"Window Focused: {Raylib.IsWindowFocused()} | [{pi}%]", infoAreaRects.top, new Vector2(1f, 1f));
+            titleFont.DrawTextWrapNone($"Window Focused: {GameWindow.IsWindowFocused} | [{pi}%]", infoAreaRects.top, new Vector2(1f, 1f));
             titleFont.DrawTextWrapNone($"Cursor On Screen: {GameWindow.IsMouseOnScreen}", infoAreaRects.bottom, new Vector2(1f, 1f));
 
 

--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ When using Shape Engine everything from Raylib is available as well. ([Raylib Ex
 
 
 ## Minimal Project Setup
-<img width="1236" alt="shapeengine-minimal-project-setup2" src="https://github.com/DaveGreen-Games/ShapeEngine/assets/34277803/2e515cec-34c7-40b2-98ea-4d4be90f9d08">
 
-```
+```c#
+
 using System.Drawing;
 using ShapeEngine.Color;
 using ShapeEngine.Core;
@@ -34,23 +34,19 @@ using ShapeEngine.Lib;
 
 namespace ShapeEngineProject;
 
-
 public static class Program
 {
     public static void Main(string[] args)
     {
-        var gameSettings = new GameSettings()
-        {
-            DevelopmentDimensions = new Dimensions(1920, 1080),
-            MultiShaderSupport = false
-        };
-        var game = new MyGameClass(gameSettings, WindowSettings.Default);
-        game.Run();
+	var game = new Game(GameSettings.StretchMode, WindowSettings.Default);
+	game.Run();
     }
 }
+
 public class MyGameClass : Game
 {
     public MyGameClass(GameSettings gameSettings, WindowSettings windowSettings) : base(gameSettings, windowSettings) { }
+    
     protected override void DrawGame(ScreenInfo game)
     {
         game.Area.Draw(new ColorRgba(Color.DarkOliveGreen));
@@ -58,6 +54,7 @@ public class MyGameClass : Game
         game.MousePos.Draw(24f, new ColorRgba(Color.Lime), 36);
     }
 }
+
 ```
 
 

--- a/ShapeEngine/Core/GameWindow.cs
+++ b/ShapeEngine/Core/GameWindow.cs
@@ -287,7 +287,7 @@ public sealed class GameWindow
             var newState = value;
             if (value == WindowDisplayState.Normal)
             {
-                Raylib.SetWindowState(ConfigFlags.TopmostWindow);
+                // Raylib.SetWindowState(ConfigFlags.TopmostWindow);
                 if (displayState == WindowDisplayState.Minimized)
                 {
                     Raylib.ClearWindowState(ConfigFlags.MinimizedWindow);
@@ -360,7 +360,7 @@ public sealed class GameWindow
             }
             else if (value == WindowDisplayState.Maximized)
             {
-                Raylib.SetWindowState(ConfigFlags.TopmostWindow);
+                // Raylib.SetWindowState(ConfigFlags.TopmostWindow);
                 
                 if (displayState == WindowDisplayState.Fullscreen)
                 {
@@ -383,7 +383,7 @@ public sealed class GameWindow
             }
             else if (value == WindowDisplayState.Minimized)
             {
-                Raylib.ClearWindowState(ConfigFlags.TopmostWindow);
+                // Raylib.ClearWindowState(ConfigFlags.TopmostWindow);
                 PrevMinimizedDisplayState = new(CurScreenSize, Raylib.GetWindowPosition(), DisplayState);
                 
                 if (displayState == WindowDisplayState.Fullscreen)
@@ -409,7 +409,7 @@ public sealed class GameWindow
             else if (value == WindowDisplayState.Fullscreen)
             {
                 PrevFullscreenDisplayState = new(CurScreenSize, Raylib.GetWindowPosition(), displayState);
-                Raylib.SetWindowState(ConfigFlags.TopmostWindow);
+                // Raylib.SetWindowState(ConfigFlags.TopmostWindow);
 
                 if (Game.IsOSX())
                 {
@@ -434,7 +434,6 @@ public sealed class GameWindow
             if(displayState != WindowDisplayState.Minimized) ResetMousePosition();
         }
     }
-    
     public WindowBorder WindowBorder
     {
         get => windowBorder;
@@ -464,7 +463,7 @@ public sealed class GameWindow
     }
     public Rect ScreenArea { get; private set; }
     
-    
+    // public bool MouseOnScreen { get; private set; }
     #endregion
 
     #region Private Members
@@ -483,6 +482,11 @@ public sealed class GameWindow
 
     private CursorState cursorState;
     private WindowConfigFlags windowConfigFlags;
+
+    /// <summary>
+    /// Stores prev fullscreen state when window loses focus while in fullscreen
+    /// </summary>
+    private bool wasFullscreen = false;
     
     // private Vector2 lastControlledMousePosition = new();
     // private bool mouseControlled = false;
@@ -513,7 +517,7 @@ public sealed class GameWindow
         
         if (windowSettings.Focused)
         {
-            Raylib.SetWindowState(ConfigFlags.TopmostWindow);
+            // Raylib.SetWindowState(ConfigFlags.TopmostWindow);
             Raylib.ClearWindowState(ConfigFlags.UnfocusedWindow);
         }
         else Raylib.SetWindowState(ConfigFlags.UnfocusedWindow);
@@ -643,6 +647,23 @@ public sealed class GameWindow
         if (cur.HasFocusedChanged(windowConfigFlags))
         {
             OnWindowFocusChanged?.Invoke(cur.Focused);
+            if (!cur.Focused)
+            {
+                //auto iconify behavior without the iconify ;)
+                if (DisplayState == WindowDisplayState.Fullscreen)
+                {
+                    DisplayState = WindowDisplayState.Normal;
+                    wasFullscreen = true;
+                }
+            }
+            else
+            {
+                if (wasFullscreen)
+                {
+                    DisplayState = WindowDisplayState.Fullscreen;
+                    wasFullscreen = false;
+                }   
+            }
         }
         if (cur.HasAlwaysRunChanged(windowConfigFlags))
         {

--- a/ShapeEngine/Core/GameWindow.cs
+++ b/ShapeEngine/Core/GameWindow.cs
@@ -322,37 +322,39 @@ public sealed class GameWindow
                 }
                 else if (displayState == WindowDisplayState.Fullscreen)
                 {
-                    if (Game.IsOSX())
+                    Raylib.ClearWindowState(ConfigFlags.FullscreenMode);
+                    Raylib.SetWindowSize(PrevFullscreenDisplayState.WindowSize.Width, PrevFullscreenDisplayState.WindowSize.Height);
+                    Raylib.SetWindowPosition((int)PrevFullscreenDisplayState.WindowPosition.X, (int)PrevFullscreenDisplayState.WindowPosition.Y);
+
+                    if (PrevFullscreenDisplayState.DisplayState == WindowDisplayState.Minimized)
                     {
-                        Raylib.ClearWindowState(ConfigFlags.FullscreenMode);
-                        Raylib.SetWindowSize(PrevFullscreenDisplayState.WindowSize.Width, PrevFullscreenDisplayState.WindowSize.Height);
-                        Raylib.SetWindowPosition((int)PrevFullscreenDisplayState.WindowPosition.X, (int)PrevFullscreenDisplayState.WindowPosition.Y);
-
-                        if (PrevFullscreenDisplayState.DisplayState == WindowDisplayState.Minimized)
-                        {
-                            Raylib.SetWindowState(ConfigFlags.MinimizedWindow);
-                            newState = WindowDisplayState.Minimized;
-                        }
-
-                        else if (PrevFullscreenDisplayState.DisplayState == WindowDisplayState.Maximized)
-                        {
-                            Raylib.SetWindowState(ConfigFlags.MaximizedWindow);
-                            newState = WindowDisplayState.Maximized;
-                        }
+                        Raylib.SetWindowState(ConfigFlags.MinimizedWindow);
+                        newState = WindowDisplayState.Minimized;
                     }
-                    else
+
+                    else if (PrevFullscreenDisplayState.DisplayState == WindowDisplayState.Maximized)
                     {
-                        Raylib.ToggleBorderlessWindowed();
-                        if (PrevFullscreenDisplayState.DisplayState == WindowDisplayState.Minimized)
-                        {
-                            newState = WindowDisplayState.Minimized;
-                        }
-
-                        else if (PrevFullscreenDisplayState.DisplayState == WindowDisplayState.Maximized)
-                        {
-                            newState = WindowDisplayState.Maximized;
-                        }
+                        Raylib.SetWindowState(ConfigFlags.MaximizedWindow);
+                        newState = WindowDisplayState.Maximized;
                     }
+
+                    // if (Game.IsOSX())
+                    // {
+                    //     
+                    // }
+                    // else
+                    // {
+                    //     Raylib.ToggleBorderlessWindowed();
+                    //     if (PrevFullscreenDisplayState.DisplayState == WindowDisplayState.Minimized)
+                    //     {
+                    //         newState = WindowDisplayState.Minimized;
+                    //     }
+                    //
+                    //     else if (PrevFullscreenDisplayState.DisplayState == WindowDisplayState.Maximized)
+                    //     {
+                    //         newState = WindowDisplayState.Maximized;
+                    //     }
+                    // }
                     
                 }
             }
@@ -409,23 +411,34 @@ public sealed class GameWindow
                 PrevFullscreenDisplayState = new(CurScreenSize, Raylib.GetWindowPosition(), displayState);
                 // Raylib.SetWindowState(ConfigFlags.TopmostWindow);
 
-                if (Game.IsOSX())
+                if (displayState == WindowDisplayState.Maximized) Raylib.ClearWindowState(ConfigFlags.MaximizedWindow);
+                else if (displayState == WindowDisplayState.Minimized)
                 {
-                    if (displayState == WindowDisplayState.Maximized) Raylib.ClearWindowState(ConfigFlags.MaximizedWindow);
-                    else if (displayState == WindowDisplayState.Minimized)
-                    {
-                        Raylib.ClearWindowState(ConfigFlags.MinimizedWindow);
-                    }
+                    Raylib.ClearWindowState(ConfigFlags.MinimizedWindow);
+                }
                 
-                    var mDim = Monitor.CurMonitor().Dimensions;
-                    var dpi = Raylib.GetWindowScaleDPI();
-                    Raylib.SetWindowSize(mDim.Width * (int)dpi.X, mDim.Height * (int)dpi.Y);
-                    Raylib.SetWindowState(ConfigFlags.FullscreenMode);
-                }
-                else
-                {
-                    Raylib.ToggleBorderlessWindowed();
-                }
+                var mDim = Monitor.CurMonitor().Dimensions;
+                var dpi = Raylib.GetWindowScaleDPI();
+                Raylib.SetWindowSize(mDim.Width * (int)dpi.X, mDim.Height * (int)dpi.Y);
+                Raylib.SetWindowState(ConfigFlags.FullscreenMode);
+                
+                // if (Game.IsOSX())
+                // {
+                //     if (displayState == WindowDisplayState.Maximized) Raylib.ClearWindowState(ConfigFlags.MaximizedWindow);
+                //     else if (displayState == WindowDisplayState.Minimized)
+                //     {
+                //         Raylib.ClearWindowState(ConfigFlags.MinimizedWindow);
+                //     }
+                //
+                //     var mDim = Monitor.CurMonitor().Dimensions;
+                //     var dpi = Raylib.GetWindowScaleDPI();
+                //     Raylib.SetWindowSize(mDim.Width * (int)dpi.X, mDim.Height * (int)dpi.Y);
+                //     Raylib.SetWindowState(ConfigFlags.FullscreenMode);
+                // }
+                // else
+                // {
+                //     Raylib.ToggleBorderlessWindowed();
+                // }
             }
             
             displayState = newState;
@@ -684,16 +697,15 @@ public sealed class GameWindow
         if (cur.HasMaximizedChanged(windowConfigFlags))
         {
             OnWindowMaximizeChanged?.Invoke(cur.Maximized);
-            if (cur.Maximized)
-            {
-                displayState = WindowDisplayState.Maximized;
-            }
+            if (cur.Maximized) displayState = WindowDisplayState.Maximized;
+            else displayState = WindowDisplayState.Normal;
         }
         
         if (cur.HasMinimizedChanged(windowConfigFlags))
         {
             OnWindowMinimizedChanged?.Invoke(cur.Minimized);
             if(cur.Minimized) displayState = WindowDisplayState.Minimized;
+            else displayState = WindowDisplayState.Normal;
         }
         if (cur.HasHiddenChanged(windowConfigFlags))
         {

--- a/ShapeEngine/Core/GameWindow.cs
+++ b/ShapeEngine/Core/GameWindow.cs
@@ -6,32 +6,6 @@ using ShapeEngine.Screen;
 
 namespace ShapeEngine.Core;
 
-/*
- 
-Set before init window with window setting struct
-ConfigFlags.TransparentWindow;
-ConfigFlags.Msaa4xHint;
-ConfigFlags.InterlacedHint;
-ConfigFlags.HighDpiWindow;
-            
-WindowMode struct
-ConfigFlags.FullscreenMode;
-ConfigFlags.BorderlessWindowMode;
-ConfigFlags.MaximizedWindow;
-ConfigFlags.MinimizedWindow;
-ConfigFlags.HiddenWindow;
-
-ShapeConfigFlags
-ConfigFlags.TopmostWindow;
-ConfigFlags.UndecoratedWindow;
-ConfigFlags.UnfocusedWindow;
-ConfigFlags.AlwaysRunWindow;
-ConfigFlags.MousePassthroughWindow;
-ConfigFlags.VSyncHint;
-ConfigFlags.ResizableWindow;
-*/
-
-
 
 public sealed class GameWindow
 {
@@ -190,11 +164,9 @@ public sealed class GameWindow
     public event Action<bool>? OnWindowMousePassThroughChanged;
     public event Action<bool>? OnWindowVSyncChanged;
     
-    
     #endregion
 
     #region Public Members
-    // public bool MouseOnScreen { get; private set; }
     public MonitorDevice Monitor { get; private set; }
     public Dimensions CurScreenSize { get; private set; }
     public Dimensions WindowMinSize { get; private set; }
@@ -500,9 +472,6 @@ public sealed class GameWindow
     private WindowDisplayState displayState = WindowDisplayState.Normal;
     private WindowBorder windowBorder = WindowBorder.Fixed;
     
-    // private Dimensions prevDisplayStateChangeWindowSize = new(128, 128);
-    // private Vector2 prevDisplayStateChangeWindowPosition = new(0);
-    // private WindowDisplayState prevDisplayStateChangeDisplayState = WindowDisplayState.Normal;
     private PrevDisplayStateInfo PrevFullscreenDisplayState = new(new(128, 128), new(), WindowDisplayState.Normal);
     private PrevDisplayStateInfo PrevMinimizedDisplayState = new(new(128, 128), new(), WindowDisplayState.Normal);
     
@@ -511,7 +480,6 @@ public sealed class GameWindow
     
     private bool? wasMouseEnabled = null;
     private bool? wasMouseVisible = null;
-    
 
     private CursorState cursorState;
     private WindowConfigFlags windowConfigFlags;
@@ -521,6 +489,9 @@ public sealed class GameWindow
     // private bool focusLostFullscreen = false;
     // private WindowFlagState windowFlagState;
     // private WindowConfigFlags prevWindowConfigFlags;
+    // private Dimensions prevDisplayStateChangeWindowSize = new(128, 128);
+    // private Vector2 prevDisplayStateChangeWindowPosition = new(0);
+    // private WindowDisplayState prevDisplayStateChangeDisplayState = WindowDisplayState.Normal;
     #endregion
 
     #region Internal

--- a/ShapeEngine/Core/GameWindow.cs
+++ b/ShapeEngine/Core/GameWindow.cs
@@ -304,6 +304,7 @@ public sealed class GameWindow
         }
     }
     public static bool IsMouseOnScreen { get; private set; }
+    public static bool IsWindowFocused => Raylib.IsWindowFocused();
     public WindowDisplayState DisplayState
     {
         get => displayState;

--- a/ShapeEngine/Core/GameWindow.cs
+++ b/ShapeEngine/Core/GameWindow.cs
@@ -292,13 +292,16 @@ public sealed class GameWindow
                     
                     if (PrevMinimizedDisplayState.DisplayState == WindowDisplayState.Fullscreen)
                     {
-                        if (Game.IsOSX())
-                        {
-                            var mDim = Monitor.CurMonitor().Dimensions;
-                            Raylib.SetWindowSize(mDim.Width, mDim.Height);
-                            Raylib.SetWindowState(ConfigFlags.FullscreenMode);
-                        }
-                        else Raylib.ToggleBorderlessWindowed();
+                        var mDim = Monitor.CurMonitor().Dimensions;
+                        Raylib.SetWindowSize(mDim.Width, mDim.Height);
+                        Raylib.SetWindowState(ConfigFlags.FullscreenMode);
+                        // if (Game.IsOSX())
+                        // {
+                        //     var mDim = Monitor.CurMonitor().Dimensions;
+                        //     Raylib.SetWindowSize(mDim.Width, mDim.Height);
+                        //     Raylib.SetWindowState(ConfigFlags.FullscreenMode);
+                        // }
+                        // else Raylib.ToggleBorderlessWindowed();
                         
                         newState = WindowDisplayState.Fullscreen;
                     }
@@ -364,17 +367,20 @@ public sealed class GameWindow
                 
                 if (displayState == WindowDisplayState.Fullscreen)
                 {
-                    if (Game.IsOSX())
-                    {
-                        Raylib.ClearWindowState(ConfigFlags.FullscreenMode);
-                        Raylib.SetWindowSize(PrevFullscreenDisplayState.WindowSize.Width, PrevFullscreenDisplayState.WindowSize.Height);
-                        Raylib.SetWindowPosition((int)PrevFullscreenDisplayState.WindowPosition.X, (int)PrevFullscreenDisplayState.WindowPosition.Y);
-                    }
-                    else
-                    {
-                        Raylib.ToggleBorderlessWindowed();
-                    }
+                    Raylib.ClearWindowState(ConfigFlags.FullscreenMode);
+                    Raylib.SetWindowSize(PrevFullscreenDisplayState.WindowSize.Width, PrevFullscreenDisplayState.WindowSize.Height);
+                    Raylib.SetWindowPosition((int)PrevFullscreenDisplayState.WindowPosition.X, (int)PrevFullscreenDisplayState.WindowPosition.Y);
                     
+                    // if (Game.IsOSX())
+                    // {
+                    //     Raylib.ClearWindowState(ConfigFlags.FullscreenMode);
+                    //     Raylib.SetWindowSize(PrevFullscreenDisplayState.WindowSize.Width, PrevFullscreenDisplayState.WindowSize.Height);
+                    //     Raylib.SetWindowPosition((int)PrevFullscreenDisplayState.WindowPosition.X, (int)PrevFullscreenDisplayState.WindowPosition.Y);
+                    // }
+                    // else
+                    // {
+                    //     Raylib.ToggleBorderlessWindowed();
+                    // }
                 
                 }
                 else if (displayState == WindowDisplayState.Minimized)Raylib.ClearWindowState(ConfigFlags.MinimizedWindow);
@@ -388,13 +394,16 @@ public sealed class GameWindow
                 
                 if (displayState == WindowDisplayState.Fullscreen)
                 {
-                    if (Game.IsOSX())
-                    {
-                        Raylib.ClearWindowState(ConfigFlags.FullscreenMode);
-                        Raylib.SetWindowSize(PrevFullscreenDisplayState.WindowSize.Width, PrevFullscreenDisplayState.WindowSize.Height);
-                        Raylib.SetWindowPosition((int)PrevFullscreenDisplayState.WindowPosition.X, (int)PrevFullscreenDisplayState.WindowPosition.Y);
-                    }
-                    else Raylib.ToggleBorderlessWindowed();
+                    Raylib.ClearWindowState(ConfigFlags.FullscreenMode);
+                    Raylib.SetWindowSize(PrevFullscreenDisplayState.WindowSize.Width, PrevFullscreenDisplayState.WindowSize.Height);
+                    Raylib.SetWindowPosition((int)PrevFullscreenDisplayState.WindowPosition.X, (int)PrevFullscreenDisplayState.WindowPosition.Y);
+                    // if (Game.IsOSX())
+                    // {
+                    //     Raylib.ClearWindowState(ConfigFlags.FullscreenMode);
+                    //     Raylib.SetWindowSize(PrevFullscreenDisplayState.WindowSize.Width, PrevFullscreenDisplayState.WindowSize.Height);
+                    //     Raylib.SetWindowPosition((int)PrevFullscreenDisplayState.WindowPosition.X, (int)PrevFullscreenDisplayState.WindowPosition.Y);
+                    // }
+                    // else Raylib.ToggleBorderlessWindowed();
                     
                 
                 }
@@ -697,15 +706,16 @@ public sealed class GameWindow
         if (cur.HasMaximizedChanged(windowConfigFlags))
         {
             OnWindowMaximizeChanged?.Invoke(cur.Maximized);
-            if (cur.Maximized) displayState = WindowDisplayState.Maximized;
-            else displayState = WindowDisplayState.Normal;
+            
+            if (cur.Maximized && displayState != WindowDisplayState.Maximized) displayState = WindowDisplayState.Maximized;
+            else if(!cur.Maximized && displayState == WindowDisplayState.Maximized) displayState = WindowDisplayState.Normal;
         }
         
         if (cur.HasMinimizedChanged(windowConfigFlags))
         {
             OnWindowMinimizedChanged?.Invoke(cur.Minimized);
-            if(cur.Minimized) displayState = WindowDisplayState.Minimized;
-            else displayState = WindowDisplayState.Normal;
+            if(cur.Minimized && displayState != WindowDisplayState.Minimized) displayState = WindowDisplayState.Minimized;
+            else if(!cur.Minimized && displayState == WindowDisplayState.Minimized) displayState = WindowDisplayState.Normal;
         }
         if (cur.HasHiddenChanged(windowConfigFlags))
         {

--- a/ShapeEngine/Core/GameWindow.cs
+++ b/ShapeEngine/Core/GameWindow.cs
@@ -725,8 +725,8 @@ public sealed class GameWindow
     
     private void CheckForCursorChanges()
     {
-        // mouseControlled = false;
-        MouseOnScreen = Raylib.IsCursorOnScreen() || ScreenArea.ContainsPoint(MousePosition);
+        
+        MouseOnScreen = Raylib.IsCursorOnScreen() || (Raylib.IsWindowFocused() && ScreenArea.ContainsPoint(MousePosition));
         
         var curCursorState = GetCurCursorState();
         

--- a/ShapeEngine/Core/GameWindow.cs
+++ b/ShapeEngine/Core/GameWindow.cs
@@ -79,8 +79,6 @@ public sealed class GameWindow
         public bool HasMaximizedChanged(WindowConfigFlags other) => Maximized != other.Maximized;
         public bool HasFullscreenChanged(WindowConfigFlags other) => Fullscreen != other.Fullscreen;
         public bool HasHiddenChanged(WindowConfigFlags other) => Hidden != other.Hidden;
-
-
         
     }
 
@@ -505,7 +503,8 @@ public sealed class GameWindow
         if(windowSettings.HighDPI) Raylib.SetConfigFlags(ConfigFlags.HighDpiWindow);
         if(windowSettings.FramebufferTransparent) Raylib.SetConfigFlags(ConfigFlags.TransparentWindow);
         
-        Raylib.InitWindow(windowSettings.WindowMinSize.Width, windowSettings.WindowMinSize.Height, windowSettings.Title);
+        // Raylib.InitWindow(windowSettings.WindowMinSize.Width, windowSettings.WindowMinSize.Height, windowSettings.Title);
+        Raylib.InitWindow(0,0, windowSettings.Title);//sets autoiconify to false until my changes are in raylib cs
         Raylib.SetWindowOpacity(0f);
         
         Monitor = new MonitorDevice();

--- a/ShapeEngine/Core/GameWindow.cs
+++ b/ShapeEngine/Core/GameWindow.cs
@@ -31,95 +31,106 @@ ConfigFlags.VSyncHint;
 ConfigFlags.ResizableWindow;
 */
 
-public struct WindowConfigFlags
-{
-    public static WindowConfigFlags AllFalse => new WindowConfigFlags()
-    {
-        Undecorated = false,
-        Resizable = false,
-        Topmost = false,
-        Unfocused = false,
-        AlwaysRun = false,
-        MousePassThrough = false,
-        VSync = false
-    };
-    public static WindowConfigFlags AllTrue => new WindowConfigFlags()
-    {
-        Undecorated = true,
-        Resizable = true,
-        Topmost = true,
-        Unfocused = true,
-        AlwaysRun = true,
-        MousePassThrough = true,
-        VSync = true
-    };
-    public static WindowConfigFlags Default => new WindowConfigFlags()
-    {
-        Undecorated = false,
-        Resizable = true,
-        Topmost = false,
-        Unfocused = false,
-        AlwaysRun = true,
-        MousePassThrough = true,
-        VSync = true
-    };
-    
-    public bool Undecorated;
-    public bool Resizable;
-    public bool Topmost;
-    public bool Unfocused;
-    public bool AlwaysRun;
-    public bool MousePassThrough;
-    public bool VSync;
-
-    public bool HasUndecoratedChanged(WindowConfigFlags other) => Undecorated != other.Undecorated;
-    public bool HasResizableChanged(WindowConfigFlags other) => Resizable != other.Resizable;
-    public bool HasTopmostChanged(WindowConfigFlags other) => Topmost != other.Topmost;
-    public bool HasUnfocusedChanged(WindowConfigFlags other) => Unfocused != other.Unfocused;
-    public bool HasAlwaysRunChanged(WindowConfigFlags other) => AlwaysRun != other.AlwaysRun;
-    public bool HasMousePassThroughChanged(WindowConfigFlags other) => MousePassThrough != other.MousePassThrough;
-    public bool HasVSyncChanged(WindowConfigFlags other) => VSync != other.VSync;
-    
-    
-    public static WindowConfigFlags Get()
-    {
-        return new()
-        {
-            Undecorated = Raylib.IsWindowState(ConfigFlags.UndecoratedWindow),
-            Resizable = Raylib.IsWindowState(ConfigFlags.ResizableWindow),
-            Topmost = Raylib.IsWindowState(ConfigFlags.TopmostWindow),
-            Unfocused = Raylib.IsWindowState(ConfigFlags.UnfocusedWindow),
-            AlwaysRun = Raylib.IsWindowState(ConfigFlags.AlwaysRunWindow),
-            MousePassThrough = Raylib.IsWindowState(ConfigFlags.MousePassthroughWindow),
-            VSync = Raylib.IsWindowState(ConfigFlags.VSyncHint)
-        };
-    }
-}
 
 
 public sealed class GameWindow
 {
     #region Structs
-    private readonly struct WindowFlagState
+    private readonly struct WindowConfigFlags
     {
+        public static WindowConfigFlags Get() => new();
+        public static WindowConfigFlags GetAllFalse() => new WindowConfigFlags(false);
+        public static WindowConfigFlags GetAllTrue() => new WindowConfigFlags(true);
+
+        
+        /// <summary>
+        /// Sets all flags to value.
+        /// </summary>
+        /// <param name="value"></param>
+        public WindowConfigFlags(bool value)
+        {
+            Undecorated = value;
+            Resizable = value;
+            Topmost = value;
+            Focused = value;
+            AlwaysRun = value;
+            MousePassThrough = value;
+            VSync = value;
+            Minimized = value;
+            Maximized = value;
+            Fullscreen = value;
+            Hidden = value;
+        }
+
+        /// <summary>
+        /// Gets the current values from raylib.
+        /// </summary>
+        public WindowConfigFlags()
+        {
+            Undecorated = Raylib.IsWindowState(ConfigFlags.UndecoratedWindow);
+            Resizable = Raylib.IsWindowState(ConfigFlags.ResizableWindow);
+            Topmost = Raylib.IsWindowState(ConfigFlags.TopmostWindow);
+            Focused = !Raylib.IsWindowState(ConfigFlags.UnfocusedWindow);
+            AlwaysRun = Raylib.IsWindowState(ConfigFlags.AlwaysRunWindow);
+            MousePassThrough = Raylib.IsWindowState(ConfigFlags.MousePassthroughWindow);
+            VSync = Raylib.IsWindowState(ConfigFlags.VSyncHint);
+            Minimized = Raylib.IsWindowState(ConfigFlags.MinimizedWindow);
+            Maximized = Raylib.IsWindowState(ConfigFlags.MaximizedWindow);
+            Fullscreen = Raylib.IsWindowFullscreen();
+            Hidden = Raylib.IsWindowState(ConfigFlags.HiddenWindow);
+        }
+        
         public readonly bool Minimized;
         public readonly bool Maximized;
         public readonly bool Fullscreen;
         public readonly bool Hidden;
         public readonly bool Focused;
+        
+        public readonly bool Undecorated;
+        public readonly bool Resizable;
         public readonly bool Topmost;
+        public readonly bool AlwaysRun;
+        public readonly bool MousePassThrough;
+        public readonly bool VSync;
 
-        public WindowFlagState()
-        {
-            Fullscreen = Raylib.IsWindowFullscreen();
-            Maximized = Raylib.IsWindowMaximized();
-            Minimized = Raylib.IsWindowMinimized();
-            Hidden = Raylib.IsWindowHidden();
-            Focused = Raylib.IsWindowFocused();
-            Topmost = Raylib.IsWindowState(ConfigFlags.TopmostWindow);
+        public bool HasUndecoratedChanged(WindowConfigFlags other) => Undecorated != other.Undecorated;
+        public bool HasResizableChanged(WindowConfigFlags other) => Resizable != other.Resizable;
+        public bool HasTopmostChanged(WindowConfigFlags other) => Topmost != other.Topmost;
+        public bool HasFocusedChanged(WindowConfigFlags other) => Focused != other.Focused;
+        public bool HasAlwaysRunChanged(WindowConfigFlags other) => AlwaysRun != other.AlwaysRun;
+        public bool HasMousePassThroughChanged(WindowConfigFlags other) => MousePassThrough != other.MousePassThrough;
+        public bool HasVSyncChanged(WindowConfigFlags other) => VSync != other.VSync;
+        
+        public bool HasMinimizedChanged(WindowConfigFlags other) => Minimized != other.Minimized;
+        public bool HasMaximizedChanged(WindowConfigFlags other) => Maximized != other.Maximized;
+        public bool HasFullscreenChanged(WindowConfigFlags other) => Fullscreen != other.Fullscreen;
+        public bool HasHiddenChanged(WindowConfigFlags other) => Hidden != other.Hidden;
 
-        }
+
+        
     }
+
+    // private readonly struct WindowFlagState
+    // {
+    //     public readonly bool Minimized;
+    //     public readonly bool Maximized;
+    //     public readonly bool Fullscreen;
+    //     public readonly bool Hidden;
+    //     public readonly bool Focused;
+    //     public readonly bool Topmost;
+    //
+    //     public WindowFlagState()
+    //     {
+    //         Fullscreen = Raylib.IsWindowFullscreen();
+    //         Maximized = Raylib.IsWindowMaximized();
+    //         Minimized = Raylib.IsWindowMinimized();
+    //         Hidden = Raylib.IsWindowHidden();
+    //         Focused = Raylib.IsWindowFocused();
+    //         Topmost = Raylib.IsWindowState(ConfigFlags.TopmostWindow);
+    //
+    //     }
+    // }
+    
     private readonly struct CursorState
     {
         public readonly bool Visible;
@@ -159,26 +170,32 @@ public sealed class GameWindow
 
     public event Action? OnMouseLeftScreen;
     public event Action? OnMouseEnteredScreen;
+    public event Action<bool>? OnMouseVisibilityChanged;
+    public event Action<bool>? OnMouseEnabledChanged;
+    
     public event Action<DimensionConversionFactors>? OnWindowSizeChanged;
     public event Action<Vector2, Vector2>? OnWindowPositionChanged;
     public event Action<MonitorInfo>? OnMonitorChanged;
 
-    public event Action<bool>? OnMouseVisibilityChanged;
-    public event Action<bool>? OnMouseEnabledChanged;
-    
-    
     public event Action<bool>? OnWindowFocusChanged;
     public event Action<bool>? OnWindowFullscreenChanged;
     public event Action<bool>? OnWindowMaximizeChanged;
     public event Action<bool>? OnWindowMinimizedChanged;
     public event Action<bool>? OnWindowHiddenChanged;
     public event Action<bool>? OnWindowTopmostChanged;
+    
+    public event Action<bool>? OnWindowUndecoratedChanged;
+    public event Action<bool>? OnWindowResizableChanged;
+    public event Action<bool>? OnWindowAlwaysRunChanged;
+    public event Action<bool>? OnWindowMousePassThroughChanged;
+    public event Action<bool>? OnWindowVSyncChanged;
+    
+    
     #endregion
 
     #region Public Members
     // public bool MouseOnScreen { get; private set; }
     public MonitorDevice Monitor { get; private set; }
-    
     public Dimensions CurScreenSize { get; private set; }
     public Dimensions WindowMinSize { get; private set; }
     public Dimensions WindowSize
@@ -494,15 +511,15 @@ public sealed class GameWindow
     private bool? wasMouseEnabled = null;
     private bool? wasMouseVisible = null;
     
-    private Vector2 lastControlledMousePosition = new();
-    private bool mouseControlled = false;
 
     private CursorState cursorState;
-    private WindowFlagState windowFlagState;
-    private bool focusLostFullscreen = false;
-
-
-    private WindowConfigFlags prevWindowConfigFlags;
+    private WindowConfigFlags windowConfigFlags;
+    
+    // private Vector2 lastControlledMousePosition = new();
+    // private bool mouseControlled = false;
+    // private bool focusLostFullscreen = false;
+    // private WindowFlagState windowFlagState;
+    // private WindowConfigFlags prevWindowConfigFlags;
     #endregion
 
     #region Internal
@@ -553,17 +570,16 @@ public sealed class GameWindow
         MouseEnabled = windowSettings.MouseEnabled;
         
         cursorState = GetCurCursorState();
-        windowFlagState = new WindowFlagState(); // GetCurWindowFlagState();
+        // windowFlagState = new WindowFlagState(); // GetCurWindowFlagState();
 
         Raylib.SetWindowOpacity(windowSettings.WindowOpacity);
         // Raylib.ToggleBorderlessWindowed();
         
-        prevWindowConfigFlags = WindowConfigFlags.Get();
+        windowConfigFlags = WindowConfigFlags.Get();
     }
     
     internal void Update(float dt)
     {
-        
         // LerpOpacitiy(dt);
         
         var newMonitor = Monitor.HasMonitorChanged();
@@ -575,20 +591,18 @@ public sealed class GameWindow
 
         ScreenArea = new Rect(0, 0, CurScreenSize.Width, CurScreenSize.Height);
         
-        //TODO: not implemented yet -> should clean up CheckForWindowFlagChanges()
         CheckForWindowConfigFlagChanges();
-        CheckForWindowFlagChanges();
+        // CheckForWindowFlagChanges();
         CheckForCursorChanges();
         
-        //still necessary?
         if (MouseVisible == Raylib.IsCursorHidden()) MouseVisible = !Raylib.IsCursorHidden();
         
     }
     internal void MoveMouse(Vector2 mousePos)
     {
         mousePos = Vector2.Clamp(mousePos, new Vector2(0, 0), CurScreenSize.ToVector2());
-        lastControlledMousePosition = mousePos;
-        mouseControlled = true;
+        // lastControlledMousePosition = mousePos;
+        // mouseControlled = true;
 
         var mx = (int)MathF.Round(mousePos.X);
         var my = (int)MathF.Round(mousePos.Y);
@@ -636,42 +650,65 @@ public sealed class GameWindow
             CurScreenSize = new(w, h);
         }
     }
-
+    
     private void CheckForWindowConfigFlagChanges()
     {
         var cur = WindowConfigFlags.Get();
 
-        if (cur.HasResizableChanged(prevWindowConfigFlags))
+        if (cur.HasResizableChanged(windowConfigFlags))
         {
-            
+            OnWindowResizableChanged?.Invoke(cur.Resizable);
         }
-        if (cur.HasTopmostChanged(prevWindowConfigFlags))
+        if (cur.HasTopmostChanged(windowConfigFlags))
         {
-            
+            OnWindowTopmostChanged?.Invoke(cur.Topmost);
         }
-        if (cur.HasUndecoratedChanged(prevWindowConfigFlags))
+        if (cur.HasUndecoratedChanged(windowConfigFlags))
         {
-            
+            OnWindowUndecoratedChanged?.Invoke(cur.Undecorated);
         }
-        if (cur.HasUnfocusedChanged(prevWindowConfigFlags))
+        
+        if (cur.HasFocusedChanged(windowConfigFlags))
         {
-            
+            OnWindowFocusChanged?.Invoke(cur.Focused);
         }
-        if (cur.HasAlwaysRunChanged(prevWindowConfigFlags))
+        if (cur.HasAlwaysRunChanged(windowConfigFlags))
         {
-            
+            OnWindowAlwaysRunChanged?.Invoke(cur.AlwaysRun);
         }
-        if (cur.HasMousePassThroughChanged(prevWindowConfigFlags))
+        if (cur.HasMousePassThroughChanged(windowConfigFlags))
         {
-            
+            OnWindowMousePassThroughChanged?.Invoke(cur.MousePassThrough);
         }
-        if (cur.HasVSyncChanged(prevWindowConfigFlags))
+        
+        if (cur.HasVSyncChanged(windowConfigFlags))
         {
-            
+            OnWindowVSyncChanged?.Invoke(cur.VSync);
         }
-
-        prevWindowConfigFlags = cur;
-
+        if (cur.HasFullscreenChanged(windowConfigFlags))
+        {
+            OnWindowFullscreenChanged?.Invoke(cur.Fullscreen);
+        }
+        if (cur.HasMaximizedChanged(windowConfigFlags))
+        {
+            OnWindowMaximizeChanged?.Invoke(cur.Maximized);
+            if (cur.Maximized)
+            {
+                displayState = WindowDisplayState.Maximized;
+            }
+        }
+        
+        if (cur.HasMinimizedChanged(windowConfigFlags))
+        {
+            OnWindowMinimizedChanged?.Invoke(cur.Minimized);
+            if(cur.Minimized) displayState = WindowDisplayState.Minimized;
+        }
+        if (cur.HasHiddenChanged(windowConfigFlags))
+        {
+            OnWindowHiddenChanged?.Invoke(cur.Hidden);
+        }
+        
+        windowConfigFlags = cur;
     }
     
     private void CheckForWindowChanges()
@@ -681,7 +718,6 @@ public sealed class GameWindow
         if (prev != CurScreenSize)
         {
             if (displayState == WindowDisplayState.Normal) windowSize = CurScreenSize;
-            // SetConversionFactors();
             var conversion = new DimensionConversionFactors(prev, CurScreenSize);
             OnWindowSizeChanged?.Invoke(conversion);
         }
@@ -689,12 +725,67 @@ public sealed class GameWindow
         var curWindowPosition = Raylib.GetWindowPosition();
         if (curWindowPosition != WindowPosition)
         {
-            // prevWindowPosition = WindowPosition;
             WindowPosition = curWindowPosition;
             OnWindowPositionChanged?.Invoke(WindowPosition, curWindowPosition);
         }
     }
+    
+    private void CheckForCursorChanges()
+    {
+        // mouseControlled = false;
+        MouseOnScreen = Raylib.IsCursorOnScreen() || ScreenArea.ContainsPoint(MousePosition);
+        
+        var curCursorState = GetCurCursorState();
+        
+        if (!MouseOnScreen || Raylib.IsWindowState(ConfigFlags.MinimizedWindow))//fullscreen to minimize fix for enabling/showing os cursor
+        {
+            if (cursorState.OnScreen)//prev state
+            {
+                OnMouseLeftScreen?.Invoke();
+                if (wasMouseVisible == null) wasMouseVisible = cursorState.Visible;
+                if (wasMouseEnabled == null) wasMouseEnabled = cursorState.Enabled;
 
+                if (!mouseEnabled)
+                {
+                    Raylib.EnableCursor();
+                    mouseEnabled = true;
+                }
+
+                if (!mouseEnabled)
+                {
+                    Raylib.ShowCursor();
+                    mouseVisible = true;
+                }
+            }
+        }
+        else
+        {
+            if (!cursorState.OnScreen) //prev state
+            {
+                OnMouseEnteredScreen?.Invoke();
+                if (wasMouseVisible != null) MouseVisible = (bool)wasMouseVisible;
+                if (wasMouseEnabled != null) MouseEnabled = (bool)wasMouseEnabled;
+                // if (wasMouseVisible != null && wasMouseVisible == false) MouseVisible = false;
+                // if (wasMouseEnabled != null && wasMouseEnabled == false) MouseEnabled = false;
+
+                wasMouseVisible = null;
+                wasMouseEnabled = null;
+            }
+        }
+
+        if (MouseOnScreen)
+        {
+            if (curCursorState.Visible && !cursorState.Visible) OnMouseVisibilityChanged?.Invoke(false);
+            else if (!curCursorState.Visible && cursorState.Visible) OnMouseVisibilityChanged?.Invoke(true);
+            
+            if (curCursorState.Enabled && !cursorState.Enabled) OnMouseEnabledChanged?.Invoke(false);
+            else if (!curCursorState.Enabled && cursorState.Enabled) OnMouseEnabledChanged?.Invoke(true);
+        }
+        
+        cursorState = curCursorState;
+    }
+    
+    /*
     private void CheckForWindowFlagChanges()
     {
         // Console.WriteLine($"--------Minimized: {Raylib.IsWindowState(ConfigFlags.FLAG_WINDOW_MINIMIZED)}");
@@ -735,6 +826,7 @@ public sealed class GameWindow
             }
             Raylib.ClearWindowState(ConfigFlags.TopmostWindow);
         }
+        
         if (curWindowFlagState.Minimized && !windowFlagState.Minimized)
         {
             OnWindowMinimizedChanged?.Invoke(true);
@@ -801,45 +893,9 @@ public sealed class GameWindow
         
         windowFlagState = curWindowFlagState;
     }
-
-    private void CheckForCursorChanges()
-    {
-        var curCursorState = GetCurCursorState();
-        
-        if (!MouseOnScreen || Raylib.IsWindowState(ConfigFlags.MinimizedWindow))//fullscreen to minimize fix for enabling/showing os cursor
-        {
-            if (cursorState.OnScreen)
-            {
-                OnMouseLeftScreen?.Invoke();
-                if (wasMouseVisible == null) wasMouseVisible = cursorState.Visible;
-                if (wasMouseEnabled == null) wasMouseEnabled = cursorState.Enabled;
-                MouseEnabled = true;
-                MouseVisible = true;
-            }
-        }
-        else
-        {
-            if (!cursorState.OnScreen)
-            {
-                OnMouseEnteredScreen?.Invoke();
-                if (wasMouseVisible != null && wasMouseVisible == false) MouseVisible = false;
-                if (wasMouseEnabled != null && wasMouseEnabled == false) MouseEnabled = false;
-
-                wasMouseVisible = null;
-                wasMouseEnabled = null;
-            }
-        }
-        
-        if (curCursorState.Visible && !cursorState.Visible) OnMouseVisibilityChanged?.Invoke(false);
-        else if (!curCursorState.Visible && cursorState.Visible) OnMouseVisibilityChanged?.Invoke(true);
-            
-        if (curCursorState.Enabled && !cursorState.Enabled) OnMouseEnabledChanged?.Invoke(false);
-        else if (!curCursorState.Enabled && cursorState.Enabled) OnMouseEnabledChanged?.Invoke(true);
-
-        cursorState = curCursorState;
-    }
-    #endregion
+    */
     
+    #endregion
     
     #region Window
 
@@ -975,12 +1031,19 @@ public sealed class GameWindow
     public float MouseY => MousePosition.Y;
 
     private bool mouseEnabled = true;
-
+    private bool mouseVisible = true;
     public bool MouseEnabled
     {
         get => mouseEnabled;
         set
         {
+
+            if (!MouseOnScreen)
+            {
+                wasMouseEnabled = value;
+                return;
+            }
+            
             if (value == mouseEnabled) return;
             mouseEnabled = value;
             if(mouseEnabled)Raylib.EnableCursor();
@@ -989,18 +1052,21 @@ public sealed class GameWindow
     }
     public bool MouseVisible
     {
-        get => !Raylib.IsCursorHidden();
+        get => mouseVisible;
         set
         {
-            if (value == !Raylib.IsCursorHidden()) return;
+            if (!MouseOnScreen)
+            {
+                wasMouseVisible = value;
+                return;
+            }
+            
+            if (value == mouseVisible) return;
+            mouseVisible = value;
             if(value) Raylib.ShowCursor();
             else Raylib.HideCursor();
         }
     }
-    // public bool MouseOnScreen
-    // {
-    //     get => Raylib.IsCursorOnScreen();
-    // }
 
     public void ResetMousePosition()
     {
@@ -1010,7 +1076,6 @@ public sealed class GameWindow
     #endregion
 
     
-
     #region Window & Cursor State
 
     private CursorState GetCurCursorState()

--- a/ShapeEngine/Core/Structs/Size.cs
+++ b/ShapeEngine/Core/Structs/Size.cs
@@ -17,7 +17,7 @@ public readonly struct Size : IEquatable<Size>
     /// </summary>
     public float Length => Width;
     
-
+    public bool Positive => Width >= 0 && Height >= 0;
     public Size()
     {
         Width = 0f;

--- a/ShapeEngine/Core/Structs/WindowSettings.cs
+++ b/ShapeEngine/Core/Structs/WindowSettings.cs
@@ -6,7 +6,7 @@ public struct WindowSettings
     {
         Undecorated = false,
         Focused = true,
-        WindowDisplayState = WindowDisplayState.Normal,
+        // WindowDisplayState = WindowDisplayState.Normal,
         WindowBorder = WindowBorder.Resizabled,
         WindowMinSize = new(480, 270),
         WindowSize = new(960, 540),
@@ -33,7 +33,7 @@ public struct WindowSettings
     public bool Undecorated;
     public bool Focused;
     
-    public WindowDisplayState WindowDisplayState;
+    // public WindowDisplayState WindowDisplayState;
     public WindowBorder WindowBorder;
     
     public bool Vsync;

--- a/ShapeEngine/Core/Structs/WindowSettings.cs
+++ b/ShapeEngine/Core/Structs/WindowSettings.cs
@@ -4,36 +4,44 @@ public struct WindowSettings
 {
     public static WindowSettings Default => new()
     {
-        Undecorated = false,
-        Focused = true,
-        // WindowDisplayState = WindowDisplayState.Normal,
+        Title = "Shape Engine Window",
+        FullscreenAutoRestoring = true,
+        Topmost = false,
         WindowBorder = WindowBorder.Resizabled,
         WindowMinSize = new(480, 270),
         WindowSize = new(960, 540),
-        // WindowLocation = new(0, 0),
         Monitor = 0,
         Vsync = false,
         FrameRateLimit = 60,
         MinFramerate = 30,
         MaxFramerate = 240,
-        // AutoIconify = true,
         WindowOpacity = 1f,
         MouseEnabled = true,
         MouseVisible = true,
         Msaa4x = true,
         HighDPI = false,
         FramebufferTransparent = false
+        
+        // Focused = true,
+        // AutoIconify = true,
+        // Undecorated = false,
+        // WindowDisplayState = WindowDisplayState.Normal,
+        // WindowLocation = new(0, 0),
     };
     
-    // public Dimensions WindowLocation;
+    
     public Dimensions WindowSize;
     public Dimensions WindowMinSize;
     
     public string Title;
-    public bool Undecorated;
-    public bool Focused;
+    public bool Topmost;
     
-    // public WindowDisplayState WindowDisplayState;
+    /// <summary>
+    /// Should fullscreen be automatically left when window loses focus and should the window be restored to
+    /// fullscreen when window gains focus again.
+    /// </summary>
+    public bool FullscreenAutoRestoring;
+    
     public WindowBorder WindowBorder;
     
     public bool Vsync;
@@ -52,9 +60,11 @@ public struct WindowSettings
     /// </summary>
     public bool HighDPI;
     public bool FramebufferTransparent;
+    
+    
+    
+    // public bool Focused;
     // public bool AutoIconify; //(minimizes window automatically if focus changes in fullscreen mode)
-    
-    
-    
-
+    // public WindowDisplayState WindowDisplayState;
+    // public Dimensions WindowLocation;
 }

--- a/ShapeEngine/Core/Structs/WindowSettings.cs
+++ b/ShapeEngine/Core/Structs/WindowSettings.cs
@@ -53,5 +53,8 @@ public struct WindowSettings
     public bool HighDPI;
     public bool FramebufferTransparent;
     // public bool AutoIconify; //(minimizes window automatically if focus changes in fullscreen mode)
+    
+    
+    
 
 }

--- a/ShapeEngine/Core/WindowDisplayState.cs
+++ b/ShapeEngine/Core/WindowDisplayState.cs
@@ -5,5 +5,6 @@ public enum WindowDisplayState
     Normal = 0,
     Minimized = 1,
     Maximized = 2,
-    Fullscreen = 3
+    Fullscreen = 3,
+    BorderlessFullscreen = 4
 }

--- a/ShapeEngine/Input/ShapeMouseDevice.cs
+++ b/ShapeEngine/Input/ShapeMouseDevice.cs
@@ -137,14 +137,14 @@ public sealed class ShapeMouseDevice : ShapeInputDevice
     public float GetValue(ShapeMouseAxis axis, float deadzone, ModifierKeyOperator modifierOperator, params IModifierKey[] modifierKeys)
     {
         if (isLocked) return 0f;
-        if (!GameWindow.IsMouseOnScreen) return 0f;
+        if (!GameWindow.CurrentGameWindowInstance.MouseOnScreen) return 0f;
         if (!IModifierKey.IsActive(modifierOperator, modifierKeys, null)) return 0f;
         return GetValue(axis, deadzone);
     }
     public float GetValue(ShapeMouseAxis axis, float deadzone = 0.5f)
     {
         if (isLocked) return 0f;
-        if (!GameWindow.IsMouseOnScreen) return 0f;
+        if (!GameWindow.CurrentGameWindowInstance.MouseOnScreen) return 0f;
        
         var value = Raylib.GetMouseDelta();
         float returnValue = axis == ShapeMouseAxis.VERTICAL ? value.Y : value.X;
@@ -186,14 +186,14 @@ public sealed class ShapeMouseDevice : ShapeInputDevice
     public float GetValue(ShapeMouseWheelAxis axis, float deadzone, ModifierKeyOperator modifierOperator, params IModifierKey[] modifierKeys)
     {
         if (isLocked) return 0f;
-        if (!GameWindow.IsMouseOnScreen) return 0f;
+        if (!GameWindow.CurrentGameWindowInstance.MouseOnScreen) return 0f;
         if (!IModifierKey.IsActive(modifierOperator, modifierKeys, null)) return 0f;
         return GetValue(axis, deadzone);
     }
     public float GetValue(ShapeMouseWheelAxis axis, float deadzone = 0.2f)
     {
         if (isLocked) return 0f;
-        if (!GameWindow.IsMouseOnScreen) return 0f;
+        if (!GameWindow.CurrentGameWindowInstance.MouseOnScreen) return 0f;
         
         var value = Raylib.GetMouseWheelMoveV();
         float returnValue = axis == ShapeMouseWheelAxis.VERTICAL ? value.Y : value.X;
@@ -277,14 +277,14 @@ public sealed class ShapeMouseDevice : ShapeInputDevice
     public float GetValue(ShapeMouseButton button, float deadzone, ModifierKeyOperator modifierOperator, params IModifierKey[] modifierKeys)
     {
         if (isLocked) return 0f;
-        if (!GameWindow.IsMouseOnScreen) return 0f;
+        if (!GameWindow.CurrentGameWindowInstance.MouseOnScreen) return 0f;
         if (!IModifierKey.IsActive(modifierOperator, modifierKeys, null)) return 0f;
         return GetValue(button, deadzone);
     }
     public float GetValue(ShapeMouseButton button, float deadzone = 0f)
     {
         if (isLocked) return 0f;
-        if (!GameWindow.IsMouseOnScreen) return 0f;
+        if (!GameWindow.CurrentGameWindowInstance.MouseOnScreen) return 0f;
         int id = (int)button;
         if (id is >= 10 and < 20)
         {

--- a/ShapeEngine/readme-nuget.md
+++ b/ShapeEngine/readme-nuget.md
@@ -48,14 +48,8 @@ public static class Program
 {     
     public static void Main(string[] args)     
     {         
-        var gameSettings = new GameSettings()         
-        {             
-            DevelopmentDimensions = new Dimensions(1920, 1080),             
-            MultiShaderSupport = false         
-        };         
-        
-        var game = new MyGameClass(gameSettings, WindowSettings.Default);         
-        game.Run();     
+        var game = new Game(GameSettings.StretchMode, WindowSettings.Default);
+		game.Run();    
     } 
 } 
 


### PR DESCRIPTION
This Pull Request is about cleaning up and improving the GameWindow class.

## Changelog:
- `MouseOnScreen` system improved
- Workaround to disable auto iconify behaviour of raylib with using `InitWindow` with 0, 0 for width, height. 
- System implemented to automatically exit fullscreen when window loses focus and to enter fullscreen once window gains focus again. (can be disabled with `WindowSettings` - disabling is useful when fullscreen is on another monitor)
- The window is no longer topmost all the time - this is now controlled via the `WindowSettings` 
- `WindowFlagState` struct removed.
- `PrevWindowStateInfo` struct removed.
- Window handling overhauled. The WindowDisplayState & WindowBorder fields are getters only now. I added dedicated functions to change the display state & window borders. 

### New window handling functions:
- `RestoreWindow()` - restores to normal window from any display state.
- `ActivateFullscreen(int w, int h)`
- `ActivateBorderlessFullscreen()`
- `MaximizeWindow()`
- `MinimizeWindow()`
- `ToggleBorderlessFullscreen()`
- `ToggleMaximizeWindow()`
- `ToggleMinimizeWindow()`