### PR TITLE
Collider passive parameter

### DIFF
--- a/ShapeEngine/Core/Collision/Collision.cs
+++ b/ShapeEngine/Core/Collision/Collision.cs
@@ -1,5 +1,6 @@
 using System.Numerics;
 using ShapeEngine.Core.Interfaces;
+using ShapeEngine.Core.Structs;
 
 namespace ShapeEngine.Core.Collision;
 
@@ -11,6 +12,7 @@ public class Collision
     public readonly Vector2 SelfVel;
     public readonly Vector2 OtherVel;
     public readonly Intersection Intersection;
+    public CollisionPoint FirstCollisionPoint => Intersection.Valid ? Intersection.FirstCollisionPoint : new();
 
     public Collision(Collider self, Collider other, bool firstContact)
     {

--- a/ShapeEngine/Core/Collision/Collision.cs
+++ b/ShapeEngine/Core/Collision/Collision.cs
@@ -12,8 +12,12 @@ public class Collision
     public readonly Vector2 SelfVel;
     public readonly Vector2 OtherVel;
     public readonly Intersection Intersection;
+    
     public CollisionPoint FirstCollisionPoint => Intersection.Valid ? Intersection.FirstCollisionPoint : new();
+    public CollisionPoint ClosestCollisionPoint => Intersection.Valid ? Intersection.Closest : new();
+    public CollisionPoint FurthestCollisionPoint => Intersection.Valid ? Intersection.Furthest : new();
 
+    
     public Collision(Collider self, Collider other, bool firstContact)
     {
         this.Self = self;
@@ -31,6 +35,69 @@ public class Collision
         this.OtherVel = other.Velocity;
         this.Intersection = new(collisionPoints, SelfVel, self.CurTransform.Position);
         this.FirstContact = firstContact;
+    }
+
+    
+    public CollisionPoint GetClosestCollisionPointToParent()
+    {
+        if (!Intersection.Valid) return new();
+        var parent = Self.Parent;
+        return parent == null ? new() : Intersection.GetClosestCollisionPoint(parent.Transform.Position);
+    }
+    public CollisionPoint GetClosestCollisionPoint()
+    {
+        if (!Intersection.Valid) return new();
+        return Intersection.GetClosestCollisionPoint(Self.CurTransform.Position);
+    }
+    public CollisionPoint GetClosestCollisionPoint(Vector2 referencePoint)
+    {
+        if (!Intersection.Valid) return new();
+        return Intersection.GetClosestCollisionPoint(referencePoint);
+    }
+
+    
+    /// <summary>
+    /// Finds the collision point with the normal facing most towards the reference direction.
+    /// </summary>
+    /// <returns></returns>
+    public CollisionPoint GetCollisionPointFacingTowardsDir(Vector2 referenceDir)
+    {
+        if (!Intersection.Valid) return new();
+        return Intersection.GetCollisionPointFacingTowardsDir(referenceDir);
+    }
+   
+    /// <summary>
+    /// Finds the collision point with the normal facing most towards the reference point.
+    /// The direction used is from each collision point towards the reference point.
+    /// </summary>
+    /// <returns></returns>
+    public CollisionPoint GetCollisionPointFacingTowardsPoint(Vector2 referencePoint)
+    {
+        if (!Intersection.Valid) return new();
+        return Intersection.GetCollisionPointFacingTowardsPoint(referencePoint);
+    }
+
+    
+    /// <summary>
+    /// Finds the collision point with the normal facing most towards the parent of self.
+    /// </summary>
+    /// <returns></returns>
+    public CollisionPoint GetCollisionPointFacingTowardsParent()
+    {
+        if (!Intersection.Valid) return new();
+        
+        var parent = Self.Parent;
+        return parent == null ? new() : Intersection.GetCollisionPointFacingTowardsPoint(parent.Transform.Position);
+    }
+    
+    /// <summary>
+    /// Finds the collision point with the normal facing most towards self.
+    /// </summary>
+    /// <returns></returns>
+    public CollisionPoint GetCollisionPointFacingTowardsSelf()
+    {
+        if (!Intersection.Valid) return new();
+        return  Intersection.GetCollisionPointFacingTowardsPoint(Self.CurTransform.Position);
     }
 
 }

--- a/ShapeEngine/Core/Collision/CollisionHandler.cs
+++ b/ShapeEngine/Core/Collision/CollisionHandler.cs
@@ -215,6 +215,7 @@ namespace ShapeEngine.Core.Collision
             {
                 if (!collisionBody.Enabled || !collisionBody.HasColliders) continue;
 
+                var passivChecking = collisionBody.Passive;
                 if (collisionBody.ProjectShape)
                 {
                     foreach (var collider in collisionBody.Colliders)
@@ -262,9 +263,16 @@ namespace ShapeEngine.Core.Collision
                                     
                                     if (computeIntersections)
                                     {
-                                        //CollisionChecksPerFrame++;
-                                        var collisionPoints = projected.Intersect(candidate); // ShapeGeometry.Intersect(collider, candidate);
-
+                                        CollisionPoints? collisionPoints = null;
+                                        if (passivChecking)
+                                        {
+                                            collisionPoints = candidate.Intersect(projected);
+                                        }
+                                        else
+                                        {
+                                            collisionPoints = projected.Intersect(candidate);
+                                        }
+                                        
                                         //shapes overlap but no collision points means collidable is completely inside other
                                         //closest point on bounds of other are now used for collision point
                                         if (collisionPoints == null || collisionPoints.Count <= 0)
@@ -346,10 +354,17 @@ namespace ShapeEngine.Core.Collision
                                     }
                                     
                                     if (computeIntersections)
-                                    {
-                                        //CollisionChecksPerFrame++;
-                                        var collisionPoints = collider.Intersect(candidate); // ShapeGeometry.Intersect(collider, candidate);
-
+                                    {                                                         
+                                        CollisionPoints? collisionPoints = null;
+                                        if (passivChecking)
+                                        {
+                                            collisionPoints = candidate.Intersect(collider);
+                                        }
+                                        else
+                                        {
+                                            collisionPoints = collider.Intersect(candidate);
+                                        }
+                                        
                                         //shapes overlap but no collision points means collidable is completely inside other
                                         //closest point on bounds of other are now used for collision point
                                         if (collisionPoints == null || collisionPoints.Count <= 0)

--- a/ShapeEngine/Core/Collision/CollisionInformation.cs
+++ b/ShapeEngine/Core/Collision/CollisionInformation.cs
@@ -42,14 +42,30 @@ public class CollisionInformation
         }
     }
 
-    //public bool ContainsCollidable(TCollidable other)
-    //{
-    //    foreach (var c in Collisions)
-    //    {
-    //        if (c.Other == other) return true;
-    //    }
-    //    return false;
-    //}
+    //return a dictionary of sorted collisions based on parent
+    public Dictionary<CollisionObject, List<Collision>> GetCollisionsSortedByParent()
+    {
+        Dictionary<CollisionObject, List<Collision>> sortedCollisions = new();
+
+        foreach (var col in Collisions)
+        {
+            var parent = col.Other.Parent;
+            if (parent == null) continue;
+            
+            if (sortedCollisions.TryGetValue(parent, out var value))
+            {
+                value.Add(col);
+            }
+            else
+            {
+                var list = new List<Collision>() { col };
+                sortedCollisions[parent] = list;
+            }
+        }
+        
+        return sortedCollisions;
+    }
+    
     public List<Collision> FilterCollisions(Predicate<Collision> match)
     {
         List<Collision> filtered = new();

--- a/ShapeEngine/Core/Collision/Intersection.cs
+++ b/ShapeEngine/Core/Collision/Intersection.cs
@@ -9,7 +9,9 @@ public class Intersection
     public readonly bool Valid;
     public readonly CollisionSurface CollisionSurface;
     public readonly CollisionPoints? ColPoints;
-
+    
+    public CollisionPoint FirstCollisionPoint =>  ColPoints is { Count: > 0 } ? ColPoints[0] : new();
+    
     public Intersection() { this.Valid = false; this.CollisionSurface = new(); this.ColPoints = null; }
     public Intersection(CollisionPoints? points, Vector2 vel, Vector2 refPoint)
     {

--- a/ShapeEngine/Core/CollisionObject.cs
+++ b/ShapeEngine/Core/CollisionObject.cs
@@ -31,6 +31,14 @@ public abstract class CollisionObject : PhysicsObject
 
     private bool enabled = true;
 
+    /// <summary>
+    /// If a Passive CollisionObject checks for collisions/intersections against Non-Passive CollisionObjects,
+    /// the CollisionInformation will be generated as if the Non-Passive CollisionObject checked for the collision.
+    /// This mostly affects CollisionPoint normal generation. Normally the normals are pointing towards the CollisionObject that is checking for the collision.
+    /// If this is not wanted and the normals should point away from the CollisionObject that is checking for the collision, the Passive flag should be set to true.
+    /// This only comes into effect for colliders that compute intersections!
+    /// </summary>
+    public bool Passive = false;
     public bool Enabled
     {
         get => enabled && !IsDead;

--- a/ShapeEngine/Core/Structs/CollisionPoint.cs
+++ b/ShapeEngine/Core/Structs/CollisionPoint.cs
@@ -21,6 +21,30 @@ public readonly struct CollisionPoint : IEquatable<CollisionPoint>
         Normal = n;
     }
 
+    public CollisionPoint(CollisionSurface surface)
+    {
+        Point = surface.Point;
+        Normal = surface.Normal;
+    }
+    public CollisionSurface ToCollisionSurface() => new CollisionSurface(Point, Normal);
+    
+    public CollisionSurface Average(CollisionPoint other) => new((Point + other.Point) / 2, (Normal + other.Normal).Normalize());
+
+    public static CollisionSurface Average(CollisionPoint a, CollisionPoint b) => new((a.Point + b.Point) / 2, (a.Normal + b.Normal).Normalize());
+
+    public static CollisionSurface Average(params CollisionPoint[] points)
+    {
+        if(points.Length == 0) return new CollisionSurface();
+        var avgPoint = Vector2.Zero;
+        var avgNormal = Vector2.Zero;
+        foreach (var point in points)
+        {
+            avgPoint += point.Point;
+            avgNormal += point.Normal;
+        }
+        return new CollisionSurface(avgPoint / points.Length, avgNormal.Normalize());
+    }
+    
     public bool Equals(CollisionPoint other)
     {
         return other.Point == Point && other.Normal == Normal;

--- a/ShapeEngine/Core/Structs/CollisionSurface.cs
+++ b/ShapeEngine/Core/Structs/CollisionSurface.cs
@@ -15,4 +15,10 @@ public readonly struct CollisionSurface
         this.Normal = normal;
     }
 
+    public CollisionSurface(CollisionPoint p)
+    {
+        Point = p.Point;
+        Normal = p.Normal;
+    }
+    public CollisionPoint ToCollisionPoint() => new CollisionPoint(Point, Normal);
 }


### PR DESCRIPTION
- `Passive` parameter added to CollisionObject: Passive CollisionObjects that listen for collisions will act as the other part of the collision, with the active object determining which normals are used and where they are pointing. This primarily affects the collision response.
- **Enhancements to CollisionPoint**: Improvements have been made to the CollisionPoint struct, providing additional functionality.
- **Enhancements to CollisionSurface**: Improvements have been made to the CollisionSurface struct, enhancing its functionality.
- **Enhancements to Collision**: Convenience functions have been added to the Collision class, allowing for filtering results based on collider parent and providing quick access to the Closest, Furthest, First CollisionPoint of the Intersection.
- **Enhancements to Intersection**: Convenience functions have been added to the Intersection class, enabling filtering results based on collider and providing quick access to the Closest, Furthest, First CollisionPoint, and the CollisionPoint with a normal pointing in a specific direction.