### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -1,4 +1,6 @@
 name: .NET Publish Examples
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/DaveGreen-Games/ShapeEngine/security/code-scanning/1](https://github.com/DaveGreen-Games/ShapeEngine/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the minimal permissions required for the workflow to function correctly. Based on the steps in the workflow, the `contents: read` permission is sufficient, as the workflow only checks out the repository, restores dependencies, builds the project, and uploads artifacts. No write permissions are needed.

The `permissions` block will be added immediately after the `name` field in the workflow file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
