### PR TITLE
Fix the minimal example in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ public static class Program
 {
     public static void Main(string[] args)
     {
-	var game = new Game(GameSettings.StretchMode, WindowSettings.Default);
+	var game = new MyGameClass(GameSettings.StretchMode, WindowSettings.Default);
 	game.Run();
     }
 }


### PR DESCRIPTION
The readme's example declared `MyGameClass` to render some basic stuff, but actually ran the base `Game` object instead - so would never render anything. Looks like [this got introduced](https://github.com/DaveGreen-Games/ShapeEngine/commit/27b13907da97fabc3c10ca38fe6f343b84882c5b) while the readme was being reworked recently?

Took me an embarrassingly long time to realise why my example code was rendering nothing, so figured I should PR back that little fix and try to save some others the confusion...