### PR TITLE
OSX Builds Crash Fix

### DIFF
--- a/Examples/Program.cs
+++ b/Examples/Program.cs
@@ -9,12 +9,14 @@ namespace Examples
         public static GameloopExamples GAMELOOP = new();
         public static void Main(string[] args)
         {
-            if (Game.IsOSX())
-            {
-                var exePath = System.Reflection.Assembly.GetEntryAssembly()?.Location;
-                var exeDir = Path.GetDirectoryName(exePath);
-                if (exeDir != null) Directory.SetCurrentDirectory(exeDir);
-            }
+            //this is a fix to be able to run the examples executable on macOS with a double click...
+            //this fix was implemented into shape engine directly, therefore it is not needed here anymore
+            // if (Game.IsOSX())
+            // {
+            //     var exePath = System.Reflection.Assembly.GetEntryAssembly()?.Location;
+            //     var exeDir = Path.GetDirectoryName(exePath);
+            //     if (exeDir != null) Directory.SetCurrentDirectory(exeDir);
+            // }
             
             
             // GAMELOOP = new();

--- a/Examples/Program.cs
+++ b/Examples/Program.cs
@@ -13,9 +13,13 @@ namespace Examples
             //this fix was implemented into shape engine directly, therefore it is not needed here anymore
             // if (Game.IsOSX())
             // {
+            //var 1
             //     var exePath = System.Reflection.Assembly.GetEntryAssembly()?.Location;
             //     var exeDir = Path.GetDirectoryName(exePath);
             //     if (exeDir != null) Directory.SetCurrentDirectory(exeDir);
+            //var 2
+            //     string exeDir = AppContext.BaseDirectory;
+            //     if (!string.IsNullOrEmpty(exeDir)) Directory.SetCurrentDirectory(exeDir);
             // }
             
             

--- a/Examples/Program.cs
+++ b/Examples/Program.cs
@@ -1,4 +1,5 @@
 ﻿global using static Examples.Program;
+using ShapeEngine.Core;
 
 namespace Examples
 {
@@ -8,6 +9,13 @@ namespace Examples
         public static GameloopExamples GAMELOOP = new();
         public static void Main(string[] args)
         {
+            if (Game.IsOSX())
+            {
+                var exePath = System.Reflection.Assembly.GetEntryAssembly()?.Location;
+                var exeDir = Path.GetDirectoryName(exePath);
+                if (exeDir != null) Directory.SetCurrentDirectory(exeDir);
+            }
+            
             
             // GAMELOOP = new();
             GAMELOOP.Run(args);

--- a/ShapeEngine/Core/Game.cs
+++ b/ShapeEngine/Core/Game.cs
@@ -240,6 +240,15 @@ public class Game
         ShapeInput.OnInputDeviceChanged += OnInputDeviceChanged;
         ShapeInput.GamepadDeviceManager.OnGamepadConnectionChanged += OnGamepadConnectionChanged;
         
+        //this will set the current directory for the executable correctly,
+        //so it can be opened with a double click on the exe file.
+        //without this, the executable has to be launched from the command line
+        if (IsOSX())
+        {
+            string? exePath = System.Reflection.Assembly.GetEntryAssembly()?.Location;
+            string? exeDir = Path.GetDirectoryName(exePath);
+            if (exeDir != null) Directory.SetCurrentDirectory(exeDir);
+        }
     }
     
 

--- a/ShapeEngine/Core/Game.cs
+++ b/ShapeEngine/Core/Game.cs
@@ -240,14 +240,18 @@ public class Game
         ShapeInput.OnInputDeviceChanged += OnInputDeviceChanged;
         ShapeInput.GamepadDeviceManager.OnGamepadConnectionChanged += OnGamepadConnectionChanged;
         
-        //this will set the current directory for the executable correctly,
-        //so it can be opened with a double click on the exe file.
+        //This sets the current directory to the executable's folder, enabling double-click launches.
         //without this, the executable has to be launched from the command line
         if (IsOSX())
         {
-            string? exePath = System.Reflection.Assembly.GetEntryAssembly()?.Location;
-            string? exeDir = Path.GetDirectoryName(exePath);
-            if (exeDir != null) Directory.SetCurrentDirectory(exeDir);
+            //old version
+            // string? exePath = System.Reflection.Assembly.GetEntryAssembly()?.Location;
+            // string? exeDir = Path.GetDirectoryName(exePath);
+            // if (exeDir != null) Directory.SetCurrentDirectory(exeDir);
+            
+            //updated version
+            string exeDir = AppContext.BaseDirectory;
+            if (!string.IsNullOrEmpty(exeDir)) Directory.SetCurrentDirectory(exeDir);
         }
     }
     


### PR DESCRIPTION
Builds would crash on macOS because the directory is not set correctly on game launch. The executable would only work when launched from the command line. This fix should allow to users to launch the exe file with a double click as well. 

This is the first step to make build on macOS work better.