### PR TITLE
CircleSector and CircleSectorCollider added

### DIFF
--- a/ShapeEngine/Core/Collision/CircleSectorCollider.cs
+++ b/ShapeEngine/Core/Collision/CircleSectorCollider.cs
@@ -1,0 +1,95 @@
+using System.Numerics;
+using ShapeEngine.Core.Shapes;
+using ShapeEngine.Core.Structs;
+using ShapeEngine.Lib;
+
+namespace ShapeEngine.Core.Collision;
+
+public class CircleSectorCollider : Collider
+{
+    
+    public int Accuracy { get; private set; }
+    public float AngleSectorRad { get; private set; }
+
+    
+    private readonly Polygon shape;
+    private bool dirty = false;
+   
+    public CircleSectorCollider(Transform2D offset, float angleSectorRad, int accuracy = 5) : base(offset)
+    {
+        AngleSectorRad = angleSectorRad;
+        Accuracy = accuracy;
+        shape = new Polygon();
+
+    }
+
+    protected override void OnTransformSetupFinished()
+    {
+        CalculatePoints();
+    }
+
+    public override void Recalculate()
+    {
+        CalculatePoints();
+    }
+
+    protected override void UpdateColliderShape(bool transformChanged)
+    {
+        if(transformChanged || dirty) CalculatePoints();
+    }
+
+    private void CalculatePoints()
+    {
+        dirty = false;
+        shape.Clear();
+        var radius = CurTransform.ScaledSize.Radius;
+        if (AngleSectorRad <= 0 || radius <= 0) return;
+            
+        //ccw order
+        var center = CurTransform.Position;
+        shape.Add(center);
+        var angleStep = AngleSectorRad / (Accuracy + 1);
+        var v = ShapeVec.VecFromAngleRad(CurTransform.RotationRad - angleStep / 2) * radius;
+        for (int i = 0; i < Accuracy + 2; i++)
+        {
+            shape.Add(center + v);
+            v = v.Rotate(angleStep);
+        }
+    }
+    public override Rect GetBoundingBox() => GetPolygonShape().GetBoundingBox();
+    public override ShapeType GetShapeType() => ShapeType.Poly;
+    public override Polygon GetPolygonShape() => shape;
+    
+    #region Set Methods
+    
+    public void SetAccuracy(int value)
+    {
+        if(Accuracy == value) return;
+        dirty = true;
+        Accuracy = value <= 0 ? 0 : value;
+    }
+    public void SetAngleSector(float radians)
+    {
+        if(Math.Abs(AngleSectorRad - radians) < 0.00001f) return;
+        dirty = true;
+        AngleSectorRad = ShapeMath.Clamp(radians, 0f, ShapeMath.PI * 2f);
+    }
+   
+    #endregion
+    
+    #region Change Methods
+    
+    public void ChangeAccuracy(int amount)
+    {
+        if(amount == 0) return;
+        SetAccuracy(Accuracy + amount);
+    }
+    public void ChangeAngleSector(float radians)
+    {
+        if(radians == 0) return;
+        SetAngleSector(AngleSectorRad + radians);
+    }
+    
+    #endregion
+
+}

--- a/ShapeEngine/Core/Collision/CircleSectorCollider.cs
+++ b/ShapeEngine/Core/Collision/CircleSectorCollider.cs
@@ -8,17 +8,40 @@ namespace ShapeEngine.Core.Collision;
 public class CircleSectorCollider : Collider
 {
     
-    public int Accuracy { get; private set; }
+    /// <summary>
+    /// How many points are used for the circle sector arc. 0 creates a triangle where the arc is a straight line.
+    /// </summary>
+    public int ArcPoints { get; private set; }
+    
+    /// <summary>
+    /// How wide the circle sector is. 
+    /// </summary>
     public float AngleSectorRad { get; private set; }
 
+    
+    /// <summary>
+    /// Represents CurTransform.Position
+    /// </summary>
+    public Vector2 Center => CurTransform.Position;
+
+    /// <summary>
+    /// Represents CurTransform.ScaledSize.Radius
+    /// </summary>
+    public float Radius => CurTransform.ScaledSize.Radius;
+
+    /// <summary>
+    /// Represents CurTransform.RotationRad
+    /// </summary>
+    public float RotationRad => CurTransform.RotationRad;
+    
     
     private readonly Polygon shape;
     private bool dirty = false;
    
-    public CircleSectorCollider(Transform2D offset, float angleSectorRad, int accuracy = 5) : base(offset)
+    public CircleSectorCollider(Transform2D offset, float angleSectorRad, int arcPoints = 5) : base(offset)
     {
         AngleSectorRad = angleSectorRad;
-        Accuracy = accuracy;
+        ArcPoints = arcPoints;
         shape = new Polygon();
 
     }
@@ -48,9 +71,9 @@ public class CircleSectorCollider : Collider
         //ccw order
         var center = CurTransform.Position;
         shape.Add(center);
-        var angleStep = AngleSectorRad / (Accuracy + 1);
+        var angleStep = AngleSectorRad / (ArcPoints + 1);
         var v = ShapeVec.VecFromAngleRad(CurTransform.RotationRad - angleStep / 2) * radius;
-        for (int i = 0; i < Accuracy + 2; i++)
+        for (int i = 0; i < ArcPoints + 2; i++)
         {
             shape.Add(center + v);
             v = v.Rotate(angleStep);
@@ -64,9 +87,9 @@ public class CircleSectorCollider : Collider
     
     public void SetAccuracy(int value)
     {
-        if(Accuracy == value) return;
+        if(ArcPoints == value) return;
         dirty = true;
-        Accuracy = value <= 0 ? 0 : value;
+        ArcPoints = value <= 0 ? 0 : value;
     }
     public void SetAngleSector(float radians)
     {
@@ -82,7 +105,7 @@ public class CircleSectorCollider : Collider
     public void ChangeAccuracy(int amount)
     {
         if(amount == 0) return;
-        SetAccuracy(Accuracy + amount);
+        SetAccuracy(ArcPoints + amount);
     }
     public void ChangeAngleSector(float radians)
     {

--- a/ShapeEngine/Core/Collision/Collider.cs
+++ b/ShapeEngine/Core/Collision/Collider.cs
@@ -119,9 +119,14 @@ namespace ShapeEngine.Core.Collision
         }
         protected virtual void OnTransformSetupFinished() { }
         /// <summary>
-        /// Is triggered automatically. Should be used manually if relative shape was changed.
+        /// Can be used to trigger recalculating the shape.
         /// </summary>
         public virtual void Recalculate() { }
+        /// <summary>
+        /// Called each frame after the transform was actualized from the parents
+        /// </summary>
+        /// <param name="transformChanged"></param>
+        protected virtual void UpdateColliderShape(bool transformChanged) { }
         internal void UpdateTransform(Transform2D parentTransform)
         {
             PrevTransform = CurTransform;
@@ -142,7 +147,8 @@ namespace ShapeEngine.Core.Collision
                 CurTransform = new(Offset.Position, rot, size, scale);
             }
 
-            if(PrevTransform != CurTransform) Recalculate();
+            // if(PrevTransform != CurTransform) Recalculate();
+            UpdateColliderShape(PrevTransform != CurTransform);
         }
 
         

--- a/ShapeEngine/Core/Collision/PolyCollider.cs
+++ b/ShapeEngine/Core/Collision/PolyCollider.cs
@@ -39,11 +39,9 @@ public class PolyCollider : Collider
 
     public override void Recalculate()
     {
-        //updates the shape in case it is diry (circle sector)
-        var s = RelativeShape.Self;
-        for (int i = 0; i < s.Count; i++)
+        for (int i = 0; i < RelativeShape.Count; i++)
         {
-            var p = CurTransform.ApplyTransformTo(s[i]);
+            var p = CurTransform.ApplyTransformTo(RelativeShape[i]);
             if (shape.Count <= i)
             {
                 shape.Add(p);
@@ -53,6 +51,12 @@ public class PolyCollider : Collider
                 shape[i] = p;
             }
         }
+    }
+
+    protected override void UpdateColliderShape(bool transformChanged)
+    {
+        if (!transformChanged) return;
+        Recalculate();
     }
 
 

--- a/ShapeEngine/Core/Collision/PolyCollider.cs
+++ b/ShapeEngine/Core/Collision/PolyCollider.cs
@@ -8,7 +8,7 @@ namespace ShapeEngine.Core.Collision;
 public class PolyCollider : Collider
 {
     public Polygon RelativeShape;
-    private Polygon shape;
+    private readonly Polygon shape;
     
    
     public PolyCollider(Transform2D offset, Points relativePoints) : base(offset)
@@ -39,9 +39,11 @@ public class PolyCollider : Collider
 
     public override void Recalculate()
     {
-        for (int i = 0; i < RelativeShape.Count; i++)
+        //updates the shape in case it is diry (circle sector)
+        var s = RelativeShape.Self;
+        for (int i = 0; i < s.Count; i++)
         {
-            var p = CurTransform.ApplyTransformTo(RelativeShape[i]);
+            var p = CurTransform.ApplyTransformTo(s[i]);
             if (shape.Count <= i)
             {
                 shape.Add(p);

--- a/ShapeEngine/Core/Collision/PolyLineCollider.cs
+++ b/ShapeEngine/Core/Collision/PolyLineCollider.cs
@@ -43,6 +43,12 @@ public class PolyLineCollider : Collider
         }
     }
 
+    protected override void UpdateColliderShape(bool transformChanged)
+    {
+        if (!transformChanged) return;
+        Recalculate();
+    }
+
 
     public override Rect GetBoundingBox() => GetPolygonShape().GetBoundingBox();
     

--- a/ShapeEngine/Core/Collision/SegmentCollider.cs
+++ b/ShapeEngine/Core/Collision/SegmentCollider.cs
@@ -54,6 +54,12 @@ public class SegmentCollider : Collider
         End = CurTransform.Position + (Dir * (1f - OriginOffset) * CurTransform.ScaledSize.Length).Rotate(CurTransform.RotationRad);
     }
 
+    protected override void UpdateColliderShape(bool transformChanged)
+    {
+        if (!transformChanged) return;
+        Recalculate();
+    }
+
     public SegmentCollider(Transform2D offset, Vector2 dir, float originOffset = 0f) : base(offset)
     {
         this.dir = dir;

--- a/ShapeEngine/Core/Shapes/Circle.cs
+++ b/ShapeEngine/Core/Shapes/Circle.cs
@@ -195,90 +195,7 @@ namespace ShapeEngine.Core.Shapes
                 Radius + other.Radius
             );
         }
-
-        /// <summary>
-        /// Creates a circle sector with points.
-        /// </summary>
-        /// <param name="direction"> The center direction of the sector.</param>
-        /// <param name="angleRad"> Determines the width of the sector. Half of the angle to the left and half to the right.</param>
-        /// <param name="accuracy"> Determines the amount of points generated for the arc.
-        /// 0 generates a triangle.
-        /// 1 has one arc point in the center at the top of the arc.</param>
-        /// <returns></returns>
-        public Points? GetSectorPoints(Vector2 direction, float angleRad, int accuracy = 3)
-        {
-            if (angleRad <= 0 || (direction.X == 0 && direction.Y == 0)) return null;
-            var result = new Points(3 + accuracy);
-            
-            //ccw order
-            result.Add(Center);
-            var angleStep = angleRad / (accuracy + 1);
-            var currentAngle = -angleStep / 2;
-            for (int i = 0; i < accuracy + 2; i++)
-            {
-                result.Add(Center + direction.Rotate(currentAngle) * Radius);
-                currentAngle += angleStep;
-            }
-            
-            return result;
-        }
-       
-        /// <summary>
-        /// Creates a circle sector with segments.
-        /// </summary>
-        /// <param name="direction"> The center direction of the sector.</param>
-        /// <param name="angleRad"> Determines the width of the sector. Half of the angle to the left and half to the right.</param>
-        /// <param name="accuracy"> Determines the amount of points generated for the arc.
-        /// 0 generates a triangle.
-        /// 1 has one arc point in the center at the top of the arc.</param>
-        /// <returns></returns>
-        public Segments? GetSectorSegments(Vector2 direction, float angleRad, int accuracy = 3)
-        {
-            if (angleRad <= 0 || (direction.X == 0 && direction.Y == 0)) return null;
-            var result = new Segments(3 + accuracy);
-            
-            //ccw order
-            var prevPoint = Center;
-            var angleStep = angleRad / (accuracy + 1);
-            var currentAngle = -angleStep / 2;
-            for (int i = 0; i < accuracy + 2; i++)
-            {
-                var p = Center + direction.Rotate(currentAngle) * Radius;
-                result.Add(new Segment(prevPoint, p));
-                prevPoint = p;
-                currentAngle += angleStep;
-            }
-            
-            return result;
-        }
-
-        /// <summary>
-        /// Creates a circle sector with points.
-        /// </summary>
-        /// <param name="direction"> The center direction of the sector.</param>
-        /// <param name="angleRad"> Determines the width of the sector. Half of the angle to the left and half to the right.</param>
-        /// <param name="accuracy"> Determines the amount of points generated for the arc.
-        /// 0 generates a triangle.
-        /// 1 has one arc point in the center at the top of the arc.</param>
-        /// <returns></returns>
-        public Polygon? GetSectorPolygon(Vector2 direction, float angleRad, int accuracy = 3)
-        {
-            if (angleRad <= 0 || (direction.X == 0 && direction.Y == 0)) return null;
-            var result = new Polygon(3 + accuracy);
-            
-            //ccw order
-            result.Add(Center);
-            var angleStep = angleRad / (accuracy + 1);
-            var currentAngle = -angleStep / 2;
-            for (int i = 0; i < accuracy + 2; i++)
-            {
-                result.Add(Center + direction.Rotate(currentAngle) * Radius);
-                currentAngle += angleStep;
-            }
-            
-            return result;
-        }
-
+        
         #endregion
         
         #region Corners
@@ -466,13 +383,23 @@ namespace ShapeEngine.Core.Shapes
         #region Contains
 
         public bool ContainsPoint(Vector2 p) => (Center - p).LengthSquared() <= Radius * Radius;
-        public bool ContainsPoint(Vector2 p, Vector2 dir, float angleRad)
+        public bool ContainsPointSector(Vector2 p, float rotationRad, float sectorAngleRad)
         {
-            if(angleRad <= 0f || (dir.X == 0 && dir.Y == 0)) return false;
+            if(sectorAngleRad <= 0f) return false;
+            rotationRad = ShapeMath.WrapAngleRad(rotationRad);
+
+            var dir = ShapeVec.VecFromAngleRad(rotationRad);
+            var a = dir.AngleRad(p - Center);
+            return MathF.Abs(a) < sectorAngleRad * 0.5f;
+        }
+        public bool ContainsPointSector(Vector2 p, Vector2 dir, float sectorAngleRad)
+        {
+            if(sectorAngleRad <= 0f) return false;
+            if(dir.X == 0f && dir.Y == 0f) return false;
             if (!ContainsPoint(p)) return false;
             
             var a = dir.AngleRad(p - Center);
-            return MathF.Abs(a) < angleRad * 0.5f;
+            return MathF.Abs(a) < sectorAngleRad * 0.5f;
         }
 
         
@@ -542,95 +469,6 @@ namespace ShapeEngine.Core.Shapes
             }
             return true;
         }
-        
-        
-        public bool ContainsCollisionObject(CollisionObject collisionObject, Vector2 direction, float angleRad)
-        {
-            if(angleRad <= 0f || (direction.X == 0 && direction.Y == 0)) return false;
-            
-            if (!collisionObject.HasColliders) return false;
-            
-            foreach (var collider in collisionObject.Colliders)
-            {
-                if (!ContainsCollider(collider, direction, angleRad)) return false;
-            }
-
-            return true;
-        }
-        public bool ContainsCollider(Collider collider, Vector2 direction, float angleRad)
-        {
-            if(angleRad <= 0f || (direction.X == 0 && direction.Y == 0)) return false;
-            
-            switch (collider.GetShapeType())
-            {
-                case ShapeType.Circle: return ContainsShape(collider.GetCircleShape(), direction, angleRad);
-                case ShapeType.Segment: return ContainsShape(collider.GetSegmentShape(), direction, angleRad);
-                case ShapeType.Triangle: return ContainsShape(collider.GetTriangleShape(), direction, angleRad);
-                case ShapeType.Quad: return ContainsShape(collider.GetQuadShape(), direction, angleRad);
-                case ShapeType.Rect: return ContainsShape(collider.GetRectShape(), direction, angleRad);
-                case ShapeType.Poly: return ContainsShape(collider.GetPolygonShape(), direction, angleRad);
-                case ShapeType.PolyLine: return ContainsShape(collider.GetPolylineShape(), direction, angleRad);
-            }
-
-            return false;
-        }
-        public bool ContainsShape(Segment segment, Vector2 direction, float angleRad)
-        {
-            if(angleRad <= 0f || (direction.X == 0 && direction.Y == 0)) return false;
-            
-            return ContainsPoint(segment.Start, direction, angleRad) && ContainsPoint(segment.End, direction, angleRad);
-        }
-        public bool ContainsShape(Circle circle, Vector2 direction, float angleRad)
-        {
-            if(angleRad <= 0f || (direction.X == 0 && direction.Y == 0)) return false;
-
-            if (!ContainsShape(circle)) return false;
-
-            //not may favourite solution but it is simple
-            var corners = GetCorners();
-            return ContainsPoint(corners.top) && 
-                   ContainsPoint(corners.bottom) && 
-                   ContainsPoint(corners.left) && 
-                   ContainsPoint(corners.right);
-        }
-        public bool ContainsShape(Rect rect, Vector2 direction, float angleRad)
-        {
-            if(angleRad <= 0f || (direction.X == 0 && direction.Y == 0)) return false;
-            
-            return ContainsPoint(rect.TopLeft, direction, angleRad) &&
-                   ContainsPoint(rect.BottomLeft, direction, angleRad) &&
-                   ContainsPoint(rect.BottomRight, direction, angleRad) &&
-                   ContainsPoint(rect.TopRight, direction, angleRad);
-        }
-        public bool ContainsShape(Triangle triangle, Vector2 direction, float angleRad)
-        {
-            if(angleRad <= 0f || (direction.X == 0 && direction.Y == 0)) return false;
-            
-            return ContainsPoint(triangle.A, direction, angleRad) &&
-                   ContainsPoint(triangle.B, direction, angleRad) &&
-                   ContainsPoint(triangle.C, direction, angleRad);
-        }
-        public bool ContainsShape(Quad quad, Vector2 direction, float angleRad)
-        {
-            if(angleRad <= 0f || (direction.X == 0 && direction.Y == 0)) return false;
-            
-            return ContainsPoint(quad.A, direction, angleRad) &&
-                   ContainsPoint(quad.B, direction, angleRad) &&
-                   ContainsPoint(quad.C, direction, angleRad) &&
-                   ContainsPoint(quad.D, direction, angleRad);
-        }
-        public bool ContainsShape(Points points, Vector2 direction, float angleRad)
-        {
-            if(angleRad <= 0f || (direction.X == 0 && direction.Y == 0)) return false;
-            
-            if (points.Count <= 0) return false;
-            foreach (var p in points)
-            {
-                if (!ContainsPoint(p, direction, angleRad)) return false;
-            }
-            return true;
-        }
-        
         #endregion
         
         #region Closest

--- a/ShapeEngine/Core/Shapes/CircleSector.cs
+++ b/ShapeEngine/Core/Shapes/CircleSector.cs
@@ -1,0 +1,169 @@
+using System.Numerics;
+using ShapeEngine.Lib;
+
+namespace ShapeEngine.Core.Shapes;
+
+public class CircleSector
+{
+    #region Public Members
+
+    public int Accuracy { get; private set; }
+    public float Radius { get; private set; }
+    public Vector2 Center { get; private set; }
+    public float AngleDirectionRad { get; private set; }
+    public float AngleSectorRad { get; private set; }
+
+    #endregion
+
+    #region Private Members
+
+    private Polygon shape = new();
+    private bool dirty = false;
+
+    #endregion
+    
+    #region Constructor
+
+    public CircleSector(Vector2 center, float radius, float angleDirectionRad, float angleSectorRad, int accuracy = 3)
+    {
+        SetCenter(center);
+        SetRadius(radius);
+        SetAngleDirection(angleDirectionRad);
+        SetAngleSector(angleSectorRad);
+        SetAccuracy(accuracy);
+
+        UpdateShape();
+    }
+    
+    public CircleSector(Vector2 center, float radius, Vector2 direction, float angleSectorRad, int accuracy = 3)
+    {
+        SetCenter(center);
+        SetRadius(radius);
+        SetAngleDirection(direction);
+        SetAngleSector(angleSectorRad);
+        SetAccuracy(accuracy);
+        
+        UpdateShape();
+    }
+    
+    #endregion
+    
+    #region Public Methods
+
+    public Polygon GetShape()
+    {
+        if (dirty) UpdateShape();
+        return shape;
+    }
+    public Polygon GetShapeCopy() => shape.ToPolygon();
+    public Polygon? GenerateShape()
+    {
+        if (AngleSectorRad <= 0 || Radius <= 0) return null;
+        var result = new Polygon(3 + Accuracy);
+            
+        //ccw order
+        result.Add(Center);
+        var angleStep = AngleSectorRad / (Accuracy + 1);
+        var v = ShapeVec.VecFromAngleRad(AngleDirectionRad - angleStep / 2) * Radius;
+        for (int i = 0; i < Accuracy + 2; i++)
+        {
+            result.Add(Center + v);
+            v = v.Rotate(angleStep);
+        }
+            
+        return result;
+    }
+
+    #endregion
+    
+    #region Set Methods
+    
+    public void SetAccuracy(int value)
+    {
+        if(Accuracy == value) return;
+        dirty = true;
+        Accuracy = value <= 0 ? 0 : value;
+    }
+    public void SetRadius(float value)
+    {
+        if(Math.Abs(Radius - value) < 0.00001f) return;
+        dirty = true;
+        Radius = value <= 0f ? 0f : value;
+    }
+    public void SetCenter(Vector2 value)
+    {
+        if(Center == value) return;
+        dirty = true;
+        Center = value;
+    }
+    public void SetAngleDirection(float radians)
+    {
+        if(Math.Abs(AngleDirectionRad - radians) < 0.00001f) return;
+        dirty = true;
+        AngleDirectionRad = ShapeMath.WrapAngleRad(radians);
+    }
+    public void SetAngleDirection(Vector2 newDirection)
+    {
+        if(newDirection == Vector2.Zero) return;
+        SetAngleDirection(newDirection.AngleRad());
+    }
+    public void SetAngleSector(float radians)
+    {
+        if(Math.Abs(AngleSectorRad - radians) < 0.00001f) return;
+        dirty = true;
+        AngleSectorRad = ShapeMath.Clamp(radians, 0f, ShapeMath.PI * 2f);
+    }
+   
+    #endregion
+    
+    #region Change Methods
+    
+    public void ChangeAccuracy(int amount)
+    {
+        if(amount == 0) return;
+        SetAccuracy(Accuracy + amount);
+    }
+    public void ChangeRadius(float amount)
+    {
+        if(amount == 0) return;
+        SetRadius(Radius + amount);
+    }
+    public void ChangeCenter(Vector2 amount)
+    {
+        if(amount.X == 0 && amount.Y == 0) return;
+        SetCenter(Center + amount);
+    }
+    public void ChangeAngleDirection(float radians)
+    {
+        if(radians == 0) return;
+        SetAngleDirection(AngleDirectionRad + radians);
+    }
+    public void ChangeAngleSector(float radians)
+    {
+        if(radians == 0) return;
+        SetAngleSector(AngleSectorRad + radians);
+    }
+    
+    #endregion
+    
+    #region Private Methods
+    
+    private void UpdateShape()
+    {
+        shape.Clear();
+        dirty = false;
+        if (AngleSectorRad <= 0 || Radius <= 0) return;
+            
+        //ccw order
+        shape.Add(Center);
+        var angleStep = AngleSectorRad / (Accuracy + 1);
+        var v = ShapeVec.VecFromAngleRad(AngleDirectionRad - angleStep / 2) * Radius;
+        for (int i = 0; i < Accuracy + 2; i++)
+        {
+            shape.Add(Center + v);
+            v = v.Rotate(angleStep);
+        }
+    }
+    
+    #endregion
+}

--- a/ShapeEngine/Core/Shapes/CircleSector.cs
+++ b/ShapeEngine/Core/Shapes/CircleSector.cs
@@ -25,11 +25,11 @@ public class CircleSector //: Polygon
     
     #region Constructor
 
-    public CircleSector(Vector2 center, float radius, float angleDirectionRad, float angleSectorRad, int accuracy = 3)
+    public CircleSector(Vector2 center, float radius, float rotationRad, float angleSectorRad, int accuracy = 3)
     {
         SetCenter(center);
         SetRadius(radius);
-        SetAngleDirection(angleDirectionRad);
+        SetAngleDirection(rotationRad);
         SetAngleSector(angleSectorRad);
         SetAccuracy(accuracy);
 

--- a/ShapeEngine/Core/Shapes/CircleSector.cs
+++ b/ShapeEngine/Core/Shapes/CircleSector.cs
@@ -1,16 +1,17 @@
 using System.Numerics;
 using ShapeEngine.Lib;
+using ShapeEngine.Random;
 
 namespace ShapeEngine.Core.Shapes;
 
-public class CircleSector
+public class CircleSector //: Polygon
 {
     #region Public Members
 
     public int Accuracy { get; private set; }
     public float Radius { get; private set; }
     public Vector2 Center { get; private set; }
-    public float AngleDirectionRad { get; private set; }
+    public float RotationRad { get; private set; }
     public float AngleSectorRad { get; private set; }
 
     #endregion
@@ -56,23 +57,7 @@ public class CircleSector
         return shape;
     }
     public Polygon GetShapeCopy() => shape.ToPolygon();
-    public Polygon? GenerateShape()
-    {
-        if (AngleSectorRad <= 0 || Radius <= 0) return null;
-        var result = new Polygon(3 + Accuracy);
-            
-        //ccw order
-        result.Add(Center);
-        var angleStep = AngleSectorRad / (Accuracy + 1);
-        var v = ShapeVec.VecFromAngleRad(AngleDirectionRad - angleStep / 2) * Radius;
-        for (int i = 0; i < Accuracy + 2; i++)
-        {
-            result.Add(Center + v);
-            v = v.Rotate(angleStep);
-        }
-            
-        return result;
-    }
+    public Polygon? GenerateShape() => GeneratePolygon(Center, Radius, RotationRad, AngleSectorRad, Accuracy);
 
     #endregion
     
@@ -98,9 +83,9 @@ public class CircleSector
     }
     public void SetAngleDirection(float radians)
     {
-        if(Math.Abs(AngleDirectionRad - radians) < 0.00001f) return;
+        if(Math.Abs(RotationRad - radians) < 0.00001f) return;
         dirty = true;
-        AngleDirectionRad = ShapeMath.WrapAngleRad(radians);
+        RotationRad = ShapeMath.WrapAngleRad(radians);
     }
     public void SetAngleDirection(Vector2 newDirection)
     {
@@ -136,7 +121,7 @@ public class CircleSector
     public void ChangeAngleDirection(float radians)
     {
         if(radians == 0) return;
-        SetAngleDirection(AngleDirectionRad + radians);
+        SetAngleDirection(RotationRad + radians);
     }
     public void ChangeAngleSector(float radians)
     {
@@ -157,7 +142,7 @@ public class CircleSector
         //ccw order
         shape.Add(Center);
         var angleStep = AngleSectorRad / (Accuracy + 1);
-        var v = ShapeVec.VecFromAngleRad(AngleDirectionRad - angleStep / 2) * Radius;
+        var v = ShapeVec.VecFromAngleRad(RotationRad - angleStep / 2) * Radius;
         for (int i = 0; i < Accuracy + 2; i++)
         {
             shape.Add(Center + v);
@@ -166,4 +151,67 @@ public class CircleSector
     }
     
     #endregion
+
+    #region Static
+
+    public static Polygon? GeneratePolygon(Vector2 center, float radius, float rotationRad, float angleSectorRad, int accuracy = 3)
+    {
+        if (angleSectorRad <= 0 || radius <= 0) return null;
+        var result = new Polygon(3 + accuracy);
+            
+        //ccw order
+        result.Add(center);
+        var angleStep = angleSectorRad / (accuracy + 1);
+        var v = ShapeVec.VecFromAngleRad(rotationRad - angleStep / 2) * radius;
+        for (int i = 0; i < accuracy + 2; i++)
+        {
+            result.Add(center + v);
+            v = v.Rotate(angleStep);
+        }
+            
+        return result;
+    }
+    public static Points? GeneratePoints(Vector2 center, float radius, float rotationRad, float angleSectorRad, int accuracy = 3)
+    {
+        if (angleSectorRad <= 0 || radius <= 0) return null;
+        var result = new Points(3 + accuracy);
+            
+        //ccw order
+        result.Add(center);
+        var angleStep = angleSectorRad / (accuracy + 1);
+        var v = ShapeVec.VecFromAngleRad(rotationRad - angleStep / 2) * radius;
+        for (int i = 0; i < accuracy + 2; i++)
+        {
+            result.Add(center + v);
+            v = v.Rotate(angleStep);
+        }
+            
+        return result;
+    }
+    public static Segments? GenerateSegments(Vector2 center, float radius, float rotationRad, float angleSectorRad, int accuracy = 3)
+    {
+        if (angleSectorRad <= 0 || radius <= 0) return null;
+        var result = new Segments(3 + accuracy);
+            
+        //ccw order
+        var prevPoint = center;
+        var angleStep = angleSectorRad / (accuracy + 1);
+        var v = ShapeVec.VecFromAngleRad(rotationRad - angleStep / 2) * radius;
+        for (int i = 0; i < accuracy + 2; i++)
+        {
+            var p = center + v;
+            result.Add(new Segment(prevPoint, p));
+            prevPoint = p;
+            v = v.Rotate(angleStep);
+        }
+            
+        return result;
+    }
+
+    #endregion
+    
+    
+    
+    
+    
 }

--- a/ShapeEngine/Core/Shapes/CircleSector.cs
+++ b/ShapeEngine/Core/Shapes/CircleSector.cs
@@ -1,10 +1,10 @@
 using System.Numerics;
 using ShapeEngine.Lib;
-using ShapeEngine.Random;
 
 namespace ShapeEngine.Core.Shapes;
 
-public class CircleSector //: Polygon
+
+public class CircleSector : Polygon
 {
     #region Public Members
 
@@ -18,7 +18,7 @@ public class CircleSector //: Polygon
 
     #region Private Members
 
-    private Polygon shape = new();
+    // private Polygon shape = new();
     private bool dirty = false;
 
     #endregion
@@ -33,7 +33,7 @@ public class CircleSector //: Polygon
         SetAngleSector(angleSectorRad);
         SetAccuracy(accuracy);
 
-        UpdateShape();
+        CalculatePoints();
     }
     
     public CircleSector(Vector2 center, float radius, Vector2 direction, float angleSectorRad, int accuracy = 3)
@@ -44,19 +44,26 @@ public class CircleSector //: Polygon
         SetAngleSector(angleSectorRad);
         SetAccuracy(accuracy);
         
-        UpdateShape();
+        CalculatePoints();
     }
     
     #endregion
     
     #region Public Methods
 
-    public Polygon GetShape()
+    /// <summary>
+    /// Recalculates the polygon points if changes have been made.
+    /// </summary>
+    public override CircleSector Self
     {
-        if (dirty) UpdateShape();
-        return shape;
+        get
+        {
+            if (dirty) CalculatePoints();
+            return this;
+        }
     }
-    public Polygon GetShapeCopy() => shape.ToPolygon();
+    public CircleSector Clone() => new CircleSector(Center, Radius, RotationRad, AngleSectorRad, Accuracy);
+    public Polygon CloneAsPolygon() => Clone();
     public Polygon? GenerateShape() => GeneratePolygon(Center, Radius, RotationRad, AngleSectorRad, Accuracy);
 
     #endregion
@@ -132,20 +139,21 @@ public class CircleSector //: Polygon
     #endregion
     
     #region Private Methods
-    
-    private void UpdateShape()
+    protected override void RecalculatePoints() => CalculatePoints();
+    private void CalculatePoints()
     {
-        shape.Clear();
+        this.Clear();
         dirty = false;
+        
         if (AngleSectorRad <= 0 || Radius <= 0) return;
             
         //ccw order
-        shape.Add(Center);
+        this.Add(Center);
         var angleStep = AngleSectorRad / (Accuracy + 1);
         var v = ShapeVec.VecFromAngleRad(RotationRad - angleStep / 2) * Radius;
         for (int i = 0; i < Accuracy + 2; i++)
         {
-            shape.Add(Center + v);
+            this.Add(Center + v);
             v = v.Rotate(angleStep);
         }
     }
@@ -209,9 +217,6 @@ public class CircleSector //: Polygon
     }
 
     #endregion
-    
-    
-    
-    
+
     
 }

--- a/ShapeEngine/Core/Shapes/CircleSector.cs
+++ b/ShapeEngine/Core/Shapes/CircleSector.cs
@@ -9,21 +9,38 @@ public class CircleSector
 {
     #region Public Members
     public Transform2D Transform { get; set; }
-    public int Accuracy { get; set; }
+    
+    /// <summary>
+    /// How many points are used for the circle sector arc. 0 creates a triangle where the arc is a straight line.
+    /// </summary>
+    public int ArcPoints { get; set; }
+    
+    /// <summary>
+    /// How wide the circle sector is. 
+    /// </summary>
     public float AngleSectorRad { get; set; }
 
+    /// <summary>
+    /// Represents Transform.Position
+    /// </summary>
     public Vector2 Center
     {
         get => Transform.Position;
         set => Transform = Transform.SetPosition(value);
     }
 
+    /// <summary>
+    /// Represents Transform.ScaledSize.Radius
+    /// </summary>
     public float Radius
     {
         get => Transform.ScaledSize.Radius;
         set => Transform = Transform.SetSize(value);
     }
 
+    /// <summary>
+    /// Represents Transform.RotationRad
+    /// </summary>
     public float RotationRad
     {
         get => Transform.RotationRad;
@@ -33,24 +50,24 @@ public class CircleSector
 
     #region Constructor
 
-    public CircleSector(Vector2 center, float radius, float rotationRad, float angleSectorRad, int accuracy = 3)
+    public CircleSector(Vector2 center, float radius, float rotationRad, float angleSectorRad, int arcPoints = 3)
     {
         Transform = new Transform2D(center, rotationRad, new Size(radius));
-        Accuracy = accuracy;
+        ArcPoints = arcPoints;
         AngleSectorRad = angleSectorRad;
     }
-    public CircleSector(Transform2D transform, float angleSectorRad, int accuracy = 3)
+    public CircleSector(Transform2D transform, float angleSectorRad, int arcPoints = 3)
     {
         Transform = transform;
-        Accuracy = accuracy;
+        ArcPoints = arcPoints;
         AngleSectorRad = angleSectorRad;
     }
-    public CircleSector(Vector2 center, float radius, Vector2 direction, float angleSectorRad, int accuracy = 3)
+    public CircleSector(Vector2 center, float radius, Vector2 direction, float angleSectorRad, int arcPoints = 3)
     {
         var rotationRad = 0f;
         if (direction != Vector2.Zero) rotationRad = direction.AngleRad();
         Transform = new Transform2D(center, rotationRad, new Size(radius));
-        Accuracy = accuracy;
+        ArcPoints = arcPoints;
         AngleSectorRad = angleSectorRad;
     }
     
@@ -71,9 +88,9 @@ public class CircleSector
         
         //ccw order
         polygon.Add(Center);
-        var angleStep = AngleSectorRad / (Accuracy + 1);
+        var angleStep = AngleSectorRad / (ArcPoints + 1);
         var v = ShapeVec.VecFromAngleRad(RotationRad - angleStep / 2) * Radius;
-        for (int i = 0; i < Accuracy + 2; i++)
+        for (int i = 0; i < ArcPoints + 2; i++)
         {
             polygon.Add(Center + v);
             v = v.Rotate(angleStep);
@@ -82,11 +99,11 @@ public class CircleSector
         return true;
     }
     
-    public CircleSector Copy() => new(Center, Radius, RotationRad, AngleSectorRad, Accuracy);
+    public CircleSector Copy() => new(Center, Radius, RotationRad, AngleSectorRad, ArcPoints);
 
-    public Polygon? GeneratePolygon() => GeneratePolygon(Center, Radius, RotationRad, AngleSectorRad, Accuracy);
-    public Points? GeneratePoints() => GeneratePoints(Center, Radius, RotationRad, AngleSectorRad, Accuracy);
-    public Segments? GenerateSegments() => GenerateSegments(Center, Radius, RotationRad, AngleSectorRad, Accuracy);
+    public Polygon? GeneratePolygon() => GeneratePolygon(Center, Radius, RotationRad, AngleSectorRad, ArcPoints);
+    public Points? GeneratePoints() => GeneratePoints(Center, Radius, RotationRad, AngleSectorRad, ArcPoints);
+    public Segments? GenerateSegments() => GenerateSegments(Center, Radius, RotationRad, AngleSectorRad, ArcPoints);
 
     #endregion
 

--- a/ShapeEngine/Core/Shapes/CircleSector.cs
+++ b/ShapeEngine/Core/Shapes/CircleSector.cs
@@ -62,9 +62,17 @@ public class CircleSector : Polygon
             return this;
         }
     }
-    public CircleSector Clone() => new CircleSector(Center, Radius, RotationRad, AngleSectorRad, Accuracy);
-    public Polygon CloneAsPolygon() => Clone();
-    public Polygon? GenerateShape() => GeneratePolygon(Center, Radius, RotationRad, AngleSectorRad, Accuracy);
+    public override void RecalculatePoints()
+    {
+        if (!dirty) return;
+        CalculatePoints();
+    }
+
+    public override CircleSector Copy() => new CircleSector(Center, Radius, RotationRad, AngleSectorRad, Accuracy);
+
+    public Polygon? GeneratePolygon() => GeneratePolygon(Center, Radius, RotationRad, AngleSectorRad, Accuracy);
+    public Points? GeneratePoints() => GeneratePoints(Center, Radius, RotationRad, AngleSectorRad, Accuracy);
+    public Segments? GenerateSegments() => GenerateSegments(Center, Radius, RotationRad, AngleSectorRad, Accuracy);
 
     #endregion
     
@@ -139,7 +147,6 @@ public class CircleSector : Polygon
     #endregion
     
     #region Private Methods
-    protected override void RecalculatePoints() => CalculatePoints();
     private void CalculatePoints()
     {
         this.Clear();

--- a/ShapeEngine/Core/Shapes/Points.cs
+++ b/ShapeEngine/Core/Shapes/Points.cs
@@ -104,6 +104,8 @@ public class Points : ShapeList<Vector2>, IEquatable<Points>
 
     #region Shapes
 
+    public override Points Copy() => new(this);
+
     public Polygon ToPolygon() => new(this);
 
     public Polyline ToPolyline() => new(this);

--- a/ShapeEngine/Core/Shapes/Polygon.cs
+++ b/ShapeEngine/Core/Shapes/Polygon.cs
@@ -1,10 +1,12 @@
 ﻿
+using System.Drawing;
 using System.Numerics;
 using Clipper2Lib;
 using ShapeEngine.Core.Collision;
 using ShapeEngine.Core.Structs;
 using ShapeEngine.Lib;
 using ShapeEngine.Random;
+using Size = ShapeEngine.Core.Structs.Size;
 
 namespace ShapeEngine.Core.Shapes
 {
@@ -14,6 +16,11 @@ namespace ShapeEngine.Core.Shapes
     /// </summary>
     public class Polygon : Points, IEquatable<Polygon>
     {
+        /// <summary>
+        /// Use this getter to get a reference to the polygon were all points have been updated
+        /// </summary>
+        public virtual Polygon Self => this;
+        
         #region Constructors
         public Polygon() { }
 
@@ -160,6 +167,11 @@ namespace ShapeEngine.Core.Shapes
 
         #region Shape
 
+        /// <summary>
+        /// Can be used to recalculate points before they are used in a function
+        /// </summary>
+        protected virtual void RecalculatePoints() { }
+        
         public (Transform2D transform, Polygon shape) ToRelative()
         {
             var pos = GetCentroid();

--- a/ShapeEngine/Core/Shapes/Polygon.cs
+++ b/ShapeEngine/Core/Shapes/Polygon.cs
@@ -16,15 +16,9 @@ namespace ShapeEngine.Core.Shapes
     /// </summary>
     public class Polygon : Points, IEquatable<Polygon>
     {
-        /// <summary>
-        /// Use this getter to get a reference to the polygon were all points have been updated
-        /// </summary>
-        public virtual Polygon Self => this;
+        
 
-        public override Polygon Copy()
-        {
-            return new(this);
-        }
+        public override Polygon Copy() => new(this);
 
         #region Constructors
         public Polygon() { }
@@ -49,6 +43,7 @@ namespace ShapeEngine.Core.Shapes
         public bool Equals(Polygon? other)
         {
             if (other == null) return false;
+            
             if (Count != other.Count) return false;
             for (var i = 0; i < Count; i++)
             {
@@ -57,20 +52,29 @@ namespace ShapeEngine.Core.Shapes
             }
             return true;
         }
-        public override int GetHashCode() { return Game.GetHashCode(this); }
+
+        public override int GetHashCode() => Game.GetHashCode(this);
+
         #endregion
 
         #region Vertices
-        public void FixWindingOrder() { if (this.IsClockwise()) this.Reverse(); }
+
+        public void FixWindingOrder()
+        {
+            if (IsClockwise())
+            {
+                Reverse();
+            }
+        }
         public void MakeClockwise()
         {
             if (IsClockwise()) return;
-            this.Reverse();
+            Reverse();
         }
         public void MakeCounterClockwise()
         {
             if (!IsClockwise()) return;
-            this.Reverse();
+            Reverse();
         }
         public void ReduceVertexCount(int newCount)
         {
@@ -93,7 +97,11 @@ namespace ShapeEngine.Core.Shapes
             }
 
         }
-        public void ReduceVertexCount(float factor) { ReduceVertexCount(Count - (int)(Count * factor)); }
+
+        public void ReduceVertexCount(float factor)
+        {
+            ReduceVertexCount(Count - (int)(Count * factor));
+        }
         public void IncreaseVertexCount(int newCount)
         {
             if (newCount <= Count) return;
@@ -115,11 +123,8 @@ namespace ShapeEngine.Core.Shapes
                 this.Insert(longestID + 1, m);
             }
         }
-        public Vector2 GetVertex(int index)
-        {
-            return this[ShapeMath.WrapIndex(Count, index)];
-        }
-        
+        public Vector2 GetVertex(int index) => this[ShapeMath.WrapIndex(Count, index)];
+
         public void RemoveColinearVertices()
         {
             if (Count < 3) return;
@@ -155,13 +160,13 @@ namespace ShapeEngine.Core.Shapes
         {
             if (Count < 3) return;
             Points result = new();
-            Vector2 centroid = GetCentroid();
+            var centroid = GetCentroid();
             for (int i = 0; i < Count; i++)
             {
-                Vector2 cur = this[i];
-                Vector2 prev = this[ShapeMath.WrapIndex(Count, i - 1)];
-                Vector2 next = this[ShapeMath.WrapIndex(Count, i + 1)];
-                Vector2 dir = (prev - cur) + (next - cur) + ((cur - centroid) * baseWeight);
+                var cur = this[i];
+                var prev = this[ShapeMath.WrapIndex(Count, i - 1)];
+                var next = this[ShapeMath.WrapIndex(Count, i + 1)];
+                var dir = (prev - cur) + (next - cur) + ((cur - centroid) * baseWeight);
                 result.Add(cur + dir * amount);
             }
 
@@ -171,11 +176,6 @@ namespace ShapeEngine.Core.Shapes
         #endregion
 
         #region Shape
-
-        /// <summary>
-        /// Can be used to recalculate points before they are used in a function
-        /// </summary>
-        public virtual void RecalculatePoints() { }
         
         public (Transform2D transform, Polygon shape) ToRelative()
         {
@@ -188,8 +188,7 @@ namespace ShapeEngine.Core.Shapes
             }
 
             var size = MathF.Sqrt(maxLengthSq);
-
-            var relativeShape = new Polygon();
+            var relativeShape = new Polygon(Count);
             for (int i = 0; i < this.Count; i++)
             {
                 var w = this[i] - pos;
@@ -201,8 +200,8 @@ namespace ShapeEngine.Core.Shapes
 
         public Points ToRelativePoints(Transform2D transform)
         {
-            var points = new Points();
-            for (int i = 0; i < this.Count; i++)
+            var points = new Points(Count);
+            for (int i = 0; i < Count; i++)
             {
                 var p = transform.RevertPosition(this[i]);
                 points.Add(p);
@@ -212,8 +211,8 @@ namespace ShapeEngine.Core.Shapes
         }
         public Polygon ToRelativePolygon(Transform2D transform)
         {
-            var points = new Polygon();
-            for (int i = 0; i < this.Count; i++)
+            var points = new Polygon(Count);
+            for (int i = 0; i < Count; i++)
             {
                 var p = transform.RevertPosition(this[i]);
                 points.Add(p);
@@ -223,8 +222,8 @@ namespace ShapeEngine.Core.Shapes
         }
         public List<Vector2> ToRelative(Transform2D transform)
         {
-            var points = new List<Vector2>();
-            for (int i = 0; i < this.Count; i++)
+            var points = new List<Vector2>(Count);
+            for (int i = 0; i < Count; i++)
             {
                 var p = transform.RevertPosition(this[i]);
                 points.Add(p);
@@ -232,13 +231,14 @@ namespace ShapeEngine.Core.Shapes
 
             return points;
         }
-        
-        
-        public Triangle GetBoundingTriangle(float margin = 3f) { return Polygon.GetBoundingTriangle(this, margin); }
+
+
+        public Triangle GetBoundingTriangle(float margin = 3f) => Polygon.GetBoundingTriangle(this, margin);
+
         public Triangulation Triangulate()
         {
             if (Count < 3) return new();
-            else if (Count == 3) return new() { new(this[0], this[1], this[2]) };
+            if (Count == 3) return new() { new(this[0], this[1], this[2]) };
 
             Triangulation triangles = new();
             List<Vector2> vertices = new();
@@ -310,7 +310,7 @@ namespace ShapeEngine.Core.Shapes
         {
             if (Count <= 1) return new();
             if (Count == 2) return new() { new(this[0], this[1]) };
-            Segments segments = new();
+            Segments segments = new(Count);
             for (int i = 0; i < Count; i++)
             {
                 segments.Add(new(this[i], this[(i + 1) % Count]));
@@ -333,10 +333,11 @@ namespace ShapeEngine.Core.Shapes
 
             return new Circle(origin, MathF.Sqrt(maxD));
         }
+        
         public Rect GetBoundingBox()
         {
             if (Count < 2) return new();
-            Vector2 start = this[0];
+            var start = this[0];
             Rect r = new(start.X, start.Y, 0, 0);
 
             foreach (var p in this)
@@ -346,6 +347,7 @@ namespace ShapeEngine.Core.Shapes
             return r;
         }
         public Polygon ToConvex() => Polygon.FindConvexHull(this);
+
         #endregion
         
         #region Math
@@ -353,6 +355,7 @@ namespace ShapeEngine.Core.Shapes
         public Points? GetProjectedShapePoints(Vector2 v)
         {
             if (v.LengthSquared() <= 0f) return null;
+            
             var points = new Points(Count);
             for (var i = 0; i < Count; i++)
             {
@@ -426,11 +429,11 @@ namespace ShapeEngine.Core.Shapes
         }
         public float GetPerimeterSquared()
         {
-            if (this.Count < 3) return 0f;
-            float lengthSq = 0f;
-            for (int i = 0; i < Count; i++)
+            if (Count < 3) return 0f;
+            var lengthSq = 0f;
+            for (var i = 0; i < Count; i++)
             {
-                Vector2 w = this[(i + 1)%Count] - this[i];
+                var w = this[(i + 1)%Count] - this[i];
                 lengthSq += w.LengthSquared();
             }
             return lengthSq;
@@ -469,7 +472,11 @@ namespace ShapeEngine.Core.Shapes
             }
             return true;
         }
-        public Points ToPoints() { return new(this); }
+
+        public Points ToPoints()
+        {
+            return new(this);
+        }
         public Vector2 GetCentroidMean()
         {
             if (Count <= 0) return new(0f);
@@ -485,10 +492,7 @@ namespace ShapeEngine.Core.Shapes
         /// the polygon is regular. More info: http://en.wikipedia.org/wiki/Apothem
         /// </summary>
         /// <returns>Return the length of the apothem.</returns>
-        public float GetApothem()
-        {
-            return (this.GetCentroid() - (this[0].Lerp(this[1], 0.5f))).Length();
-        }
+        public float GetApothem() => (this.GetCentroid() - (this[0].Lerp(this[1], 0.5f))).Length();
 
         #endregion
         

--- a/ShapeEngine/Core/Shapes/Polygon.cs
+++ b/ShapeEngine/Core/Shapes/Polygon.cs
@@ -20,7 +20,12 @@ namespace ShapeEngine.Core.Shapes
         /// Use this getter to get a reference to the polygon were all points have been updated
         /// </summary>
         public virtual Polygon Self => this;
-        
+
+        public override Polygon Copy()
+        {
+            return new(this);
+        }
+
         #region Constructors
         public Polygon() { }
 
@@ -170,7 +175,7 @@ namespace ShapeEngine.Core.Shapes
         /// <summary>
         /// Can be used to recalculate points before they are used in a function
         /// </summary>
-        protected virtual void RecalculatePoints() { }
+        public virtual void RecalculatePoints() { }
         
         public (Transform2D transform, Polygon shape) ToRelative()
         {

--- a/ShapeEngine/Core/Shapes/ShapeList.cs
+++ b/ShapeEngine/Core/Shapes/ShapeList.cs
@@ -11,7 +11,12 @@ public class ShapeList<T> : List<T>
         
     }
     public void AddRange(params T[] items) { AddRange(items as IEnumerable<T>);}
-    public ShapeList<T> Copy()
+    
+    /// <summary>
+    /// Does not deep copy
+    /// </summary>
+    /// <returns></returns>
+    public virtual ShapeList<T> Copy()
     {
         ShapeList<T> newList = new();
         newList.AddRange(this);


### PR DESCRIPTION
This PR adds 2 new classes:
- CircleSector
- CircleSectorCollider

### Circle Sector
Can be used to generate or update polygons with circle sector parameters. CircleSectors can be used for vision cones of turrets or enemies.

### Circle Sector Collider
Ready to use collider for the collision system. Uses polygon as shape type.

### Misc
- small changes and improvements to the collider class to make it easier to update a shape if certain values have changed (CircleSectorCollider needed that)
- polygon class clean up
- SegmentCollider, PolylineCollider, PolygonCollider small changes based on the changes of the collider class.