### PR TITLE
CollisionPoint & CollisionPoints renamed

### DIFF
--- a/Examples/Scenes/ExampleScenes/EndlessSpaceExampleSource/AsteroidObstacle.cs
+++ b/Examples/Scenes/ExampleScenes/EndlessSpaceExampleSource/AsteroidObstacle.cs
@@ -116,7 +116,7 @@ internal class AsteroidObstacle : CollisionObject
     protected override void Collision(CollisionInformation info)
     {
         if(info.Count <= 0) return;
-        if(!info.Validate(out CollisionPoint combined)) return;
+        if(!info.Validate(out IntersectionPoint combined)) return;
         foreach (var collision in info)
         {
             if(collision.Points == null || collision.Points.Count <= 0 || !collision.FirstContact)continue;

--- a/Examples/Scenes/ExampleScenes/EndlessSpaceExampleSource/LaserBeam.cs
+++ b/Examples/Scenes/ExampleScenes/EndlessSpaceExampleSource/LaserBeam.cs
@@ -27,7 +27,7 @@ internal class LaserBeam
     private float damageTimer = 0f;
     private float chargeTimer = 0f;
     private float chargeDuration = 1f;
-    private CollisionPoint hitPoint = new();
+    private IntersectionPoint hitPoint = new();
     private List<LaserBeamParticle> particles = new();
     private float laserBeamWidthVariationFactor = 1f;
     private float laserBeamWidthVariationFactorTimer = 0f;

--- a/Examples/Scenes/ExampleScenes/EndlessSpaceExampleSource/Ship.cs
+++ b/Examples/Scenes/ExampleScenes/EndlessSpaceExampleSource/Ship.cs
@@ -82,7 +82,7 @@ internal class Ship : CollisionObject, ICameraFollowTarget
     protected override void Collision(CollisionInformation info)
     {
         if(info.Count <= 0 || info.Other is not AsteroidObstacle a) return;
-        if(!info.Validate(out CollisionPoint combined)) return;
+        if(!info.Validate(out IntersectionPoint combined)) return;
             
         a.Cut(GetCutShape());
             

--- a/Examples/Scenes/ExampleScenes/GameObjectHandlerExample.cs
+++ b/Examples/Scenes/ExampleScenes/GameObjectHandlerExample.cs
@@ -228,14 +228,14 @@ namespace Examples.Scenes.ExampleScenes
 
         protected override void Collision(CollisionInformation info)
         {
-            // CollisionPoint p = new();
+            // IntersectionPoint p = new();
             // if (info.Count > 0)
             // {
             //     foreach (var collision in info)
             //     {
             //         if(!collision.FirstContact) continue;
             //         if(collision.Points == null) continue;
-            //         if (collision.Validate(out CollisionPoint combined))
+            //         if (collision.Validate(out IntersectionPoint combined))
             //         {
             //             if (combined.Valid) p = p.Combine(combined);
             //         }
@@ -244,7 +244,7 @@ namespace Examples.Scenes.ExampleScenes
 
             if(!info.FirstContact) return;
             
-            var p = info.FilteredCollisionPoint;
+            var p = info.FilteredIntersectionPoint;
             if (p.Valid)
             {
                 Velocity = Velocity.Reflect(p.Normal);
@@ -325,7 +325,7 @@ namespace Examples.Scenes.ExampleScenes
 
         protected override void Collision(CollisionInformation info)
         {
-            CollisionPoint p = new();
+            IntersectionPoint p = new();
             if (info.Count > 0)
             {
                 foreach (var collision in info)
@@ -484,7 +484,7 @@ namespace Examples.Scenes.ExampleScenes
         
         protected override void Collision(CollisionInformation info)
         {
-            CollisionPoint p = new();
+            IntersectionPoint p = new();
             if (info.Count > 0)
             {
                 foreach (var collision in info)
@@ -575,14 +575,14 @@ namespace Examples.Scenes.ExampleScenes
 
         protected override void Collision(CollisionInformation info)
         {
-            // CollisionPoint p = new();
+            // IntersectionPoint p = new();
             // if (info.Count > 0)
             // {
             //     foreach (var collision in info)
             //     {
             //         if(!collision.FirstContact) continue;
             //         if(collision.Points == null) continue;
-            //         if (collision.Validate(out CollisionPoint combined))
+            //         if (collision.Validate(out IntersectionPoint combined))
             //         {
             //             // var cp = collision.Points.GetAverageCollisionPoint();
             //             if (combined.Valid) p = p.Combine(combined);
@@ -591,7 +591,7 @@ namespace Examples.Scenes.ExampleScenes
             // }
 
             if(!info.FirstContact) return;
-            var p = info.FilteredCollisionPoint;
+            var p = info.FilteredIntersectionPoint;
             if (p.Valid)
             {
                 Velocity = Velocity.Reflect(p.Normal);

--- a/Examples/Scenes/ExampleScenes/PhysicsExampleSource/Asteroid.cs
+++ b/Examples/Scenes/ExampleScenes/PhysicsExampleSource/Asteroid.cs
@@ -168,7 +168,7 @@ public class Asteroid : CollisionObject
             return;
         }
         
-        var cp = info.FilteredCollisionPoint;
+        var cp = info.FilteredIntersectionPoint;
         if (!cp.Valid)
         {
             return;

--- a/Examples/Scenes/ExampleScenes/ProjectedShapesExample.cs
+++ b/Examples/Scenes/ExampleScenes/ProjectedShapesExample.cs
@@ -26,11 +26,11 @@ public class ProjectedShapesExample : ExampleScene
         public abstract ShapeType GetShapeType();
         public abstract ClosestDistance GetClosestDistanceTo(Shape shape);
         public abstract bool OverlapWith(Shape shape);
-        public abstract CollisionPoints? IntersectWith(Shape shape);
+        public abstract IntersectionPoints? IntersectWith(Shape shape);
 
         public abstract ClosestDistance GetClosestDistanceTo(Polygon polygon);
         public abstract bool OverlapWith(Polygon polygon);
-        public abstract CollisionPoints? IntersectWith(Polygon polygon);
+        public abstract IntersectionPoints? IntersectWith(Polygon polygon);
         
         public abstract Polygon? GetProjectionPoints(Vector2 projectionPosition);
         
@@ -81,7 +81,7 @@ public class ProjectedShapesExample : ExampleScene
     //     {
     //         return false;
     //     }
-    //     public override CollisionPoints? IntersectWith(Shape shape)
+    //     public override IntersectionPoints? IntersectWith(Shape shape)
     //     {
     //         return null;
     //     }
@@ -146,7 +146,7 @@ public class ProjectedShapesExample : ExampleScene
             if (shape is PolylineShape polylineShape) return Segment.OverlapShape(polylineShape.Polyline);
             return new();
         }
-        public override CollisionPoints? IntersectWith(Shape shape)
+        public override IntersectionPoints? IntersectWith(Shape shape)
         {
             // if (shape is PointShape pointShape) return null;
             if (shape is SegmentShape segmentShape) return Segment.IntersectShape(segmentShape.Segment);
@@ -163,7 +163,7 @@ public class ProjectedShapesExample : ExampleScene
 
         public override bool OverlapWith(Polygon polygon) => Segment.OverlapShape(polygon);
 
-        public override CollisionPoints? IntersectWith(Polygon polygon) => polygon.IntersectShape(Segment);
+        public override IntersectionPoints? IntersectWith(Polygon polygon) => polygon.IntersectShape(Segment);
         
         public override Polygon? GetProjectionPoints(Vector2 projectionPosition)
         {
@@ -217,7 +217,7 @@ public class ProjectedShapesExample : ExampleScene
             if (shape is PolylineShape polylineShape) return Circle.OverlapShape(polylineShape.Polyline);
             return new();
         }
-        public override CollisionPoints? IntersectWith(Shape shape)
+        public override IntersectionPoints? IntersectWith(Shape shape)
         {
             // if (shape is PointShape pointShape) return null;
             if (shape is SegmentShape segmentShape) return Circle.IntersectShape(segmentShape.Segment);
@@ -234,7 +234,7 @@ public class ProjectedShapesExample : ExampleScene
 
         public override bool OverlapWith(Polygon polygon) => Circle.OverlapShape(polygon);
 
-        public override CollisionPoints? IntersectWith(Polygon polygon) => polygon.IntersectShape(Circle);
+        public override IntersectionPoints? IntersectWith(Polygon polygon) => polygon.IntersectShape(Circle);
         
         public override Polygon? GetProjectionPoints(Vector2 projectionPosition)
         {
@@ -298,7 +298,7 @@ public class ProjectedShapesExample : ExampleScene
             if (shape is PolylineShape polylineShape) return Triangle.OverlapShape(polylineShape.Polyline);
             return new();
         }
-        public override CollisionPoints? IntersectWith(Shape shape)
+        public override IntersectionPoints? IntersectWith(Shape shape)
         {
             // if (shape is PointShape pointShape) return null;
             if (shape is SegmentShape segmentShape) return Triangle.IntersectShape(segmentShape.Segment);
@@ -315,7 +315,7 @@ public class ProjectedShapesExample : ExampleScene
 
         public override bool OverlapWith(Polygon polygon) => Triangle.OverlapShape(polygon);
 
-        public override CollisionPoints? IntersectWith(Polygon polygon) => polygon.IntersectShape(Triangle);
+        public override IntersectionPoints? IntersectWith(Polygon polygon) => polygon.IntersectShape(Triangle);
         public override Polygon? GetProjectionPoints(Vector2 projectionPosition)
         {
             var v = projectionPosition - position;
@@ -370,7 +370,7 @@ public class ProjectedShapesExample : ExampleScene
             if (shape is PolylineShape polylineShape) return Quad.OverlapShape(polylineShape.Polyline);
             return new();
         }
-        public override CollisionPoints? IntersectWith(Shape shape)
+        public override IntersectionPoints? IntersectWith(Shape shape)
         {
             // if (shape is PointShape pointShape) return null;
             if (shape is SegmentShape segmentShape) return Quad.IntersectShape(segmentShape.Segment);
@@ -387,7 +387,7 @@ public class ProjectedShapesExample : ExampleScene
 
         public override bool OverlapWith(Polygon polygon) => Quad.OverlapShape(polygon);
 
-        public override CollisionPoints? IntersectWith(Polygon polygon) => polygon.IntersectShape(Quad);
+        public override IntersectionPoints? IntersectWith(Polygon polygon) => polygon.IntersectShape(Quad);
         
         public override Polygon? GetProjectionPoints(Vector2 projectionPosition)
         {
@@ -443,7 +443,7 @@ public class ProjectedShapesExample : ExampleScene
             if (shape is PolylineShape polylineShape) return Rect.OverlapShape(polylineShape.Polyline);
             return new();
         }
-        public override CollisionPoints? IntersectWith(Shape shape)
+        public override IntersectionPoints? IntersectWith(Shape shape)
         {
             // if (shape is PointShape pointShape) return null;
             if (shape is SegmentShape segmentShape) return Rect.IntersectShape(segmentShape.Segment);
@@ -459,7 +459,7 @@ public class ProjectedShapesExample : ExampleScene
 
         public override bool OverlapWith(Polygon polygon) => Rect.OverlapShape(polygon);
 
-        public override CollisionPoints? IntersectWith(Polygon polygon) => polygon.IntersectShape(Rect);
+        public override IntersectionPoints? IntersectWith(Polygon polygon) => polygon.IntersectShape(Rect);
         public override Polygon? GetProjectionPoints(Vector2 projectionPosition)
         {
             var v = projectionPosition - Rect.Center;
@@ -517,7 +517,7 @@ public class ProjectedShapesExample : ExampleScene
             if (shape is PolylineShape polylineShape) return Polygon.OverlapShape(polylineShape.Polyline);
             return new();
         }
-        public override CollisionPoints? IntersectWith(Shape shape)
+        public override IntersectionPoints? IntersectWith(Shape shape)
         {
             // if (shape is PointShape pointShape) return null;
             if (shape is SegmentShape segmentShape) return Polygon.IntersectShape(segmentShape.Segment);
@@ -533,7 +533,7 @@ public class ProjectedShapesExample : ExampleScene
 
         public override bool OverlapWith(Polygon polygon) => Polygon.OverlapShape(polygon);
 
-        public override CollisionPoints? IntersectWith(Polygon polygon) => polygon.IntersectShape(Polygon);
+        public override IntersectionPoints? IntersectWith(Polygon polygon) => polygon.IntersectShape(Polygon);
         public override Polygon? GetProjectionPoints(Vector2 projectionPosition)
         {
             var v = projectionPosition - position;
@@ -598,7 +598,7 @@ public class ProjectedShapesExample : ExampleScene
             if (shape is PolylineShape polylineShape) return Polyline.OverlapShape(polylineShape.Polyline);
             return new();
         }
-        public override CollisionPoints? IntersectWith(Shape shape)
+        public override IntersectionPoints? IntersectWith(Shape shape)
         {
             // if (shape is PointShape pointShape) return null;
             if (shape is SegmentShape segmentShape) return Polyline.IntersectShape(segmentShape.Segment);
@@ -614,7 +614,7 @@ public class ProjectedShapesExample : ExampleScene
 
         public override bool OverlapWith(Polygon polygon) => Polyline.OverlapShape(polygon);
 
-        public override CollisionPoints? IntersectWith(Polygon polygon) => polygon.IntersectShape(Polyline);
+        public override IntersectionPoints? IntersectWith(Polygon polygon) => polygon.IntersectShape(Polyline);
         public override Polygon? GetProjectionPoints(Vector2 projectionPosition)
         {
             var v = projectionPosition -position;

--- a/Examples/Scenes/ExampleScenes/ShapeIntersectionExample.cs
+++ b/Examples/Scenes/ExampleScenes/ShapeIntersectionExample.cs
@@ -51,11 +51,11 @@ public class ShapeIntersectionExample : ExampleScene
         
         public abstract ClosestPointResult GetClosestPointToShape(Shape shape);
         public abstract bool OverlapWith(Shape shape);
-        public abstract CollisionPoints? IntersectWith(Shape shape);
+        public abstract IntersectionPoints? IntersectWith(Shape shape);
         public abstract bool Contains(Shape shape);
         public abstract ClosestPointResult GetClosestPointToPolygon(Polygon polygon);
         public abstract bool OverlapWith(Polygon polygon);
-        public abstract CollisionPoints? IntersectWith(Polygon polygon);
+        public abstract IntersectionPoints? IntersectWith(Polygon polygon);
         public abstract bool Contains(Polygon polygon);
         public abstract Polygon? GetProjectionPoints(Vector2 projectionPosition);
         
@@ -115,8 +115,8 @@ public class ShapeIntersectionExample : ExampleScene
             if (shape is PointShape pointShape)
             {
                 var disSquared = (pointShape.Position - Position).LengthSquared();
-                var cpSelf = new CollisionPoint(Position, (pointShape.Position - Position).Normalize());
-                var cpOther = new CollisionPoint(pointShape.Position, (Position - pointShape.Position).Normalize());
+                var cpSelf = new IntersectionPoint(Position, (pointShape.Position - Position).Normalize());
+                var cpOther = new IntersectionPoint(pointShape.Position, (Position - pointShape.Position).Normalize());
                 return new(cpSelf, cpOther, disSquared);
             }
             if (shape is SegmentShape segmentShape) return circle.GetClosestPoint(segmentShape.Segment);
@@ -151,10 +151,10 @@ public class ShapeIntersectionExample : ExampleScene
             return false;
 
         }
-        public override CollisionPoints? IntersectWith(Shape shape)
+        public override IntersectionPoints? IntersectWith(Shape shape)
         {
             var circle = new Circle(Position, Size);
-            CollisionPoints? result = null;
+            IntersectionPoints? result = null;
             if (shape is PointShape pointShape)
             {
                 var otherCircle = new Circle(pointShape.Position, Size);
@@ -205,7 +205,7 @@ public class ShapeIntersectionExample : ExampleScene
             var circle = new Circle(Position, Size);
             return circle.OverlapShape(polygon);
         }
-        public override CollisionPoints? IntersectWith(Polygon polygon)
+        public override IntersectionPoints? IntersectWith(Polygon polygon)
         {
             var circle = new Circle(Position, Size);
             return polygon.IntersectShape(circle);
@@ -261,7 +261,7 @@ public class ShapeIntersectionExample : ExampleScene
                 var p= Segment.GetClosestPoint(point, out float distance);
                 return new ClosestPointResult(
                     p,
-                    new CollisionPoint(point, (p.Point - point).Normalize()),
+                    new IntersectionPoint(point, (p.Point - point).Normalize()),
                     distance
                     );
             }
@@ -290,7 +290,7 @@ public class ShapeIntersectionExample : ExampleScene
             if (shape is PolylineShape polylineShape) return Segment.OverlapShape(polylineShape.Polyline);
             return false;
         }
-        public override CollisionPoints? IntersectWith(Shape shape)
+        public override IntersectionPoints? IntersectWith(Shape shape)
         {
             if (shape is PointShape pointShape) return pointShape.IntersectWith(this); 
             if (shape is SegmentShape segmentShape) return Segment.IntersectShape(segmentShape.Segment);
@@ -325,7 +325,7 @@ public class ShapeIntersectionExample : ExampleScene
         {
             return Segment.OverlapShape(polygon);
         }
-        public override CollisionPoints? IntersectWith(Polygon polygon)
+        public override IntersectionPoints? IntersectWith(Polygon polygon)
         {
             return polygon.IntersectShape(Segment);
         }
@@ -369,7 +369,7 @@ public class ShapeIntersectionExample : ExampleScene
                 var p= Ray.GetClosestPoint(point, out float distance);
                 return new ClosestPointResult(
                     p,
-                    new CollisionPoint(point, (p.Point - point).Normalize()),
+                    new IntersectionPoint(point, (p.Point - point).Normalize()),
                     distance
                     );
             }
@@ -398,7 +398,7 @@ public class ShapeIntersectionExample : ExampleScene
             if (shape is PolylineShape polylineShape) return Ray.OverlapShape(polylineShape.Polyline);
             return false;
         }
-        public override CollisionPoints? IntersectWith(Shape shape)
+        public override IntersectionPoints? IntersectWith(Shape shape)
         {
             if (shape is PointShape pointShape) return pointShape.IntersectWith(this);
             if (shape is SegmentShape segmentShape) return Ray.IntersectShape(segmentShape.Segment);
@@ -433,7 +433,7 @@ public class ShapeIntersectionExample : ExampleScene
         {
             return Ray.OverlapShape(polygon);
         }
-        public override CollisionPoints? IntersectWith(Polygon polygon)
+        public override IntersectionPoints? IntersectWith(Polygon polygon)
         {
             return polygon.IntersectShape(Ray);
         }
@@ -475,7 +475,7 @@ public class ShapeIntersectionExample : ExampleScene
                 var p= Line.GetClosestPoint(point, out float distance);
                 return new ClosestPointResult(
                     p,
-                    new CollisionPoint(point, (p.Point - point).Normalize()),
+                    new IntersectionPoint(point, (p.Point - point).Normalize()),
                     distance
                     );
             }
@@ -504,7 +504,7 @@ public class ShapeIntersectionExample : ExampleScene
             if (shape is PolylineShape polylineShape) return Line.OverlapShape(polylineShape.Polyline);
             return false;
         }
-        public override CollisionPoints? IntersectWith(Shape shape)
+        public override IntersectionPoints? IntersectWith(Shape shape)
         {
             if (shape is PointShape pointShape) return pointShape.IntersectWith(this);
             if (shape is SegmentShape segmentShape) return Line.IntersectShape(segmentShape.Segment);
@@ -531,7 +531,7 @@ public class ShapeIntersectionExample : ExampleScene
         {
             return Line.OverlapShape(polygon);
         }
-        public override CollisionPoints? IntersectWith(Polygon polygon)
+        public override IntersectionPoints? IntersectWith(Polygon polygon)
         {
             return polygon.IntersectShape(Line);
         }
@@ -596,7 +596,7 @@ public class ShapeIntersectionExample : ExampleScene
                 var p= Circle.GetClosestPoint(point, out float distance);
                 return new ClosestPointResult(
                     p,
-                    new CollisionPoint(point, (p.Point - point).Normalize()),
+                    new IntersectionPoint(point, (p.Point - point).Normalize()),
                     distance
                 );
             }
@@ -625,7 +625,7 @@ public class ShapeIntersectionExample : ExampleScene
             if (shape is PolylineShape polylineShape) return Circle.OverlapShape(polylineShape.Polyline);
             return false;
         }
-        public override CollisionPoints? IntersectWith(Shape shape)
+        public override IntersectionPoints? IntersectWith(Shape shape)
         {
             if (shape is PointShape pointShape) return pointShape.IntersectWith(this);
             if (shape is SegmentShape segmentShape) return Circle.IntersectShape(segmentShape.Segment);
@@ -652,7 +652,7 @@ public class ShapeIntersectionExample : ExampleScene
         {
             return Circle.OverlapShape(polygon);
         }
-        public override CollisionPoints? IntersectWith(Polygon polygon)
+        public override IntersectionPoints? IntersectWith(Polygon polygon)
         {
             return polygon.IntersectShape(Circle);
         }
@@ -739,7 +739,7 @@ public class ShapeIntersectionExample : ExampleScene
                 var p= Triangle.GetClosestPoint(point, out float distance, out int index);
                 return new ClosestPointResult(
                     p,
-                    new CollisionPoint(point, (p.Point - point).Normalize()),
+                    new IntersectionPoint(point, (p.Point - point).Normalize()),
                     distance,
                     index,
                     -1
@@ -770,7 +770,7 @@ public class ShapeIntersectionExample : ExampleScene
             if (shape is PolylineShape polylineShape) return Triangle.OverlapShape(polylineShape.Polyline);
             return false;
         }
-        public override CollisionPoints? IntersectWith(Shape shape)
+        public override IntersectionPoints? IntersectWith(Shape shape)
         {
             if (shape is PointShape pointShape) return pointShape.IntersectWith(this);
             if (shape is SegmentShape segmentShape) return Triangle.IntersectShape(segmentShape.Segment);
@@ -816,7 +816,7 @@ public class ShapeIntersectionExample : ExampleScene
         {
             return Triangle.OverlapShape(polygon);
         }
-        public override CollisionPoints? IntersectWith(Polygon polygon)
+        public override IntersectionPoints? IntersectWith(Polygon polygon)
         {
             return polygon.IntersectShape(Triangle);
         }
@@ -874,7 +874,7 @@ public class ShapeIntersectionExample : ExampleScene
                 var p= Quad.GetClosestPoint(point, out float distance, out int index);
                 return new ClosestPointResult(
                     p,
-                    new CollisionPoint(point, (p.Point - point).Normalize()),
+                    new IntersectionPoint(point, (p.Point - point).Normalize()),
                     distance,
                     index,
                     -1
@@ -906,7 +906,7 @@ public class ShapeIntersectionExample : ExampleScene
             if (shape is PolylineShape polylineShape) return Quad.OverlapShape(polylineShape.Polyline);
             return false;
         }
-        public override CollisionPoints? IntersectWith(Shape shape)
+        public override IntersectionPoints? IntersectWith(Shape shape)
         {
             if (shape is PointShape pointShape) return pointShape.IntersectWith(this);
             if (shape is SegmentShape segmentShape) return Quad.IntersectShape(segmentShape.Segment);
@@ -933,7 +933,7 @@ public class ShapeIntersectionExample : ExampleScene
         {
             return Quad.OverlapShape(polygon);
         }
-        public override CollisionPoints? IntersectWith(Polygon polygon)
+        public override IntersectionPoints? IntersectWith(Polygon polygon)
         {
             return polygon.IntersectShape(Quad);
         }
@@ -1015,7 +1015,7 @@ public class ShapeIntersectionExample : ExampleScene
                 var p= Rect.GetClosestPoint(point, out float distance, out int index);
                 return new ClosestPointResult(
                     p,
-                    new CollisionPoint(point, (p.Point - point).Normalize()),
+                    new IntersectionPoint(point, (p.Point - point).Normalize()),
                     distance,
                     index,
                     -1
@@ -1046,7 +1046,7 @@ public class ShapeIntersectionExample : ExampleScene
             if (shape is PolylineShape polylineShape) return Rect.OverlapShape(polylineShape.Polyline);
             return false;
         }
-        public override CollisionPoints? IntersectWith(Shape shape)
+        public override IntersectionPoints? IntersectWith(Shape shape)
         {
             if (shape is PointShape pointShape) return pointShape.IntersectWith(this);
             if (shape is SegmentShape segmentShape) return Rect.IntersectShape(segmentShape.Segment);
@@ -1073,7 +1073,7 @@ public class ShapeIntersectionExample : ExampleScene
         {
             return Rect.OverlapShape(polygon);
         }
-        public override CollisionPoints? IntersectWith(Polygon polygon)
+        public override IntersectionPoints? IntersectWith(Polygon polygon)
         {
             return polygon.IntersectShape(Rect);
         }
@@ -1160,7 +1160,7 @@ public class ShapeIntersectionExample : ExampleScene
                 var p= Polygon.GetClosestPoint(point, out float distance, out int index);
                 return new ClosestPointResult(
                     p,
-                    new CollisionPoint(point, (p.Point - point).Normalize()),
+                    new IntersectionPoint(point, (p.Point - point).Normalize()),
                     distance,
                     index,
                     -1
@@ -1207,7 +1207,7 @@ public class ShapeIntersectionExample : ExampleScene
                 return Polygon.OverlapShape(polylineShape.Polyline);
             return false;
         }
-        public override CollisionPoints? IntersectWith(Shape shape)
+        public override IntersectionPoints? IntersectWith(Shape shape)
         {
             if (shape is PointShape pointShape) return pointShape.IntersectWith(this);
             if (shape is SegmentShape segmentShape) return Polygon.IntersectShape(segmentShape.Segment);
@@ -1234,7 +1234,7 @@ public class ShapeIntersectionExample : ExampleScene
         {
             return Polygon.OverlapShape(polygon);
         }
-        public override CollisionPoints? IntersectWith(Polygon polygon)
+        public override IntersectionPoints? IntersectWith(Polygon polygon)
         {
             return polygon.IntersectShape(Polygon);
         }
@@ -1312,7 +1312,7 @@ public class ShapeIntersectionExample : ExampleScene
                 var p= Polyline.GetClosestPoint(point, out float distance, out int index);
                 return new ClosestPointResult(
                     p,
-                    new CollisionPoint(point, (p.Point - point).Normalize()),
+                    new IntersectionPoint(point, (p.Point - point).Normalize()),
                     distance,
                     index,
                     -1
@@ -1344,7 +1344,7 @@ public class ShapeIntersectionExample : ExampleScene
             if (shape is PolylineShape polylineShape) return Polyline.OverlapShape(polylineShape.Polyline);
             return false;
         }
-        public override CollisionPoints? IntersectWith(Shape shape)
+        public override IntersectionPoints? IntersectWith(Shape shape)
         {
             if (shape is PointShape pointShape) return pointShape.IntersectWith(this);
             if (shape is SegmentShape segmentShape) return Polyline.IntersectShape(segmentShape.Segment);
@@ -1379,7 +1379,7 @@ public class ShapeIntersectionExample : ExampleScene
         {
             return Polyline.OverlapShape(polygon);
         }
-        public override CollisionPoints? IntersectWith(Polygon polygon)
+        public override IntersectionPoints? IntersectWith(Polygon polygon)
         {
             return polygon.IntersectShape(Polyline);
         }

--- a/ShapeEngine/Core/Structs/BoundsCollisionInfo.cs
+++ b/ShapeEngine/Core/Structs/BoundsCollisionInfo.cs
@@ -18,11 +18,11 @@ public readonly struct BoundsCollisionInfo
     /// </summary>
     public readonly Vector2 SafePosition;
     /// <summary>
-    /// The collision point where the object left the bounds on the horizontal plane (left to right).
+    /// The intersection point where the object left the bounds on the horizontal plane (left to right).
     /// </summary>
     public readonly IntersectionPoint Horizontal;
     /// <summary>
-    /// The collision point where the object left the bounds on the vertical plane (top to bottom).
+    /// The intersection point where the object left the bounds on the vertical plane (top to bottom).
     /// </summary>
     public readonly IntersectionPoint Vertical;
     /// <summary>
@@ -43,8 +43,8 @@ public readonly struct BoundsCollisionInfo
     /// Initializes a new instance of the <see cref="BoundsCollisionInfo"/> struct with the specified safe position and collision points.
     /// </summary>
     /// <param name="safePosition">The closest position within the bounds that is considered safe.</param>
-    /// <param name="horizontal">The collision point on the horizontal plane.</param>
-    /// <param name="vertical">The collision point on the vertical plane.</param>
+    /// <param name="horizontal">The intersection point on the horizontal plane.</param>
+    /// <param name="vertical">The intersection point on the vertical plane.</param>
     public BoundsCollisionInfo(Vector2 safePosition, IntersectionPoint horizontal, IntersectionPoint vertical)
     {
         SafePosition = safePosition;
@@ -56,7 +56,7 @@ public readonly struct BoundsCollisionInfo
     /// Creates a <see cref="BoundsCollisionInfo"/> instance for a horizontal collision only.
     /// </summary>
     /// <param name="safePosition">The closest position within the bounds that is considered safe.</param>
-    /// <param name="horizontal">The collision point on the horizontal plane.</param>
+    /// <param name="horizontal">The intersection point on the horizontal plane.</param>
     /// <returns>A <see cref="BoundsCollisionInfo"/> with only the horizontal collision set.</returns>
     public static BoundsCollisionInfo GetHorizontal(Vector2 safePosition, IntersectionPoint horizontal) =>
         new(safePosition, horizontal, new());
@@ -65,7 +65,7 @@ public readonly struct BoundsCollisionInfo
     /// Creates a <see cref="BoundsCollisionInfo"/> instance for a vertical collision only.
     /// </summary>
     /// <param name="safePosition">The closest position within the bounds that is considered safe.</param>
-    /// <param name="vertical">The collision point on the vertical plane.</param>
+    /// <param name="vertical">The intersection point on the vertical plane.</param>
     /// <returns>A <see cref="BoundsCollisionInfo"/> with only the vertical collision set.</returns>
     public static BoundsCollisionInfo GetVertical(Vector2 safePosition, IntersectionPoint vertical) =>
         new(safePosition, new(), vertical);

--- a/ShapeEngine/Core/Structs/BoundsCollisionInfo.cs
+++ b/ShapeEngine/Core/Structs/BoundsCollisionInfo.cs
@@ -20,11 +20,11 @@ public readonly struct BoundsCollisionInfo
     /// <summary>
     /// The collision point where the object left the bounds on the horizontal plane (left to right).
     /// </summary>
-    public readonly CollisionPoint Horizontal;
+    public readonly IntersectionPoint Horizontal;
     /// <summary>
     /// The collision point where the object left the bounds on the vertical plane (top to bottom).
     /// </summary>
-    public readonly CollisionPoint Vertical;
+    public readonly IntersectionPoint Vertical;
     /// <summary>
     /// Indicates whether a valid collision occurred on either the horizontal or vertical plane.
     /// </summary>
@@ -45,7 +45,7 @@ public readonly struct BoundsCollisionInfo
     /// <param name="safePosition">The closest position within the bounds that is considered safe.</param>
     /// <param name="horizontal">The collision point on the horizontal plane.</param>
     /// <param name="vertical">The collision point on the vertical plane.</param>
-    public BoundsCollisionInfo(Vector2 safePosition, CollisionPoint horizontal, CollisionPoint vertical)
+    public BoundsCollisionInfo(Vector2 safePosition, IntersectionPoint horizontal, IntersectionPoint vertical)
     {
         SafePosition = safePosition;
         Horizontal = horizontal;
@@ -58,7 +58,7 @@ public readonly struct BoundsCollisionInfo
     /// <param name="safePosition">The closest position within the bounds that is considered safe.</param>
     /// <param name="horizontal">The collision point on the horizontal plane.</param>
     /// <returns>A <see cref="BoundsCollisionInfo"/> with only the horizontal collision set.</returns>
-    public static BoundsCollisionInfo GetHorizontal(Vector2 safePosition, CollisionPoint horizontal) =>
+    public static BoundsCollisionInfo GetHorizontal(Vector2 safePosition, IntersectionPoint horizontal) =>
         new(safePosition, horizontal, new());
 
     /// <summary>
@@ -67,6 +67,6 @@ public readonly struct BoundsCollisionInfo
     /// <param name="safePosition">The closest position within the bounds that is considered safe.</param>
     /// <param name="vertical">The collision point on the vertical plane.</param>
     /// <returns>A <see cref="BoundsCollisionInfo"/> with only the vertical collision set.</returns>
-    public static BoundsCollisionInfo GetVertical(Vector2 safePosition, CollisionPoint vertical) =>
+    public static BoundsCollisionInfo GetVertical(Vector2 safePosition, IntersectionPoint vertical) =>
         new(safePosition, new(), vertical);
 }

--- a/ShapeEngine/Geometry/CircleDef/CircleClosestPoint.cs
+++ b/ShapeEngine/Geometry/CircleDef/CircleClosestPoint.cs
@@ -20,8 +20,8 @@ public readonly partial struct Circle
     /// </summary>
     /// <param name="p">The point to check.</param>
     /// <param name="disSquared">The squared distance between the circle and the point.</param>
-    /// <returns>A <see cref="CollisionPoint"/> representing the closest point.</returns>
-    public CollisionPoint GetClosestPoint(Vector2 p, out float disSquared)
+    /// <returns>A <see cref="IntersectionPoint"/> representing the closest point.</returns>
+    public IntersectionPoint GetClosestPoint(Vector2 p, out float disSquared)
     {
         var dir = (p - Center).Normalize();
         var closestPoint = Center + dir * Radius;

--- a/ShapeEngine/Geometry/CircleDef/CircleIntersectShape.cs
+++ b/ShapeEngine/Geometry/CircleDef/CircleIntersectShape.cs
@@ -18,12 +18,12 @@ public readonly partial struct Circle
     /// </summary>
     /// <param name="collider">The collider to test for intersection. Can represent various shapes.</param>
     /// <returns>
-    /// A <see cref="CollisionPoints"/> object containing the intersection points, or <c>null</c> if there is no intersection.
+    /// A <see cref="IntersectionPoints"/> object containing the intersection points, or <c>null</c> if there is no intersection.
     /// </returns>
     /// <remarks>
     /// The method dispatches to the appropriate shape-specific intersection logic based on the collider's type.
     /// </remarks>
-    public CollisionPoints? Intersect(Collider collider)
+    public IntersectionPoints? Intersect(Collider collider)
     {
         if (!collider.Enabled) return null;
 
@@ -66,14 +66,14 @@ public readonly partial struct Circle
     /// </summary>
     /// <param name="c">The other circle to test for intersection.</param>
     /// <returns>
-    /// A <see cref="CollisionPoints"/> object containing the intersection points, or <c>null</c> if there is no intersection.
+    /// A <see cref="IntersectionPoints"/> object containing the intersection points, or <c>null</c> if there is no intersection.
     /// </returns>
-    public CollisionPoints? IntersectShape(Circle c)
+    public IntersectionPoints? IntersectShape(Circle c)
     {
         var result = IntersectCircleCircle(Center, Radius, c.Center, c.Radius);
         if (result.a.Valid || result.b.Valid)
         {
-            var points = new CollisionPoints();
+            var points = new IntersectionPoints();
             if (result.a.Valid) points.Add(result.a);
             if (result.b.Valid) points.Add(result.b);
             return points;
@@ -87,14 +87,14 @@ public readonly partial struct Circle
     /// </summary>
     /// <param name="r">The ray to test for intersection.</param>
     /// <returns>
-    /// A <see cref="CollisionPoints"/> object containing the intersection points, or <c>null</c> if there is no intersection.
+    /// A <see cref="IntersectionPoints"/> object containing the intersection points, or <c>null</c> if there is no intersection.
     /// </returns>
-    public CollisionPoints? IntersectShape(Ray r)
+    public IntersectionPoints? IntersectShape(Ray r)
     {
         var result = IntersectCircleRay(Center, Radius, r.Point, r.Direction, r.Normal);
         if (result.a.Valid || result.b.Valid)
         {
-            var points = new CollisionPoints();
+            var points = new IntersectionPoints();
             if (result.a.Valid) points.Add(result.a);
             if (result.b.Valid) points.Add(result.b);
             return points;
@@ -108,15 +108,15 @@ public readonly partial struct Circle
     /// </summary>
     /// <param name="l">The line to test for intersection.</param>
     /// <returns>
-    /// A <see cref="CollisionPoints"/> object containing the intersection points, or <c>null</c> if there is no intersection.
+    /// A <see cref="IntersectionPoints"/> object containing the intersection points, or <c>null</c> if there is no intersection.
     /// </returns>
-    public CollisionPoints? IntersectShape(Line l)
+    public IntersectionPoints? IntersectShape(Line l)
     {
         var result = IntersectCircleLine(Center, Radius, l.Point, l.Direction, l.Normal);
 
         if (result.a.Valid || result.b.Valid)
         {
-            var points = new CollisionPoints();
+            var points = new IntersectionPoints();
             if (result.a.Valid) points.Add(result.a);
             if (result.b.Valid) points.Add(result.b);
             return points;
@@ -130,14 +130,14 @@ public readonly partial struct Circle
     /// </summary>
     /// <param name="s">The segment to test for intersection.</param>
     /// <returns>
-    /// A <see cref="CollisionPoints"/> object containing the intersection points, or <c>null</c> if there is no intersection.
+    /// A <see cref="IntersectionPoints"/> object containing the intersection points, or <c>null</c> if there is no intersection.
     /// </returns>
-    public CollisionPoints? IntersectShape(Segment s)
+    public IntersectionPoints? IntersectShape(Segment s)
     {
         var result = IntersectCircleSegment(Center, Radius, s.Start, s.End);
         if (result.a.Valid || result.b.Valid)
         {
-            var points = new CollisionPoints();
+            var points = new IntersectionPoints();
             if (result.a.Valid) points.Add(result.a);
             if (result.b.Valid) points.Add(result.b);
             return points;
@@ -151,11 +151,11 @@ public readonly partial struct Circle
     /// </summary>
     /// <param name="t">The triangle to test for intersection.</param>
     /// <returns>
-    /// A <see cref="CollisionPoints"/> object containing the intersection points, or <c>null</c> if there is no intersection.
+    /// A <see cref="IntersectionPoints"/> object containing the intersection points, or <c>null</c> if there is no intersection.
     /// </returns>
-    public CollisionPoints? IntersectShape(Triangle t)
+    public IntersectionPoints? IntersectShape(Triangle t)
     {
-        CollisionPoints? points = null;
+        IntersectionPoints? points = null;
         var result = IntersectCircleSegment(Center, Radius, t.A, t.B);
         if (result.a.Valid || result.b.Valid)
         {
@@ -188,11 +188,11 @@ public readonly partial struct Circle
     /// </summary>
     /// <param name="r">The rectangle to test for intersection.</param>
     /// <returns>
-    /// A <see cref="CollisionPoints"/> object containing the intersection points, or <c>null</c> if there is no intersection.
+    /// A <see cref="IntersectionPoints"/> object containing the intersection points, or <c>null</c> if there is no intersection.
     /// </returns>
-    public CollisionPoints? IntersectShape(Rect r)
+    public IntersectionPoints? IntersectShape(Rect r)
     {
-        CollisionPoints? points = null;
+        IntersectionPoints? points = null;
         var a = r.TopLeft;
         var b = r.BottomLeft;
 
@@ -238,11 +238,11 @@ public readonly partial struct Circle
     /// </summary>
     /// <param name="q">The quad to test for intersection.</param>
     /// <returns>
-    /// A <see cref="CollisionPoints"/> object containing the intersection points, or <c>null</c> if there is no intersection.
+    /// A <see cref="IntersectionPoints"/> object containing the intersection points, or <c>null</c> if there is no intersection.
     /// </returns>
-    public CollisionPoints? IntersectShape(Quad q)
+    public IntersectionPoints? IntersectShape(Quad q)
     {
-        CollisionPoints? points = null;
+        IntersectionPoints? points = null;
 
         var result = IntersectCircleSegment(Center, Radius, q.A, q.B);
         if (result.a.Valid || result.b.Valid)
@@ -284,13 +284,13 @@ public readonly partial struct Circle
     /// </summary>
     /// <param name="p">The polygon to test for intersection.</param>
     /// <returns>
-    /// A <see cref="CollisionPoints"/> object containing the intersection points, or <c>null</c> if there is no intersection.
+    /// A <see cref="IntersectionPoints"/> object containing the intersection points, or <c>null</c> if there is no intersection.
     /// </returns>
-    public CollisionPoints? IntersectShape(Polygon p)
+    public IntersectionPoints? IntersectShape(Polygon p)
     {
         if (p.Count < 3) return null;
 
-        CollisionPoints? points = null;
+        IntersectionPoints? points = null;
 
         for (var i = 0; i < p.Count; i++)
         {
@@ -311,13 +311,13 @@ public readonly partial struct Circle
     /// </summary>
     /// <param name="pl">The polyline to test for intersection.</param>
     /// <returns>
-    /// A <see cref="CollisionPoints"/> object containing the intersection points, or <c>null</c> if there is no intersection.
+    /// A <see cref="IntersectionPoints"/> object containing the intersection points, or <c>null</c> if there is no intersection.
     /// </returns>
-    public CollisionPoints? IntersectShape(Polyline pl)
+    public IntersectionPoints? IntersectShape(Polyline pl)
     {
         if (pl.Count < 2) return null;
 
-        CollisionPoints? points = null;
+        IntersectionPoints? points = null;
 
         for (var i = 0; i < pl.Count - 1; i++)
         {
@@ -338,11 +338,11 @@ public readonly partial struct Circle
     /// </summary>
     /// <param name="shape">The collection of segments to test for intersection.</param>
     /// <returns>
-    /// A <see cref="CollisionPoints"/> object containing the intersection points, or <c>null</c> if there is no intersection.
+    /// A <see cref="IntersectionPoints"/> object containing the intersection points, or <c>null</c> if there is no intersection.
     /// </returns>
-    public CollisionPoints? IntersectShape(Segments shape)
+    public IntersectionPoints? IntersectShape(Segments shape)
     {
-        CollisionPoints? points = null;
+        IntersectionPoints? points = null;
         foreach (var seg in shape)
         {
             var result = IntersectCircleSegment(Center, Radius, seg.Start, seg.End);
@@ -358,7 +358,7 @@ public readonly partial struct Circle
     }
 
     /// <summary>
-    /// Calculates and adds intersection points between this circle and a collider to the provided <see cref="CollisionPoints"/> collection.
+    /// Calculates and adds intersection points between this circle and a collider to the provided <see cref="IntersectionPoints"/> collection.
     /// </summary>
     /// <param name="collider">The collider to test for intersection.</param>
     /// <param name="points">The collection to which valid intersection points will be added.</param>
@@ -366,7 +366,7 @@ public readonly partial struct Circle
     /// If <c>true</c>, the method returns after the first valid intersection is found.
     /// </param>
     /// <returns>The number of intersection points found and added.</returns> 
-    public int Intersect(Collider collider, ref CollisionPoints points, bool returnAfterFirstValid = false)
+    public int Intersect(Collider collider, ref IntersectionPoints points, bool returnAfterFirstValid = false)
     {
         if (!collider.Enabled) return 0;
 
@@ -405,7 +405,7 @@ public readonly partial struct Circle
     }
 
     /// <summary>
-    /// Calculates and adds intersection points between this circle and a ray to the provided <see cref="CollisionPoints"/> collection.
+    /// Calculates and adds intersection points between this circle and a ray to the provided <see cref="IntersectionPoints"/> collection.
     /// </summary>
     /// <param name="r">The ray to test for intersection.</param>
     /// <param name="points">The collection to which valid intersection points will be added.</param>
@@ -413,7 +413,7 @@ public readonly partial struct Circle
     /// If <c>true</c>, the method returns after the first valid intersection is found.
     /// </param>
     /// <returns>The number of intersection points found and added.</returns>
-    public int IntersectShape(Ray r, ref CollisionPoints points, bool returnAfterFirstValid = false)
+    public int IntersectShape(Ray r, ref IntersectionPoints points, bool returnAfterFirstValid = false)
     {
         var result = IntersectCircleRay(Center, Radius, r.Point, r.Direction, r.Normal);
         if (result.a.Valid && result.b.Valid)
@@ -445,7 +445,7 @@ public readonly partial struct Circle
     }
 
     /// <summary>
-    /// Calculates and adds intersection points between this circle and a line to the provided <see cref="CollisionPoints"/> collection.
+    /// Calculates and adds intersection points between this circle and a line to the provided <see cref="IntersectionPoints"/> collection.
     /// </summary>
     /// <param name="l">The line to test for intersection.</param>
     /// <param name="points">The collection to which valid intersection points will be added.</param>
@@ -453,7 +453,7 @@ public readonly partial struct Circle
     /// If <c>true</c>, the method returns after the first valid intersection is found.
     /// </param>
     /// <returns>The number of intersection points found and added.</returns>
-    public int IntersectShape(Line l, ref CollisionPoints points, bool returnAfterFirstValid = false)
+    public int IntersectShape(Line l, ref IntersectionPoints points, bool returnAfterFirstValid = false)
     {
         var result = IntersectCircleLine(Center, Radius, l.Point, l.Direction, l.Normal);
         if (result.a.Valid && result.b.Valid)
@@ -485,7 +485,7 @@ public readonly partial struct Circle
     }
 
     /// <summary>
-    /// Calculates and adds intersection points between this circle and a segment to the provided <see cref="CollisionPoints"/> collection.
+    /// Calculates and adds intersection points between this circle and a segment to the provided <see cref="IntersectionPoints"/> collection.
     /// </summary>
     /// <param name="s">The segment to test for intersection.</param>
     /// <param name="points">The collection to which valid intersection points will be added.</param>
@@ -493,7 +493,7 @@ public readonly partial struct Circle
     /// If <c>true</c>, the method returns after the first valid intersection is found.
     /// </param>
     /// <returns>The number of intersection points found and added.</returns>
-    public int IntersectShape(Segment s, ref CollisionPoints points, bool returnAfterFirstValid = false)
+    public int IntersectShape(Segment s, ref IntersectionPoints points, bool returnAfterFirstValid = false)
     {
         var result = IntersectCircleSegment(Center, Radius, s.Start, s.End);
         if (result.a.Valid && result.b.Valid)
@@ -525,7 +525,7 @@ public readonly partial struct Circle
     }
 
     /// <summary>
-    /// Calculates and adds intersection points between this circle and another circle to the provided <see cref="CollisionPoints"/> collection.
+    /// Calculates and adds intersection points between this circle and another circle to the provided <see cref="IntersectionPoints"/> collection.
     /// </summary>
     /// <param name="c">The other circle to test for intersection.</param>
     /// <param name="points">The collection to which valid intersection points will be added.</param>
@@ -533,7 +533,7 @@ public readonly partial struct Circle
     /// If <c>true</c>, the method returns after the first valid intersection is found.
     /// </param>
     /// <returns>The number of intersection points found and added.</returns>
-    public int IntersectShape(Circle c, ref CollisionPoints points, bool returnAfterFirstValid = false)
+    public int IntersectShape(Circle c, ref IntersectionPoints points, bool returnAfterFirstValid = false)
     {
         var result = IntersectCircleCircle(Center, Radius, c.Center, c.Radius);
         if (result.a.Valid && result.b.Valid)
@@ -565,7 +565,7 @@ public readonly partial struct Circle
     }
 
     /// <summary>
-    /// Calculates and adds intersection points between this circle and a triangle to the provided <see cref="CollisionPoints"/> collection.
+    /// Calculates and adds intersection points between this circle and a triangle to the provided <see cref="IntersectionPoints"/> collection.
     /// </summary>
     /// <param name="t">The triangle to test for intersection.</param>
     /// <param name="points">The collection to which valid intersection points will be added.</param>
@@ -573,7 +573,7 @@ public readonly partial struct Circle
     /// If <c>true</c>, the method returns after the first valid intersection is found.
     /// </param>
     /// <returns>The number of intersection points found and added.</returns>
-    public int IntersectShape(Triangle t, ref CollisionPoints points, bool returnAfterFirstValid = false)
+    public int IntersectShape(Triangle t, ref IntersectionPoints points, bool returnAfterFirstValid = false)
     {
         var result = IntersectCircleSegment(Center, Radius, t.A, t.B);
         var count = 0;
@@ -624,7 +624,7 @@ public readonly partial struct Circle
     }
 
     /// <summary>
-    /// Calculates and adds intersection points between this circle and a quadrilateral to the provided <see cref="CollisionPoints"/> collection.
+    /// Calculates and adds intersection points between this circle and a quadrilateral to the provided <see cref="IntersectionPoints"/> collection.
     /// </summary>
     /// <param name="q">The quad to test for intersection.</param>
     /// <param name="points">The collection to which valid intersection points will be added.</param>
@@ -632,7 +632,7 @@ public readonly partial struct Circle
     /// If <c>true</c>, the method returns after the first valid intersection is found.
     /// </param>
     /// <returns>The number of intersection points found and added.</returns>
-    public int IntersectShape(Quad q, ref CollisionPoints points, bool returnAfterFirstValid = false)
+    public int IntersectShape(Quad q, ref IntersectionPoints points, bool returnAfterFirstValid = false)
     {
         var count = 0;
 
@@ -699,7 +699,7 @@ public readonly partial struct Circle
     }
 
     /// <summary>
-    /// Calculates and adds intersection points between this circle and a rectangle to the provided <see cref="CollisionPoints"/> collection.
+    /// Calculates and adds intersection points between this circle and a rectangle to the provided <see cref="IntersectionPoints"/> collection.
     /// </summary>
     /// <param name="r">The rectangle to test for intersection.</param>
     /// <param name="points">The collection to which valid intersection points will be added.</param>
@@ -707,7 +707,7 @@ public readonly partial struct Circle
     /// If <c>true</c>, the method returns after the first valid intersection is found.
     /// </param>
     /// <returns>The number of intersection points found and added.</returns>
-    public int IntersectShape(Rect r, ref CollisionPoints points, bool returnAfterFirstValid = false)
+    public int IntersectShape(Rect r, ref IntersectionPoints points, bool returnAfterFirstValid = false)
     {
         var count = 0;
         var a = r.TopLeft;
@@ -778,7 +778,7 @@ public readonly partial struct Circle
     }
 
     /// <summary>
-    /// Calculates and adds intersection points between this circle and a polygon to the provided <see cref="CollisionPoints"/> collection.
+    /// Calculates and adds intersection points between this circle and a polygon to the provided <see cref="IntersectionPoints"/> collection.
     /// </summary>
     /// <param name="p">The polygon to test for intersection.</param>
     /// <param name="points">The collection to which valid intersection points will be added.</param>
@@ -786,7 +786,7 @@ public readonly partial struct Circle
     /// If <c>true</c>, the method returns after the first valid intersection is found.
     /// </param>
     /// <returns>The number of intersection points found and added.</returns>
-    public int IntersectShape(Polygon p, ref CollisionPoints points, bool returnAfterFirstValid = false)
+    public int IntersectShape(Polygon p, ref IntersectionPoints points, bool returnAfterFirstValid = false)
     {
         if (p.Count < 3) return 0;
 
@@ -814,7 +814,7 @@ public readonly partial struct Circle
     }
 
     /// <summary>
-    /// Calculates and adds intersection points between this circle and a polyline to the provided <see cref="CollisionPoints"/> collection.
+    /// Calculates and adds intersection points between this circle and a polyline to the provided <see cref="IntersectionPoints"/> collection.
     /// </summary>
     /// <param name="pl">The polyline to test for intersection.</param>
     /// <param name="points">The collection to which valid intersection points will be added.</param>
@@ -822,7 +822,7 @@ public readonly partial struct Circle
     /// If <c>true</c>, the method returns after the first valid intersection is found.
     /// </param>
     /// <returns>The number of intersection points found and added.</returns>
-    public int IntersectShape(Polyline pl, ref CollisionPoints points, bool returnAfterFirstValid = false)
+    public int IntersectShape(Polyline pl, ref IntersectionPoints points, bool returnAfterFirstValid = false)
     {
         if (pl.Count < 2) return 0;
 
@@ -850,7 +850,7 @@ public readonly partial struct Circle
     }
 
     /// <summary>
-    /// Calculates and adds intersection points between this circle and a collection of segments to the provided <see cref="CollisionPoints"/> collection.
+    /// Calculates and adds intersection points between this circle and a collection of segments to the provided <see cref="IntersectionPoints"/> collection.
     /// </summary>
     /// <param name="shape">The collection of segments to test for intersection.</param>
     /// <param name="points">The collection to which valid intersection points will be added.</param>
@@ -858,7 +858,7 @@ public readonly partial struct Circle
     /// If <c>true</c>, the method returns after the first valid intersection is found.
     /// </param>
     /// <returns>The number of intersection points found and added.</returns>
-    public int IntersectShape(Segments shape, ref CollisionPoints points, bool returnAfterFirstValid = false)
+    public int IntersectShape(Segments shape, ref IntersectionPoints points, bool returnAfterFirstValid = false)
     {
         var count = 0;
         foreach (var seg in shape)

--- a/ShapeEngine/Geometry/CircleDef/CircleIntersectionStatic.cs
+++ b/ShapeEngine/Geometry/CircleDef/CircleIntersectionStatic.cs
@@ -14,8 +14,8 @@ public readonly partial struct Circle
     /// <param name="aRadius">The radius of the first circle.</param>
     /// <param name="bPos">The center of the second circle.</param>
     /// <param name="bRadius">The radius of the second circle.</param>
-    /// <returns>A tuple containing the intersection points as <see cref="CollisionPoint"/>.</returns>
-    public static (CollisionPoint a, CollisionPoint b) IntersectCircleCircle(Vector2 aPos, float aRadius, Vector2 bPos, float bRadius)
+    /// <returns>A tuple containing the intersection points as <see cref="IntersectionPoint"/>.</returns>
+    public static (IntersectionPoint a, IntersectionPoint b) IntersectCircleCircle(Vector2 aPos, float aRadius, Vector2 bPos, float bRadius)
     {
         return IntersectCircleCircle(aPos.X, aPos.Y, aRadius, bPos.X, bPos.Y, bRadius);
     }
@@ -29,8 +29,8 @@ public readonly partial struct Circle
     /// <param name="cx1">The x-coordinate of the second circle's center.</param>
     /// <param name="cy1">The y-coordinate of the second circle's center.</param>
     /// <param name="radius1">The radius of the second circle.</param>
-    /// <returns>A tuple containing the intersection points as <see cref="CollisionPoint"/>.</returns>
-    public static (CollisionPoint a, CollisionPoint b) IntersectCircleCircle(float cx0, float cy0, float radius0, float cx1, float cy1, float radius1)
+    /// <returns>A tuple containing the intersection points as <see cref="IntersectionPoint"/>.</returns>
+    public static (IntersectionPoint a, IntersectionPoint b) IntersectCircleCircle(float cx0, float cy0, float radius0, float cx1, float cy1, float radius1)
     {
         // Find the distance between the centers.
         float dx = cx0 - cx1;
@@ -76,15 +76,15 @@ public readonly partial struct Circle
         if (ShapeMath.EqualsF((float)dist, radius0 + radius1))
         {
             var n = intersection1 - new Vector2(cx1, cy1);
-            var cp = new CollisionPoint(intersection1, n.Normalize());
+            var cp = new IntersectionPoint(intersection1, n.Normalize());
             return (cp, new());
         }
 
         var n1 = intersection1 - new Vector2(cx1, cy1);
-        var cp1 = new CollisionPoint(intersection1, n1.Normalize());
+        var cp1 = new IntersectionPoint(intersection1, n1.Normalize());
 
         var n2 = intersection2 - new Vector2(cx1, cy1);
-        var cp2 = new CollisionPoint(intersection2, n2.Normalize());
+        var cp2 = new IntersectionPoint(intersection2, n2.Normalize());
         return (cp1, cp2);
     }
 
@@ -95,8 +95,8 @@ public readonly partial struct Circle
     /// <param name="circleRadius">The radius of the circle.</param>
     /// <param name="start">The start point of the segment.</param>
     /// <param name="end">The end point of the segment.</param>
-    /// <returns>A tuple containing the intersection points as <see cref="CollisionPoint"/>.</returns>
-    public static (CollisionPoint a, CollisionPoint b) IntersectCircleSegment(Vector2 circlePos, float circleRadius, Vector2 start, Vector2 end)
+    /// <returns>A tuple containing the intersection points as <see cref="IntersectionPoint"/>.</returns>
+    public static (IntersectionPoint a, IntersectionPoint b) IntersectCircleSegment(Vector2 circlePos, float circleRadius, Vector2 start, Vector2 end)
     {
         return IntersectCircleSegment(
             circlePos.X, circlePos.Y, circleRadius,
@@ -112,8 +112,8 @@ public readonly partial struct Circle
     /// <param name="rayPoint">The origin point of the ray.</param>
     /// <param name="rayDirection">The direction vector of the ray.</param>
     /// <param name="rayNormal">The normal vector of the ray.</param>
-    /// <returns>A tuple containing the intersection points as <see cref="CollisionPoint"/>.</returns>
-    public static (CollisionPoint a, CollisionPoint b) IntersectCircleRay(Vector2 circleCenter, float circleRadius, Vector2 rayPoint, Vector2 rayDirection,
+    /// <returns>A tuple containing the intersection points as <see cref="IntersectionPoint"/>.</returns>
+    public static (IntersectionPoint a, IntersectionPoint b) IntersectCircleRay(Vector2 circleCenter, float circleRadius, Vector2 rayPoint, Vector2 rayDirection,
         Vector2 rayNormal)
     {
         var toCircle = circleCenter - rayPoint;
@@ -127,8 +127,8 @@ public readonly partial struct Circle
             var intersection1 = closestPoint - offset * rayDirection;
             var intersection2 = closestPoint + offset * rayDirection;
 
-            CollisionPoint a = new();
-            CollisionPoint b = new();
+            IntersectionPoint a = new();
+            IntersectionPoint b = new();
             if (Vector2.Dot(intersection1 - rayPoint, rayDirection) >= 0)
             {
                 a = new(intersection1, rayNormal);
@@ -146,7 +146,7 @@ public readonly partial struct Circle
         {
             if (Vector2.Dot(closestPoint - rayPoint, rayDirection) >= 0)
             {
-                var cp = new CollisionPoint(closestPoint, rayNormal);
+                var cp = new IntersectionPoint(closestPoint, rayNormal);
                 return (cp, new());
             }
         }
@@ -162,8 +162,8 @@ public readonly partial struct Circle
     /// <param name="linePoint">A point on the line.</param>
     /// <param name="lineDirection">The direction vector of the line.</param>
     /// <param name="lineNormal">The normal vector of the line.</param>
-    /// <returns>A tuple containing the intersection points as <see cref="CollisionPoint"/>.</returns>
-    public static (CollisionPoint a, CollisionPoint b) IntersectCircleLine(Vector2 circleCenter, float circleRadius, Vector2 linePoint, Vector2 lineDirection,
+    /// <returns>A tuple containing the intersection points as <see cref="IntersectionPoint"/>.</returns>
+    public static (IntersectionPoint a, IntersectionPoint b) IntersectCircleLine(Vector2 circleCenter, float circleRadius, Vector2 linePoint, Vector2 lineDirection,
         Vector2 lineNormal)
     {
         // Normalize the direction vector
@@ -192,14 +192,14 @@ public readonly partial struct Circle
             var intersection2 = closestPoint + offset * lineDirection;
 
             // Normals at the intersection points
-            var p1 = new CollisionPoint(intersection1, lineNormal);
-            var p2 = new CollisionPoint(intersection2, lineNormal);
+            var p1 = new IntersectionPoint(intersection1, lineNormal);
+            var p2 = new IntersectionPoint(intersection2, lineNormal);
             return (p1, p2);
         }
 
         if (Math.Abs(distanceToCenter - circleRadius) < ShapeMath.EpsilonF)
         {
-            var p = new CollisionPoint(closestPoint, lineNormal);
+            var p = new IntersectionPoint(closestPoint, lineNormal);
             return (p, new());
         }
 
@@ -216,8 +216,8 @@ public readonly partial struct Circle
     /// <param name="segStartY">The y-coordinate of the segment's start point.</param>
     /// <param name="segEndX">The x-coordinate of the segment's end point.</param>
     /// <param name="segEndY">The y-coordinate of the segment's end point.</param>
-    /// <returns>A tuple containing the intersection points as <see cref="CollisionPoint"/>.</returns>
-    public static (CollisionPoint a, CollisionPoint b) IntersectCircleSegment(float circleX, float circleY, float circleRadius, float segStartX,
+    /// <returns>A tuple containing the intersection points as <see cref="IntersectionPoint"/>.</returns>
+    public static (IntersectionPoint a, IntersectionPoint b) IntersectCircleSegment(float circleX, float circleY, float circleRadius, float segStartX,
         float segStartY, float segEndX, float segEndY)
     {
         float difX = segEndX - segStartX;
@@ -244,7 +244,7 @@ public readonly partial struct Circle
                 // intersection point is not actually within line segment
                 var p = new Vector2(iX, iY);
                 var n = Segment.GetNormal(new(segStartX, segStartY), new(segEndX, segEndY), false); // p - new Vector2(circleX, circleY);
-                var cp = new CollisionPoint(p, n);
+                var cp = new IntersectionPoint(p, n);
                 return (cp, new());
             }
 
@@ -254,8 +254,8 @@ public readonly partial struct Circle
         if (dist < circleRadius)
         {
             // List<Vector2>? intersectionPoints = null;
-            CollisionPoint a = new();
-            CollisionPoint b = new();
+            IntersectionPoint a = new();
+            IntersectionPoint b = new();
             // two possible intersection points
 
             float dt = MathF.Sqrt(circleRadius * circleRadius - dist * dist) / MathF.Sqrt(dl);
@@ -273,7 +273,7 @@ public readonly partial struct Circle
                 var p = new Vector2(i1X, i1Y);
                 // var n = p - new Vector2(circleX, circleY);
                 var n = Segment.GetNormal(new(segStartX, segStartY), new(segEndX, segEndY), false);
-                a = new CollisionPoint(p, n);
+                a = new IntersectionPoint(p, n);
             }
 
             // intersection point farthest from A
@@ -288,7 +288,7 @@ public readonly partial struct Circle
                 var p = new Vector2(i2X, i2Y);
                 // var n = p - new Vector2(circleX, circleY);
                 var n = Segment.GetNormal(new(segStartX, segStartY), new(segEndX, segEndY), false);
-                b = new CollisionPoint(p, n);
+                b = new IntersectionPoint(p, n);
             }
 
             return (a, b);

--- a/ShapeEngine/Geometry/CollisionSystem/ClosestPointResult.cs
+++ b/ShapeEngine/Geometry/CollisionSystem/ClosestPointResult.cs
@@ -13,11 +13,11 @@ public readonly struct ClosestPointResult
     /// <summary>
     /// The closest point on the 'self' shape or segment.
     /// </summary>
-    public readonly CollisionPoint Self;
+    public readonly IntersectionPoint Self;
     /// <summary>
     /// The closest point on the 'other' shape or segment.
     /// </summary>
-    public readonly CollisionPoint Other;
+    public readonly IntersectionPoint Other;
     /// <summary>
     /// The squared distance between <see cref="Self"/> and <see cref="Other"/>.
     /// </summary>
@@ -54,7 +54,7 @@ public readonly struct ClosestPointResult
     /// <param name="distanceSquared">The squared distance between the points.</param>
     /// <param name="segmentIndex">The segment index on the 'self' shape (default -1).</param>
     /// <param name="otherSegmentIndex">The segment index on the 'other' shape (default -1).</param>
-    public ClosestPointResult(CollisionPoint self, CollisionPoint other, float distanceSquared, int segmentIndex = -1, int otherSegmentIndex = -1)
+    public ClosestPointResult(IntersectionPoint self, IntersectionPoint other, float distanceSquared, int segmentIndex = -1, int otherSegmentIndex = -1)
     {
         Self = self;
         Other = other;

--- a/ShapeEngine/Geometry/CollisionSystem/Collider.cs
+++ b/ShapeEngine/Geometry/CollisionSystem/Collider.cs
@@ -360,11 +360,11 @@ public abstract class Collider : Shape
     /// </summary>
     /// <param name="p">The point in world space to test against.</param>
     /// <param name="disSquared">Outputs the squared distance from the point to the closest point on the collider. Returns -1 if not applicable.</param>
-    /// <returns>A <see cref="CollisionPoint"/> representing the closest point on the collider.</returns>
+    /// <returns>A <see cref="IntersectionPoint"/> representing the closest point on the collider.</returns>
     /// <remarks>
     /// The squared distance is often more efficient for comparisons than the actual distance.
     /// </remarks>
-    public CollisionPoint GetClosestPoint(Vector2 p, out float disSquared)
+    public IntersectionPoint GetClosestPoint(Vector2 p, out float disSquared)
     {
         disSquared = -1;
         switch (GetShapeType())
@@ -1304,11 +1304,11 @@ public abstract class Collider : Shape
     /// Returns the intersection points between this collider and another <see cref="CollisionObject"/>.
     /// </summary>
     /// <param name="other">The other collision object.</param>
-    /// <returns>A <see cref="CollisionPoints"/> collection, or null if no intersection.</returns>
-    public CollisionPoints? Intersect(CollisionObject other)
+    /// <returns>A <see cref="IntersectionPoints"/> collection, or null if no intersection.</returns>
+    public IntersectionPoints? Intersect(CollisionObject other)
     {
         if (!Enabled || !other.Enabled || !other.HasColliders) return null;
-        CollisionPoints? result = null;
+        IntersectionPoints? result = null;
         foreach (var otherCol in other.Colliders)
         {
             var points = Intersect(otherCol);
@@ -1323,8 +1323,8 @@ public abstract class Collider : Shape
     /// Returns the intersection points between this collider and another collider.
     /// </summary>
     /// <param name="other">The other collider.</param>
-    /// <returns>A <see cref="CollisionPoints"/> collection, or null if no intersection.</returns>
-    public CollisionPoints? Intersect(Collider other)
+    /// <returns>A <see cref="IntersectionPoints"/> collection, or null if no intersection.</returns>
+    public IntersectionPoints? Intersect(Collider other)
     {
         if (!Enabled || !other.Enabled) return null;
 
@@ -1347,8 +1347,8 @@ public abstract class Collider : Shape
     /// Returns the intersection points between this collider and the given shape.
     /// </summary>
     /// <param name="other">The other shape.</param>
-    /// <returns>A <see cref="CollisionPoints"/> collection, or null if no intersection.</returns>
-    public CollisionPoints? Intersect(IShape other)
+    /// <returns>A <see cref="IntersectionPoints"/> collection, or null if no intersection.</returns>
+    public IntersectionPoints? Intersect(IShape other)
     {
         if (!Enabled) return null;
 
@@ -1372,8 +1372,8 @@ public abstract class Collider : Shape
     /// Returns the intersection points between this collider and the given <see cref="Ray"/>.
     /// </summary>
     /// <param name="ray">The ray to check for intersection.</param>
-    /// <returns>A <see cref="CollisionPoints"/> collection, or null if no intersection.</returns>
-    public CollisionPoints? Intersect(Ray ray)
+    /// <returns>A <see cref="IntersectionPoints"/> collection, or null if no intersection.</returns>
+    public IntersectionPoints? Intersect(Ray ray)
     {
         if (!Enabled) return null;
 
@@ -1414,8 +1414,8 @@ public abstract class Collider : Shape
     /// Returns the intersection points between this collider and the given <see cref="Line"/>.
     /// </summary>
     /// <param name="line">The ray to check for intersection.</param>
-    /// <returns>A <see cref="CollisionPoints"/> collection, or null if no intersection.</returns>
-    public CollisionPoints? Intersect(Line line)
+    /// <returns>A <see cref="IntersectionPoints"/> collection, or null if no intersection.</returns>
+    public IntersectionPoints? Intersect(Line line)
     {
         if (!Enabled) return null;
 
@@ -1456,8 +1456,8 @@ public abstract class Collider : Shape
     /// Returns the intersection points between this collider and the given <see cref="Segment"/>.
     /// </summary>
     /// <param name="segment">The ray to check for intersection.</param>
-    /// <returns>A <see cref="CollisionPoints"/> collection, or null if no intersection.</returns>
-    public CollisionPoints? Intersect(Segment segment)
+    /// <returns>A <see cref="IntersectionPoints"/> collection, or null if no intersection.</returns>
+    public IntersectionPoints? Intersect(Segment segment)
     {
         if (!Enabled) return null;
 
@@ -1498,8 +1498,8 @@ public abstract class Collider : Shape
     /// Returns the intersection points between this collider and the given <see cref="Triangle"/>.
     /// </summary>
     /// <param name="triangle">The ray to check for intersection.</param>
-    /// <returns>A <see cref="CollisionPoints"/> collection, or null if no intersection.</returns>
-    public CollisionPoints? Intersect(Triangle triangle)
+    /// <returns>A <see cref="IntersectionPoints"/> collection, or null if no intersection.</returns>
+    public IntersectionPoints? Intersect(Triangle triangle)
     {
         if (!Enabled) return null;
 
@@ -1540,8 +1540,8 @@ public abstract class Collider : Shape
     /// Returns the intersection points between this collider and the given <see cref="Circle"/>.
     /// </summary>
     /// <param name="circle">The ray to check for intersection.</param>
-    /// <returns>A <see cref="CollisionPoints"/> collection, or null if no intersection.</returns>
-    public CollisionPoints? Intersect(Circle circle)
+    /// <returns>A <see cref="IntersectionPoints"/> collection, or null if no intersection.</returns>
+    public IntersectionPoints? Intersect(Circle circle)
     {
         if (!Enabled) return null;
 
@@ -1582,8 +1582,8 @@ public abstract class Collider : Shape
     /// Returns the intersection points between this collider and the given <see cref="Rect"/>.
     /// </summary>
     /// <param name="rect">The ray to check for intersection.</param>
-    /// <returns>A <see cref="CollisionPoints"/> collection, or null if no intersection.</returns>
-    public CollisionPoints? Intersect(Rect rect)
+    /// <returns>A <see cref="IntersectionPoints"/> collection, or null if no intersection.</returns>
+    public IntersectionPoints? Intersect(Rect rect)
     {
         if (!Enabled) return null;
 
@@ -1624,8 +1624,8 @@ public abstract class Collider : Shape
     /// Returns the intersection points between this collider and the given <see cref="Quad"/>.
     /// </summary>
     /// <param name="quad">The ray to check for intersection.</param>
-    /// <returns>A <see cref="CollisionPoints"/> collection, or null if no intersection.</returns>
-    public CollisionPoints? Intersect(Quad quad)
+    /// <returns>A <see cref="IntersectionPoints"/> collection, or null if no intersection.</returns>
+    public IntersectionPoints? Intersect(Quad quad)
     {
         if (!Enabled) return null;
 
@@ -1666,8 +1666,8 @@ public abstract class Collider : Shape
     /// Returns the intersection points between this collider and the given <see cref="Polygon"/>.
     /// </summary>
     /// <param name="poly">The ray to check for intersection.</param>
-    /// <returns>A <see cref="CollisionPoints"/> collection, or null if no intersection.</returns>
-    public CollisionPoints? Intersect(Polygon poly)
+    /// <returns>A <see cref="IntersectionPoints"/> collection, or null if no intersection.</returns>
+    public IntersectionPoints? Intersect(Polygon poly)
     {
         if (!Enabled) return null;
 
@@ -1708,8 +1708,8 @@ public abstract class Collider : Shape
     /// Returns the intersection points between this collider and the given <see cref="Polyline"/>.
     /// </summary>
     /// <param name="polyLine">The ray to check for intersection.</param>
-    /// <returns>A <see cref="CollisionPoints"/> collection, or null if no intersection.</returns>
-    public CollisionPoints? Intersect(Polyline polyLine)
+    /// <returns>A <see cref="IntersectionPoints"/> collection, or null if no intersection.</returns>
+    public IntersectionPoints? Intersect(Polyline polyLine)
     {
         if (!Enabled) return null;
 
@@ -1753,12 +1753,12 @@ public abstract class Collider : Shape
     /// Adds the intersection points to the provided <paramref name="points"/> collection.
     /// </summary>
     /// <param name="other">The other collision object to check for intersection.</param>
-    /// <param name="points">A reference to a <see cref="CollisionPoints"/> collection to store the intersection points.</param>
+    /// <param name="points">A reference to a <see cref="IntersectionPoints"/> collection to store the intersection points.</param>
     /// <param name="returnAfterFirstValid">
     /// If true, the method returns after finding the first valid intersection; otherwise, it continues to find all intersections.
     /// </param>
     /// <returns>The number of intersection points found and added to <paramref name="points"/>.</returns>
-    public int Intersect(CollisionObject other, ref CollisionPoints points, bool returnAfterFirstValid = false)
+    public int Intersect(CollisionObject other, ref IntersectionPoints points, bool returnAfterFirstValid = false)
     {
         if (!Enabled || !other.Enabled || !other.HasColliders) return 0;
         var count = 0;
@@ -1774,12 +1774,12 @@ public abstract class Collider : Shape
     /// Adds the intersection points to the provided <paramref name="points"/> collection.
     /// </summary>
     /// <param name="other">The other collider to check for intersection.</param>
-    /// <param name="points">A reference to a <see cref="CollisionPoints"/> collection to store the intersection points.</param>
+    /// <param name="points">A reference to a <see cref="IntersectionPoints"/> collection to store the intersection points.</param>
     /// <param name="returnAfterFirstValid">
     /// If true, the method returns after finding the first valid intersection; otherwise, it continues to find all intersections.
     /// </param>
     /// <returns>The number of intersection points found and added to <paramref name="points"/>.</returns>
-    public int Intersect(Collider other, ref CollisionPoints points, bool returnAfterFirstValid = false)
+    public int Intersect(Collider other, ref IntersectionPoints points, bool returnAfterFirstValid = false)
     {
         if (!Enabled || !other.Enabled) return 0;
 
@@ -1804,12 +1804,12 @@ public abstract class Collider : Shape
     /// Adds the intersection points to the provided <paramref name="points"/> collection.
     /// </summary>
     /// <param name="other">The other shape to check for intersection.</param>
-    /// <param name="points">A reference to a <see cref="CollisionPoints"/> collection to store the intersection points.</param>
+    /// <param name="points">A reference to a <see cref="IntersectionPoints"/> collection to store the intersection points.</param>
     /// <param name="returnAfterFirstValid">
     /// If true, the method returns after finding the first valid intersection; otherwise, it continues to find all intersections.
     /// </param>
     /// <returns>The number of intersection points found and added to <paramref name="points"/>.</returns>
-    public int Intersect(IShape other, ref CollisionPoints points, bool returnAfterFirstValid = false)
+    public int Intersect(IShape other, ref IntersectionPoints points, bool returnAfterFirstValid = false)
     {
         if (!Enabled) return 0;
 
@@ -1834,12 +1834,12 @@ public abstract class Collider : Shape
     /// Adds the intersection points to the provided <paramref name="points"/> collection.
     /// </summary>
     /// <param name="ray">The ray to check for intersection.</param>
-    /// <param name="points">A reference to a <see cref="CollisionPoints"/> collection to store the intersection points.</param>
+    /// <param name="points">A reference to a <see cref="IntersectionPoints"/> collection to store the intersection points.</param>
     /// <param name="returnAfterFirstValid">
     /// If true, the method returns after finding the first valid intersection; otherwise, it continues to find all intersections.
     /// </param>
     /// <returns>The number of intersection points found and added to <paramref name="points"/>.</returns>
-    public int Intersect(Ray ray, ref CollisionPoints points, bool returnAfterFirstValid = false)
+    public int Intersect(Ray ray, ref IntersectionPoints points, bool returnAfterFirstValid = false)
     {
         if (!Enabled) return 0;
 
@@ -1881,12 +1881,12 @@ public abstract class Collider : Shape
     /// Adds the intersection points to the provided <paramref name="points"/> collection.
     /// </summary>
     /// <param name="line">The ray to check for intersection.</param>
-    /// <param name="points">A reference to a <see cref="CollisionPoints"/> collection to store the intersection points.</param>
+    /// <param name="points">A reference to a <see cref="IntersectionPoints"/> collection to store the intersection points.</param>
     /// <param name="returnAfterFirstValid">
     /// If true, the method returns after finding the first valid intersection; otherwise, it continues to find all intersections.
     /// </param>
     /// <returns>The number of intersection points found and added to <paramref name="points"/>.</returns>
-    public int Intersect(Line line, ref CollisionPoints points, bool returnAfterFirstValid = false)
+    public int Intersect(Line line, ref IntersectionPoints points, bool returnAfterFirstValid = false)
     {
         if (!Enabled) return 0;
 
@@ -1928,12 +1928,12 @@ public abstract class Collider : Shape
     /// Adds the intersection points to the provided <paramref name="points"/> collection.
     /// </summary>
     /// <param name="segment">The ray to check for intersection.</param>
-    /// <param name="points">A reference to a <see cref="CollisionPoints"/> collection to store the intersection points.</param>
+    /// <param name="points">A reference to a <see cref="IntersectionPoints"/> collection to store the intersection points.</param>
     /// <param name="returnAfterFirstValid">
     /// If true, the method returns after finding the first valid intersection; otherwise, it continues to find all intersections.
     /// </param>
     /// <returns>The number of intersection points found and added to <paramref name="points"/>.</returns>
-    public int Intersect(Segment segment, ref CollisionPoints points, bool returnAfterFirstValid = false)
+    public int Intersect(Segment segment, ref IntersectionPoints points, bool returnAfterFirstValid = false)
     {
         if (!Enabled) return 0;
 
@@ -1975,12 +1975,12 @@ public abstract class Collider : Shape
     /// Adds the intersection points to the provided <paramref name="points"/> collection.
     /// </summary>
     /// <param name="triangle">The ray to check for intersection.</param>
-    /// <param name="points">A reference to a <see cref="CollisionPoints"/> collection to store the intersection points.</param>
+    /// <param name="points">A reference to a <see cref="IntersectionPoints"/> collection to store the intersection points.</param>
     /// <param name="returnAfterFirstValid">
     /// If true, the method returns after finding the first valid intersection; otherwise, it continues to find all intersections.
     /// </param>
     /// <returns>The number of intersection points found and added to <paramref name="points"/>.</returns>
-    public int Intersect(Triangle triangle, ref CollisionPoints points, bool returnAfterFirstValid = false)
+    public int Intersect(Triangle triangle, ref IntersectionPoints points, bool returnAfterFirstValid = false)
     {
         if (!Enabled) return 0;
 
@@ -2022,12 +2022,12 @@ public abstract class Collider : Shape
     /// Adds the intersection points to the provided <paramref name="points"/> collection.
     /// </summary>
     /// <param name="circle">The ray to check for intersection.</param>
-    /// <param name="points">A reference to a <see cref="CollisionPoints"/> collection to store the intersection points.</param>
+    /// <param name="points">A reference to a <see cref="IntersectionPoints"/> collection to store the intersection points.</param>
     /// <param name="returnAfterFirstValid">
     /// If true, the method returns after finding the first valid intersection; otherwise, it continues to find all intersections.
     /// </param>
     /// <returns>The number of intersection points found and added to <paramref name="points"/>.</returns>
-    public int Intersect(Circle circle, ref CollisionPoints points, bool returnAfterFirstValid = false)
+    public int Intersect(Circle circle, ref IntersectionPoints points, bool returnAfterFirstValid = false)
     {
         if (!Enabled) return 0;
 
@@ -2069,12 +2069,12 @@ public abstract class Collider : Shape
     /// Adds the intersection points to the provided <paramref name="points"/> collection.
     /// </summary>
     /// <param name="rect">The ray to check for intersection.</param>
-    /// <param name="points">A reference to a <see cref="CollisionPoints"/> collection to store the intersection points.</param>
+    /// <param name="points">A reference to a <see cref="IntersectionPoints"/> collection to store the intersection points.</param>
     /// <param name="returnAfterFirstValid">
     /// If true, the method returns after finding the first valid intersection; otherwise, it continues to find all intersections.
     /// </param>
     /// <returns>The number of intersection points found and added to <paramref name="points"/>.</returns>
-    public int Intersect(Rect rect, ref CollisionPoints points, bool returnAfterFirstValid = false)
+    public int Intersect(Rect rect, ref IntersectionPoints points, bool returnAfterFirstValid = false)
     {
         if (!Enabled) return 0;
 
@@ -2116,12 +2116,12 @@ public abstract class Collider : Shape
     /// Adds the intersection points to the provided <paramref name="points"/> collection.
     /// </summary>
     /// <param name="quad">The ray to check for intersection.</param>
-    /// <param name="points">A reference to a <see cref="CollisionPoints"/> collection to store the intersection points.</param>
+    /// <param name="points">A reference to a <see cref="IntersectionPoints"/> collection to store the intersection points.</param>
     /// <param name="returnAfterFirstValid">
     /// If true, the method returns after finding the first valid intersection; otherwise, it continues to find all intersections.
     /// </param>
     /// <returns>The number of intersection points found and added to <paramref name="points"/>.</returns>
-    public int Intersect(Quad quad, ref CollisionPoints points, bool returnAfterFirstValid = false)
+    public int Intersect(Quad quad, ref IntersectionPoints points, bool returnAfterFirstValid = false)
     {
         if (!Enabled) return 0;
 
@@ -2163,12 +2163,12 @@ public abstract class Collider : Shape
     /// Adds the intersection points to the provided <paramref name="points"/> collection.
     /// </summary>
     /// <param name="poly">The ray to check for intersection.</param>
-    /// <param name="points">A reference to a <see cref="CollisionPoints"/> collection to store the intersection points.</param>
+    /// <param name="points">A reference to a <see cref="IntersectionPoints"/> collection to store the intersection points.</param>
     /// <param name="returnAfterFirstValid">
     /// If true, the method returns after finding the first valid intersection; otherwise, it continues to find all intersections.
     /// </param>
     /// <returns>The number of intersection points found and added to <paramref name="points"/>.</returns>
-    public int Intersect(Polygon poly, ref CollisionPoints points, bool returnAfterFirstValid = false)
+    public int Intersect(Polygon poly, ref IntersectionPoints points, bool returnAfterFirstValid = false)
     {
         if (!Enabled) return 0;
 
@@ -2210,12 +2210,12 @@ public abstract class Collider : Shape
     /// Adds the intersection points to the provided <paramref name="points"/> collection.
     /// </summary>
     /// <param name="polyLine">The ray to check for intersection.</param>
-    /// <param name="points">A reference to a <see cref="CollisionPoints"/> collection to store the intersection points.</param>
+    /// <param name="points">A reference to a <see cref="IntersectionPoints"/> collection to store the intersection points.</param>
     /// <param name="returnAfterFirstValid">
     /// If true, the method returns after finding the first valid intersection; otherwise, it continues to find all intersections.
     /// </param>
     /// <returns>The number of intersection points found and added to <paramref name="points"/>.</returns>
-    public int Intersect(Polyline polyLine, ref CollisionPoints points, bool returnAfterFirstValid = false)
+    public int Intersect(Polyline polyLine, ref IntersectionPoints points, bool returnAfterFirstValid = false)
     {
         if (!Enabled) return 0;
 

--- a/ShapeEngine/Geometry/CollisionSystem/Collision.cs
+++ b/ShapeEngine/Geometry/CollisionSystem/Collision.cs
@@ -37,7 +37,7 @@ public class Collision
     /// <remarks>
     /// If there are no collision points, this instance represents an overlap rather than an intersection.
     /// </remarks>
-    public readonly CollisionPoints? Points;
+    public readonly IntersectionPoints? Points;
     /// <summary>
     /// Gets an <see cref="Overlap"/> object representing this collision.
     /// </summary>
@@ -71,7 +71,7 @@ public class Collision
     /// If null or empty (Count &lt;= 0), <see cref="Points"/> will be set to null,
     /// indicating an overlap rather than an intersection.
     /// </param>
-    public Collision(Collider self, Collider other, bool firstContact, CollisionPoints? collisionPoints)
+    public Collision(Collider self, Collider other, bool firstContact, IntersectionPoints? collisionPoints)
     {
         Self = self;
         Other = other;
@@ -107,13 +107,13 @@ public class Collision
     /// <summary>
     /// Validates the collision points using <see cref="SelfVel"/> as reference direction and <see cref="Self"/>.CurTransform.Position as reference point.
     /// </summary>
-    /// <param name="combined">The average <see cref="CollisionPoint"/> of all valid collision points.</param>
+    /// <param name="combined">The average <see cref="IntersectionPoint"/> of all valid collision points.</param>
     /// <returns>Returns true if there are valid collision points left.</returns>
-    public bool Validate(out CollisionPoint combined)
+    public bool Validate(out IntersectionPoint combined)
     {
         if (Points == null || Points.Count <= 0)
         {
-            combined = new CollisionPoint();
+            combined = new IntersectionPoint();
             return false;
         }
         return Points.Validate(SelfVel, Self.CurTransform.Position, out combined);
@@ -121,15 +121,15 @@ public class Collision
     /// <summary>
     /// Validates the collision points using <see cref="SelfVel"/> as reference direction and <see cref="Self"/>.CurTransform.Position as reference point.
     /// </summary>
-    /// <param name="combined">The average <see cref="CollisionPoint"/> of all valid collision points.</param>
-    /// <param name="closest">The closest valid <see cref="CollisionPoint"/> to the reference point.</param>
+    /// <param name="combined">The average <see cref="IntersectionPoint"/> of all valid collision points.</param>
+    /// <param name="closest">The closest valid <see cref="IntersectionPoint"/> to the reference point.</param>
     /// <returns>Returns true if there are valid collision points left.</returns>
-    public bool Validate(out CollisionPoint combined, out CollisionPoint closest)
+    public bool Validate(out IntersectionPoint combined, out IntersectionPoint closest)
     {
         if (Points == null || Points.Count <= 0)
         {
-            combined = new CollisionPoint();
-            closest = new CollisionPoint(); 
+            combined = new IntersectionPoint();
+            closest = new IntersectionPoint(); 
             return false;
         }
         return Points.Validate(SelfVel, Self.CurTransform.Position, out combined, out closest);
@@ -150,14 +150,14 @@ public class Collision
     }
     #endregion
     
-    #region CollisionPoint
+    #region IntersectionPoint
 
     /// <summary>
     /// Checks if there is any collision point that matches the conditions defined by the specified predicate.
     /// </summary>
     /// <param name="match">The predicate that defines the conditions of the collision points to search for.</param>
     /// <returns>true if any collision point matches the predicate; otherwise, false.</returns>
-    public bool Exists(Predicate<CollisionPoint> match)
+    public bool Exists(Predicate<IntersectionPoint> match)
     {
         return Points is { Count: > 0 } && Points.Exists(match);
     }
@@ -166,9 +166,9 @@ public class Collision
     /// </summary>
     /// <param name="match">The predicate that defines the conditions of the collision point to search for.</param>
     /// <returns>
-    /// The first collision point that matches the predicate, or a default <see cref="CollisionPoint"/> if no match is found.
+    /// The first collision point that matches the predicate, or a default <see cref="IntersectionPoint"/> if no match is found.
     /// </returns>
-    public CollisionPoint Find(Predicate<CollisionPoint> match)
+    public IntersectionPoint Find(Predicate<IntersectionPoint> match)
     {
         return Points is not { Count: > 0 } ? new() : Points.Find(match);
     }
@@ -177,10 +177,10 @@ public class Collision
     /// </summary>
     /// <param name="match">The predicate that defines the conditions of the collision points to search for.</param>
     /// <returns>
-    /// A new <see cref="CollisionPoints"/> instance containing all the collision points that match the predicate,
+    /// A new <see cref="IntersectionPoints"/> instance containing all the collision points that match the predicate,
     /// or null if no points match.
     /// </returns>
-    public CollisionPoints? FindAll(Predicate<CollisionPoint> match)
+    public IntersectionPoints? FindAll(Predicate<IntersectionPoint> match)
     {
         if (Points is not { Count: > 0 }) return null;
         var result = Points.FindAll(match);
@@ -191,60 +191,60 @@ public class Collision
     /// Calculates the combined collision point from all valid collision points.
     /// </summary>
     /// <returns>
-    /// The combined <see cref="CollisionPoint"/> representing the average position and normal of all valid collision points,
-    /// or a default <see cref="CollisionPoint"/> if there are no valid points.
+    /// The combined <see cref="IntersectionPoint"/> representing the average position and normal of all valid collision points,
+    /// or a default <see cref="IntersectionPoint"/> if there are no valid points.
     /// </returns>
-    public CollisionPoint GetCombinedCollisionPoint()
+    public IntersectionPoint GetCombinedCollisionPoint()
     {
-        return Points is not { Count: > 0 } ? new CollisionPoint() : Points.GetCombinedCollisionPoint();
+        return Points is not { Count: > 0 } ? new IntersectionPoint() : Points.GetCombinedCollisionPoint();
     }
     /// <summary>
     /// Finds the collision point closest to the 'self' collider's position.
     /// </summary>
     /// <returns>
-    /// The closest <see cref="CollisionPoint"/> to the 'self' collider's position,
-    /// or a default <see cref="CollisionPoint"/> if there are no collision points.
+    /// The closest <see cref="IntersectionPoint"/> to the 'self' collider's position,
+    /// or a default <see cref="IntersectionPoint"/> if there are no collision points.
     /// </returns>
-    public CollisionPoint GetClosestCollisionPoint()
+    public IntersectionPoint GetClosestCollisionPoint()
     {
-        return Points is not { Count: > 0 } ? new CollisionPoint() : Points.GetClosestCollisionPoint(Self.CurTransform.Position);
+        return Points is not { Count: > 0 } ? new IntersectionPoint() : Points.GetClosestCollisionPoint(Self.CurTransform.Position);
     }
     /// <summary>
     /// Finds the collision point furthest from the 'self' collider's position.
     /// </summary>
     /// <returns>
-    /// The furthest <see cref="CollisionPoint"/> from the 'self' collider's position,
-    /// or a default <see cref="CollisionPoint"/> if there are no collision points.
+    /// The furthest <see cref="IntersectionPoint"/> from the 'self' collider's position,
+    /// or a default <see cref="IntersectionPoint"/> if there are no collision points.
     /// </returns>
-    public CollisionPoint GetFurthestCollisionPoint()
+    public IntersectionPoint GetFurthestCollisionPoint()
     {
-        return Points is not { Count: > 0 } ? new CollisionPoint() : Points.GetFurthestCollisionPoint(Self.CurTransform.Position);
+        return Points is not { Count: > 0 } ? new IntersectionPoint() : Points.GetFurthestCollisionPoint(Self.CurTransform.Position);
     }
     /// <summary>
     /// Finds the collision point closest to the 'self' collider's position and provides the distance squared to that point.
     /// </summary>
     /// <param name="closestDistanceSquared">Outputs the distance squared to the closest collision point.</param>
     /// <returns>
-    /// The closest <see cref="CollisionPoint"/> to the 'self' collider's position,
-    /// or a default <see cref="CollisionPoint"/> if there are no collision points.
+    /// The closest <see cref="IntersectionPoint"/> to the 'self' collider's position,
+    /// or a default <see cref="IntersectionPoint"/> if there are no collision points.
     /// </returns>
-    public CollisionPoint GetClosestCollisionPoint(out float closestDistanceSquared)
+    public IntersectionPoint GetClosestCollisionPoint(out float closestDistanceSquared)
     {
         closestDistanceSquared = -1;
-        return Points is not { Count: > 0 } ? new CollisionPoint() : Points.GetClosestCollisionPoint(Self.CurTransform.Position, out closestDistanceSquared);
+        return Points is not { Count: > 0 } ? new IntersectionPoint() : Points.GetClosestCollisionPoint(Self.CurTransform.Position, out closestDistanceSquared);
     }
     /// <summary>
     /// Finds the collision point furthest from the 'self' collider's position and provides the distance squared to that point.
     /// </summary>
     /// <param name="furthestDistanceSquared">Outputs the distance squared to the furthest collision point.</param>
     /// <returns>
-    /// The furthest <see cref="CollisionPoint"/> from the 'self' collider's position,
-    /// or a default <see cref="CollisionPoint"/> if there are no collision points.
+    /// The furthest <see cref="IntersectionPoint"/> from the 'self' collider's position,
+    /// or a default <see cref="IntersectionPoint"/> if there are no collision points.
     /// </returns>
-    public CollisionPoint GetFurthestCollisionPoint(out float furthestDistanceSquared)
+    public IntersectionPoint GetFurthestCollisionPoint(out float furthestDistanceSquared)
     {
         furthestDistanceSquared = -1;
-        return Points is not { Count: > 0 } ? new CollisionPoint() : Points.GetFurthestCollisionPoint(Self.CurTransform.Position, out furthestDistanceSquared);
+        return Points is not { Count: > 0 } ? new IntersectionPoint() : Points.GetFurthestCollisionPoint(Self.CurTransform.Position, out furthestDistanceSquared);
     }
 
     /// <summary>
@@ -252,24 +252,24 @@ public class Collision
     /// Each collision point normal is checked against the direction from the collision point towards the reference point.
     /// </summary>
     /// <returns>
-    /// The <see cref="CollisionPoint"/> facing most towards the 'self' collider's position,
-    /// or a default <see cref="CollisionPoint"/> if there are no collision points.
+    /// The <see cref="IntersectionPoint"/> facing most towards the 'self' collider's position,
+    /// or a default <see cref="IntersectionPoint"/> if there are no collision points.
     /// </returns>
-    public CollisionPoint GetCollisionPointFacingTowardsSelf()
+    public IntersectionPoint GetCollisionPointFacingTowardsSelf()
     {
-        return Points is not { Count: > 0 } ? new CollisionPoint() : Points.GetCollisionPointFacingTowardsPoint(Self.CurTransform.Position);
+        return Points is not { Count: > 0 } ? new IntersectionPoint() : Points.GetCollisionPointFacingTowardsPoint(Self.CurTransform.Position);
     }
    
     /// <summary>
     /// Finds the collision point with the normal facing most in the direction of <see cref="SelfVel"/>.
     /// </summary>
     /// <returns>
-    /// The <see cref="CollisionPoint"/> facing most in the direction of <see cref="SelfVel"/>,
-    /// or a default <see cref="CollisionPoint"/> if there are no collision points or if <see cref="SelfVel"/> is zero.
+    /// The <see cref="IntersectionPoint"/> facing most in the direction of <see cref="SelfVel"/>,
+    /// or a default <see cref="IntersectionPoint"/> if there are no collision points or if <see cref="SelfVel"/> is zero.
     /// </returns>
-    public CollisionPoint GetCollisionPointFacingTowardsSelfVel()
+    public IntersectionPoint GetCollisionPointFacingTowardsSelfVel()
     {
-        if(SelfVel is { X: 0f, Y: 0f } || Points is not { Count: > 0 }) return new CollisionPoint();
+        if(SelfVel is { X: 0f, Y: 0f } || Points is not { Count: > 0 }) return new IntersectionPoint();
         return Points.GetCollisionPointFacingTowardsDir(SelfVel);
     }
     

--- a/ShapeEngine/Geometry/CollisionSystem/Collision.cs
+++ b/ShapeEngine/Geometry/CollisionSystem/Collision.cs
@@ -153,20 +153,20 @@ public class Collision
     #region IntersectionPoint
 
     /// <summary>
-    /// Checks if there is any collision point that matches the conditions defined by the specified predicate.
+    /// Checks if there is any intersection point that matches the conditions defined by the specified predicate.
     /// </summary>
     /// <param name="match">The predicate that defines the conditions of the collision points to search for.</param>
-    /// <returns>true if any collision point matches the predicate; otherwise, false.</returns>
+    /// <returns>true if any intersection point matches the predicate; otherwise, false.</returns>
     public bool Exists(Predicate<IntersectionPoint> match)
     {
         return Points is { Count: > 0 } && Points.Exists(match);
     }
     /// <summary>
-    /// Finds the first collision point that matches the conditions defined by the specified predicate.
+    /// Finds the first intersection point that matches the conditions defined by the specified predicate.
     /// </summary>
-    /// <param name="match">The predicate that defines the conditions of the collision point to search for.</param>
+    /// <param name="match">The predicate that defines the conditions of the intersection point to search for.</param>
     /// <returns>
-    /// The first collision point that matches the predicate, or a default <see cref="IntersectionPoint"/> if no match is found.
+    /// The first intersection point that matches the predicate, or a default <see cref="IntersectionPoint"/> if no match is found.
     /// </returns>
     public IntersectionPoint Find(Predicate<IntersectionPoint> match)
     {
@@ -188,7 +188,7 @@ public class Collision
     }
     
     /// <summary>
-    /// Calculates the combined collision point from all valid collision points.
+    /// Calculates the combined intersection point from all valid collision points.
     /// </summary>
     /// <returns>
     /// The combined <see cref="IntersectionPoint"/> representing the average position and normal of all valid collision points,
@@ -199,7 +199,7 @@ public class Collision
         return Points is not { Count: > 0 } ? new IntersectionPoint() : Points.GetCombinedCollisionPoint();
     }
     /// <summary>
-    /// Finds the collision point closest to the 'self' collider's position.
+    /// Finds the intersection point closest to the 'self' collider's position.
     /// </summary>
     /// <returns>
     /// The closest <see cref="IntersectionPoint"/> to the 'self' collider's position,
@@ -210,7 +210,7 @@ public class Collision
         return Points is not { Count: > 0 } ? new IntersectionPoint() : Points.GetClosestCollisionPoint(Self.CurTransform.Position);
     }
     /// <summary>
-    /// Finds the collision point furthest from the 'self' collider's position.
+    /// Finds the intersection point furthest from the 'self' collider's position.
     /// </summary>
     /// <returns>
     /// The furthest <see cref="IntersectionPoint"/> from the 'self' collider's position,
@@ -221,9 +221,9 @@ public class Collision
         return Points is not { Count: > 0 } ? new IntersectionPoint() : Points.GetFurthestCollisionPoint(Self.CurTransform.Position);
     }
     /// <summary>
-    /// Finds the collision point closest to the 'self' collider's position and provides the distance squared to that point.
+    /// Finds the intersection point closest to the 'self' collider's position and provides the distance squared to that point.
     /// </summary>
-    /// <param name="closestDistanceSquared">Outputs the distance squared to the closest collision point.</param>
+    /// <param name="closestDistanceSquared">Outputs the distance squared to the closest intersection point.</param>
     /// <returns>
     /// The closest <see cref="IntersectionPoint"/> to the 'self' collider's position,
     /// or a default <see cref="IntersectionPoint"/> if there are no collision points.
@@ -234,9 +234,9 @@ public class Collision
         return Points is not { Count: > 0 } ? new IntersectionPoint() : Points.GetClosestCollisionPoint(Self.CurTransform.Position, out closestDistanceSquared);
     }
     /// <summary>
-    /// Finds the collision point furthest from the 'self' collider's position and provides the distance squared to that point.
+    /// Finds the intersection point furthest from the 'self' collider's position and provides the distance squared to that point.
     /// </summary>
-    /// <param name="furthestDistanceSquared">Outputs the distance squared to the furthest collision point.</param>
+    /// <param name="furthestDistanceSquared">Outputs the distance squared to the furthest intersection point.</param>
     /// <returns>
     /// The furthest <see cref="IntersectionPoint"/> from the 'self' collider's position,
     /// or a default <see cref="IntersectionPoint"/> if there are no collision points.
@@ -248,8 +248,8 @@ public class Collision
     }
 
     /// <summary>
-    /// Finds the collision point with the normal facing most in the direction of the <see cref="Self"/> colliders position.
-    /// Each collision point normal is checked against the direction from the collision point towards the reference point.
+    /// Finds the intersection point with the normal facing most in the direction of the <see cref="Self"/> colliders position.
+    /// Each intersection point normal is checked against the direction from the intersection point towards the reference point.
     /// </summary>
     /// <returns>
     /// The <see cref="IntersectionPoint"/> facing most towards the 'self' collider's position,
@@ -261,7 +261,7 @@ public class Collision
     }
    
     /// <summary>
-    /// Finds the collision point with the normal facing most in the direction of <see cref="SelfVel"/>.
+    /// Finds the intersection point with the normal facing most in the direction of <see cref="SelfVel"/>.
     /// </summary>
     /// <returns>
     /// The <see cref="IntersectionPoint"/> facing most in the direction of <see cref="SelfVel"/>,

--- a/ShapeEngine/Geometry/CollisionSystem/CollisionHandler.cs
+++ b/ShapeEngine/Geometry/CollisionSystem/CollisionHandler.cs
@@ -412,7 +412,7 @@ public class CollisionHandler : IBounds
                                 
                                 if (computeIntersections)
                                 {
-                                    CollisionPoints? collisionPoints;
+                                    IntersectionPoints? collisionPoints;
                                     if (passivChecking)
                                     {
                                         collisionPoints = candidate.Intersect(projected);
@@ -490,7 +490,7 @@ public class CollisionHandler : IBounds
                                 
                                 if (computeIntersections)
                                 {                                                         
-                                    CollisionPoints? collisionPoints;
+                                    IntersectionPoints? collisionPoints;
                                     if (passivChecking)
                                     {
                                         collisionPoints = candidate.Intersect(collider);

--- a/ShapeEngine/Geometry/CollisionSystem/CollisionHandler.cs
+++ b/ShapeEngine/Geometry/CollisionSystem/CollisionHandler.cs
@@ -423,7 +423,7 @@ public class CollisionHandler : IBounds
                                     }
                                     
                                     //shapes overlap but no collision points means collidable is completely inside other
-                                    //closest point on bounds of other are now used for collision point
+                                    //closest point on bounds of other are now used for intersection point
                                     if (collisionPoints == null || collisionPoints.Count <= 0)
                                     {
                                         var refPoint = collider.PrevTransform.Position;// PrevPosition;
@@ -501,7 +501,7 @@ public class CollisionHandler : IBounds
                                     }
                                     
                                     //shapes overlap but no collision points means collidable is completely inside other
-                                    //closest point on bounds of other are now used for collision point
+                                    //closest point on bounds of other are now used for intersection point
                                     if (collisionPoints == null || collisionPoints.Count <= 0)
                                     {
                                         var refPoint = collider.PrevTransform.Position;// PrevPosition;

--- a/ShapeEngine/Geometry/CollisionSystem/CollisionInformation.cs
+++ b/ShapeEngine/Geometry/CollisionSystem/CollisionInformation.cs
@@ -39,7 +39,7 @@ public class CollisionInformation : List<Collision>
     /// </summary>
     public int TotalCollisionPointCount { get; private set; }
     /// <summary>
-    /// The filtered collision point.
+    /// The filtered intersection point.
     /// Only valid when the collision object has <see cref="CollisionObject.FilterCollisionPoints"/> enabled and
     /// the collider has <see cref="Collider.ComputeIntersections"/> enabled.
     /// </summary>
@@ -82,9 +82,9 @@ public class CollisionInformation : List<Collision>
     #endregion
 
     /// <summary>
-    /// Generates a filtered collision point based on the specified filter type and reference point.
+    /// Generates a filtered intersection point based on the specified filter type and reference point.
     /// </summary>
-    /// <param name="filterType">The filter type to use for selecting the collision point.</param>
+    /// <param name="filterType">The filter type to use for selecting the intersection point.</param>
     /// <param name="referencePoint">The reference point for filtering.</param>
     internal void GenerateFilteredCollisionPoint(CollisionPointsFilterType filterType, Vector2 referencePoint)
     {
@@ -283,10 +283,10 @@ public class CollisionInformation : List<Collision>
 
     
     /// <summary>
-    /// Determines whether any collision point in any collision matches the specified predicate.
+    /// Determines whether any intersection point in any collision matches the specified predicate.
     /// </summary>
-    /// <param name="match">A predicate to test each collision point.</param>
-    /// <returns>True if a matching collision point exists; otherwise, false.</returns>
+    /// <param name="match">A predicate to test each intersection point.</param>
+    /// <returns>True if a matching intersection point exists; otherwise, false.</returns>
     public bool ExistsCollisionPoint(Predicate<IntersectionPoint> match)
     {
         if(Count <= 0) return false;
@@ -299,9 +299,9 @@ public class CollisionInformation : List<Collision>
     }
     /// <summary>
     /// Returns the first <see cref="IntersectionPoint"/> that matches the given predicate across all collisions.
-    /// If no matching collision point is found, returns an empty <see cref="IntersectionPoint"/>.
+    /// If no matching intersection point is found, returns an empty <see cref="IntersectionPoint"/>.
     /// </summary>
-    /// <param name="match">Predicate to test each collision point.</param>
+    /// <param name="match">Predicate to test each intersection point.</param>
     /// <returns>The first matching <see cref="IntersectionPoint"/>, or an empty one if none found.</returns>
     public IntersectionPoint FindCollisionPoint(Predicate<IntersectionPoint> match)
     {
@@ -318,7 +318,7 @@ public class CollisionInformation : List<Collision>
     /// Finds all collision points that match the given predicate across all valid collisions.
     /// Returns a <see cref="IntersectionPoints"/> collection if any are found; otherwise, returns null.
     /// </summary>
-    /// <param name="match">Predicate to test each collision point.</param>
+    /// <param name="match">Predicate to test each intersection point.</param>
     /// <returns>A <see cref="IntersectionPoints"/> collection of matching points, or null if none found.</returns>
     public IntersectionPoints? FindAllCollisionPoints(Predicate<IntersectionPoint> match)
     {
@@ -387,7 +387,7 @@ public class CollisionInformation : List<Collision>
         return result;
     }
     /// <summary>
-    /// Calculates and returns the average (combined) collision point from all valid collision points
+    /// Calculates and returns the average (combined) intersection point from all valid collision points
     /// across all valid collisions in this collection.
     /// </summary>
     /// <returns>The combined <see cref="IntersectionPoint"/> if any exist; otherwise, an empty <see cref="IntersectionPoint"/>.</returns>
@@ -432,7 +432,7 @@ public class CollisionInformation : List<Collision>
         return result;
     }
     /// <summary>
-    /// Gets the furthest collision point from the specified reference point within all valid collisions.
+    /// Gets the furthest intersection point from the specified reference point within all valid collisions.
     /// </summary>
     /// <param name="referencePoint">The reference point to measure distance from.</param>
     /// <returns>The furthest <see cref="IntersectionPoint"/> from the reference point, or an empty <see cref="IntersectionPoint"/> if none exist.</returns>
@@ -462,7 +462,7 @@ public class CollisionInformation : List<Collision>
     /// and outputs the squared distance to that point. If no valid collision points exist, returns an empty <see cref="IntersectionPoint"/>
     /// and sets <paramref name="closestDistanceSquared"/> to a negative value.
     /// </summary>
-    /// <param name="closestDistanceSquared">The squared distance to the closest collision point, or a negative value if none found.</param>
+    /// <param name="closestDistanceSquared">The squared distance to the closest intersection point, or a negative value if none found.</param>
     /// <returns>The closest <see cref="IntersectionPoint"/>, or an empty one if none exist.</returns>
     public IntersectionPoint GetClosestCollisionPoint(out float closestDistanceSquared)
     {
@@ -490,7 +490,7 @@ public class CollisionInformation : List<Collision>
     /// and outputs the squared distance to that point. If no valid collision points exist, returns an empty <see cref="IntersectionPoint"/>
     /// and sets <paramref name="furthestDistanceSquared"/> to a negative value.
     /// </summary>
-    /// <param name="furthestDistanceSquared">The squared distance to the furthest collision point, or a negative value if none found.</param>
+    /// <param name="furthestDistanceSquared">The squared distance to the furthest intersection point, or a negative value if none found.</param>
     /// <returns>The furthest <see cref="IntersectionPoint"/> from <see cref="Self"/>.Transform.Position, or an empty one if none exist.</returns>
     public IntersectionPoint GetFurthestCollisionPoint(out float furthestDistanceSquared)
     {
@@ -519,9 +519,9 @@ public class CollisionInformation : List<Collision>
     /// If no valid collision points exist, returns an empty <see cref="IntersectionPoint"/>
     /// and sets <paramref name="closestDistanceSquared"/> to a negative value.
     /// </summary>
-    /// <param name="referencePoint">The reference point for finding the closest collision point.</param>
+    /// <param name="referencePoint">The reference point for finding the closest intersection point.</param>
     /// <param name="closestDistanceSquared">
-    /// The squared distance between the closest collision point and the reference point. Negative if no valid point is found.
+    /// The squared distance between the closest intersection point and the reference point. Negative if no valid point is found.
     /// </param>
     /// <returns>The closest <see cref="IntersectionPoint"/>, or an empty one if none exist.</returns>
     public IntersectionPoint GetClosestCollisionPoint(Vector2 referencePoint, out float closestDistanceSquared)
@@ -551,9 +551,9 @@ public class CollisionInformation : List<Collision>
     /// If no valid collision points exist, returns an empty <see cref="IntersectionPoint"/>
     /// and sets <paramref name="furthestDistanceSquared"/> to a negative value.
     /// </summary>
-    /// <param name="referencePoint">The reference point for finding the furthest collision point.</param>
+    /// <param name="referencePoint">The reference point for finding the furthest intersection point.</param>
     /// <param name="furthestDistanceSquared">
-    /// The squared distance between the furthest collision point and the reference point. Negative if no valid point is found.
+    /// The squared distance between the furthest intersection point and the reference point. Negative if no valid point is found.
     /// </param>
     /// <returns>The furthest <see cref="IntersectionPoint"/>, or an empty one if none exist.</returns>
     public IntersectionPoint GetFurthestCollisionPoint(Vector2 referencePoint, out float furthestDistanceSquared)

--- a/ShapeEngine/Geometry/CollisionSystem/CollisionInformation.cs
+++ b/ShapeEngine/Geometry/CollisionSystem/CollisionInformation.cs
@@ -12,7 +12,7 @@ namespace ShapeEngine.Geometry.CollisionSystem;
 /// </remarks>
 public class CollisionInformation : List<Collision>
 {
-    private static readonly CollisionPoints filterList = new CollisionPoints(64);
+    private static readonly IntersectionPoints filterList = new IntersectionPoints(64);
     #region Members
     /// <summary>
     /// The collision object representing 'self' in the collision information.
@@ -43,7 +43,7 @@ public class CollisionInformation : List<Collision>
     /// Only valid when the collision object has <see cref="CollisionObject.FilterCollisionPoints"/> enabled and
     /// the collider has <see cref="Collider.ComputeIntersections"/> enabled.
     /// </summary>
-    public CollisionPoint FilteredCollisionPoint { get; private set; }
+    public IntersectionPoint FilteredIntersectionPoint { get; private set; }
     #endregion
     
     #region Constructors
@@ -60,7 +60,7 @@ public class CollisionInformation : List<Collision>
         Other = other;
         OtherVel = other.Velocity;
         FirstContact = firstContact;
-        FilteredCollisionPoint = new CollisionPoint();
+        FilteredIntersectionPoint = new IntersectionPoint();
     }
     /// <summary>
     /// Initializes a new instance of the <see cref="CollisionInformation"/> class with a list of collisions.
@@ -77,7 +77,7 @@ public class CollisionInformation : List<Collision>
         OtherVel = other.Velocity;
         FirstContact = firstContact;
         AddRange(collisions);
-        FilteredCollisionPoint = new CollisionPoint();
+        FilteredIntersectionPoint = new IntersectionPoint();
     }
     #endregion
 
@@ -95,7 +95,7 @@ public class CollisionInformation : List<Collision>
         }
         if (filterList.Count > 0)
         {
-            FilteredCollisionPoint = filterList.Filter(filterType, referencePoint);
+            FilteredIntersectionPoint = filterList.Filter(filterType, referencePoint);
             filterList.Clear();
         }
     }
@@ -103,16 +103,16 @@ public class CollisionInformation : List<Collision>
     /// <summary>
     /// Validates the collisions and removes invalid ones using <see cref="SelfVel"/> as reference direction and <see cref="Self"/>.CurTransform.Position as reference point.
     /// </summary>
-    /// <param name="combined">The average <see cref="CollisionPoint"/> of all valid collision points.</param>
+    /// <param name="combined">The average <see cref="IntersectionPoint"/> of all valid collision points.</param>
     /// <returns>Returns true if there are valid collision points left.</returns>
-    public bool Validate(out CollisionPoint combined)
+    public bool Validate(out IntersectionPoint combined)
     {
-        combined = new CollisionPoint();
+        combined = new IntersectionPoint();
         if(Count <= 0) return false;
         for (int i = Count - 1; i >= 0; i--)
         {
             var collision = this[i];
-            if (collision.Validate(out CollisionPoint combinedCollisionPoint))
+            if (collision.Validate(out IntersectionPoint combinedCollisionPoint))
             {
                 combined = combinedCollisionPoint.Combine(combined);
             }
@@ -123,19 +123,19 @@ public class CollisionInformation : List<Collision>
     /// <summary>
     /// Validates the collisions and removes invalid ones using <see cref="SelfVel"/> as reference direction and <see cref="Self"/>.CurTransform.Position as reference point.
     /// </summary>
-    /// <param name="combined">The average <see cref="CollisionPoint"/> of all valid collision points.</param>
-    /// <param name="closest">The closest valid <see cref="CollisionPoint"/> to the reference point.</param>
+    /// <param name="combined">The average <see cref="IntersectionPoint"/> of all valid collision points.</param>
+    /// <param name="closest">The closest valid <see cref="IntersectionPoint"/> to the reference point.</param>
     /// <returns>Returns true if there are valid collision points left.</returns>
-    public bool Validate(out CollisionPoint combined, out CollisionPoint closest)
+    public bool Validate(out IntersectionPoint combined, out IntersectionPoint closest)
     {
-        combined = new CollisionPoint();
-        closest = new CollisionPoint();
+        combined = new IntersectionPoint();
+        closest = new IntersectionPoint();
         var closestDistanceSquared = -1f;
         if(Count <= 0) return false;
         for (int i = Count - 1; i >= 0; i--)
         {
             var collision = this[i];
-            if (collision.Validate(out CollisionPoint combinedCollisionPoint, out var closestCollisionPoint))
+            if (collision.Validate(out IntersectionPoint combinedCollisionPoint, out var closestCollisionPoint))
             {
                 combined = combinedCollisionPoint.Combine(combined);
                 var dis = (collision.Self.CurTransform.Position - closestCollisionPoint.Point).LengthSquared();
@@ -157,10 +157,10 @@ public class CollisionInformation : List<Collision>
     public bool Validate(out CollisionPointValidationResult result)
     {
         result = new CollisionPointValidationResult();
-        var combined = new CollisionPoint();
-        var closest = new CollisionPoint();
-        var furthest = new CollisionPoint();
-        var pointing = new CollisionPoint();
+        var combined = new IntersectionPoint();
+        var closest = new IntersectionPoint();
+        var furthest = new IntersectionPoint();
+        var pointing = new IntersectionPoint();
         var closestDistanceSquared = -1f;
         var furthestDistanceSquared = -1f;
         var maxDot = -1f;
@@ -287,7 +287,7 @@ public class CollisionInformation : List<Collision>
     /// </summary>
     /// <param name="match">A predicate to test each collision point.</param>
     /// <returns>True if a matching collision point exists; otherwise, false.</returns>
-    public bool ExistsCollisionPoint(Predicate<CollisionPoint> match)
+    public bool ExistsCollisionPoint(Predicate<IntersectionPoint> match)
     {
         if(Count <= 0) return false;
         foreach (var collision in this)
@@ -298,12 +298,12 @@ public class CollisionInformation : List<Collision>
         return false;
     }
     /// <summary>
-    /// Returns the first <see cref="CollisionPoint"/> that matches the given predicate across all collisions.
-    /// If no matching collision point is found, returns an empty <see cref="CollisionPoint"/>.
+    /// Returns the first <see cref="IntersectionPoint"/> that matches the given predicate across all collisions.
+    /// If no matching collision point is found, returns an empty <see cref="IntersectionPoint"/>.
     /// </summary>
     /// <param name="match">Predicate to test each collision point.</param>
-    /// <returns>The first matching <see cref="CollisionPoint"/>, or an empty one if none found.</returns>
-    public CollisionPoint FindCollisionPoint(Predicate<CollisionPoint> match)
+    /// <returns>The first matching <see cref="IntersectionPoint"/>, or an empty one if none found.</returns>
+    public IntersectionPoint FindCollisionPoint(Predicate<IntersectionPoint> match)
     {
         if(Count <= 0) return new();
         foreach (var collision in this)
@@ -316,20 +316,20 @@ public class CollisionInformation : List<Collision>
     }
     /// <summary>
     /// Finds all collision points that match the given predicate across all valid collisions.
-    /// Returns a <see cref="CollisionPoints"/> collection if any are found; otherwise, returns null.
+    /// Returns a <see cref="IntersectionPoints"/> collection if any are found; otherwise, returns null.
     /// </summary>
     /// <param name="match">Predicate to test each collision point.</param>
-    /// <returns>A <see cref="CollisionPoints"/> collection of matching points, or null if none found.</returns>
-    public CollisionPoints? FindAllCollisionPoints(Predicate<CollisionPoint> match)
+    /// <returns>A <see cref="IntersectionPoints"/> collection of matching points, or null if none found.</returns>
+    public IntersectionPoints? FindAllCollisionPoints(Predicate<IntersectionPoint> match)
     {
         if (Count <= 0) return null;
-        CollisionPoints? result = null;
+        IntersectionPoints? result = null;
         foreach (var collision in this)
         {
            var points = collision.FindAll(match);
            if(points == null) continue;
            
-           result??= new CollisionPoints();
+           result??= new IntersectionPoints();
            result.AddRange(points);
         }
 
@@ -338,14 +338,14 @@ public class CollisionInformation : List<Collision>
 
     
     /// <summary>
-    /// Returns the closest <see cref="CollisionPoint"/> to <see cref="Self"/>.Transform.Position across all valid collisions.
+    /// Returns the closest <see cref="IntersectionPoint"/> to <see cref="Self"/>.Transform.Position across all valid collisions.
     /// </summary>
-    /// <returns>The closest <see cref="CollisionPoint"/>, or an empty one if none exist.</returns>
-    public CollisionPoint GetClosestCollisionPoint()
+    /// <returns>The closest <see cref="IntersectionPoint"/>, or an empty one if none exist.</returns>
+    public IntersectionPoint GetClosestCollisionPoint()
     {
-        if(Count <= 0) return new CollisionPoint();
+        if(Count <= 0) return new IntersectionPoint();
         
-        var result = new CollisionPoint();
+        var result = new IntersectionPoint();
         var closestDistanceSquared = -1f;
         foreach (var collision in this)
         {
@@ -363,14 +363,14 @@ public class CollisionInformation : List<Collision>
     }
 
     /// <summary>
-    /// Returns the furthest <see cref="CollisionPoint"/> from <see cref="Self"/>.Transform.Position across all valid collisions.
+    /// Returns the furthest <see cref="IntersectionPoint"/> from <see cref="Self"/>.Transform.Position across all valid collisions.
     /// </summary>
-    /// <returns>The furthest <see cref="CollisionPoint"/>, or an empty one if none exist.</returns>
-    public CollisionPoint GetFurthestCollisionPoint()
+    /// <returns>The furthest <see cref="IntersectionPoint"/>, or an empty one if none exist.</returns>
+    public IntersectionPoint GetFurthestCollisionPoint()
     {
-        if(Count <= 0) return new CollisionPoint();
+        if(Count <= 0) return new IntersectionPoint();
         
-        var result = new CollisionPoint();
+        var result = new IntersectionPoint();
         var furthestDistanceSquared = -1f;
         foreach (var collision in this)
         {
@@ -390,12 +390,12 @@ public class CollisionInformation : List<Collision>
     /// Calculates and returns the average (combined) collision point from all valid collision points
     /// across all valid collisions in this collection.
     /// </summary>
-    /// <returns>The combined <see cref="CollisionPoint"/> if any exist; otherwise, an empty <see cref="CollisionPoint"/>.</returns>
-    public CollisionPoint GetCombinedCollisionPoint()
+    /// <returns>The combined <see cref="IntersectionPoint"/> if any exist; otherwise, an empty <see cref="IntersectionPoint"/>.</returns>
+    public IntersectionPoint GetCombinedCollisionPoint()
     {
-        if(Count <= 0) return new CollisionPoint();
+        if(Count <= 0) return new IntersectionPoint();
         
-        var result = new CollisionPoint();
+        var result = new IntersectionPoint();
         foreach (var collision in this)
         {
             if(collision.Points is not { Count: > 0 }) continue;
@@ -407,15 +407,15 @@ public class CollisionInformation : List<Collision>
         return result;
     }
     /// <summary>
-    /// Returns the closest <see cref="CollisionPoint"/> to the specified reference point across all valid collisions.
+    /// Returns the closest <see cref="IntersectionPoint"/> to the specified reference point across all valid collisions.
     /// </summary>
     /// <param name="referencePoint">The reference point to measure distance from.</param>
-    /// <returns>The closest <see cref="CollisionPoint"/>, or an empty one if none exist.</returns>
-    public CollisionPoint GetClosestCollisionPoint(Vector2 referencePoint)
+    /// <returns>The closest <see cref="IntersectionPoint"/>, or an empty one if none exist.</returns>
+    public IntersectionPoint GetClosestCollisionPoint(Vector2 referencePoint)
     {
-        if(Count <= 0) return new CollisionPoint();
+        if(Count <= 0) return new IntersectionPoint();
         
-        var result = new CollisionPoint();
+        var result = new IntersectionPoint();
         var closestDistanceSquared = -1f;
         foreach (var collision in this)
         {
@@ -435,12 +435,12 @@ public class CollisionInformation : List<Collision>
     /// Gets the furthest collision point from the specified reference point within all valid collisions.
     /// </summary>
     /// <param name="referencePoint">The reference point to measure distance from.</param>
-    /// <returns>The furthest <see cref="CollisionPoint"/> from the reference point, or an empty <see cref="CollisionPoint"/> if none exist.</returns>
-    public CollisionPoint GetFurthestCollisionPoint(Vector2 referencePoint)
+    /// <returns>The furthest <see cref="IntersectionPoint"/> from the reference point, or an empty <see cref="IntersectionPoint"/> if none exist.</returns>
+    public IntersectionPoint GetFurthestCollisionPoint(Vector2 referencePoint)
     {
-        if(Count <= 0) return new CollisionPoint();
+        if(Count <= 0) return new IntersectionPoint();
         
-        var result = new CollisionPoint();
+        var result = new IntersectionPoint();
         var furthestDistanceSquared = -1f;
         foreach (var collision in this)
         {
@@ -458,18 +458,18 @@ public class CollisionInformation : List<Collision>
     }
     
     /// <summary>
-    /// Returns the closest <see cref="CollisionPoint"/> to <see cref="Self"/>.Transform.Position within all valid collisions,
-    /// and outputs the squared distance to that point. If no valid collision points exist, returns an empty <see cref="CollisionPoint"/>
+    /// Returns the closest <see cref="IntersectionPoint"/> to <see cref="Self"/>.Transform.Position within all valid collisions,
+    /// and outputs the squared distance to that point. If no valid collision points exist, returns an empty <see cref="IntersectionPoint"/>
     /// and sets <paramref name="closestDistanceSquared"/> to a negative value.
     /// </summary>
     /// <param name="closestDistanceSquared">The squared distance to the closest collision point, or a negative value if none found.</param>
-    /// <returns>The closest <see cref="CollisionPoint"/>, or an empty one if none exist.</returns>
-    public CollisionPoint GetClosestCollisionPoint(out float closestDistanceSquared)
+    /// <returns>The closest <see cref="IntersectionPoint"/>, or an empty one if none exist.</returns>
+    public IntersectionPoint GetClosestCollisionPoint(out float closestDistanceSquared)
     {
         closestDistanceSquared = -1f;
-        if(Count <= 0) return new CollisionPoint();
+        if(Count <= 0) return new IntersectionPoint();
         
-        var result = new CollisionPoint();
+        var result = new IntersectionPoint();
         foreach (var collision in this)
         {
             if(collision.Points == null || collision.Points.Count <= 0) continue;
@@ -486,18 +486,18 @@ public class CollisionInformation : List<Collision>
     }
 
     /// <summary>
-    /// Returns the furthest <see cref="CollisionPoint"/> from <see cref="Self"/>.Transform.Position across all valid collisions,
-    /// and outputs the squared distance to that point. If no valid collision points exist, returns an empty <see cref="CollisionPoint"/>
+    /// Returns the furthest <see cref="IntersectionPoint"/> from <see cref="Self"/>.Transform.Position across all valid collisions,
+    /// and outputs the squared distance to that point. If no valid collision points exist, returns an empty <see cref="IntersectionPoint"/>
     /// and sets <paramref name="furthestDistanceSquared"/> to a negative value.
     /// </summary>
     /// <param name="furthestDistanceSquared">The squared distance to the furthest collision point, or a negative value if none found.</param>
-    /// <returns>The furthest <see cref="CollisionPoint"/> from <see cref="Self"/>.Transform.Position, or an empty one if none exist.</returns>
-    public CollisionPoint GetFurthestCollisionPoint(out float furthestDistanceSquared)
+    /// <returns>The furthest <see cref="IntersectionPoint"/> from <see cref="Self"/>.Transform.Position, or an empty one if none exist.</returns>
+    public IntersectionPoint GetFurthestCollisionPoint(out float furthestDistanceSquared)
     {
         furthestDistanceSquared = -1f;
-        if(Count <= 0) return new CollisionPoint();
+        if(Count <= 0) return new IntersectionPoint();
         
-        var result = new CollisionPoint();
+        var result = new IntersectionPoint();
         foreach (var collision in this)
         {
             if(collision.Points == null || collision.Points.Count <= 0) continue;
@@ -514,22 +514,22 @@ public class CollisionInformation : List<Collision>
     }
     
     /// <summary>
-    /// Returns the closest <see cref="CollisionPoint"/> to the specified reference point within all valid collisions,
+    /// Returns the closest <see cref="IntersectionPoint"/> to the specified reference point within all valid collisions,
     /// and outputs the squared distance to that point.
-    /// If no valid collision points exist, returns an empty <see cref="CollisionPoint"/>
+    /// If no valid collision points exist, returns an empty <see cref="IntersectionPoint"/>
     /// and sets <paramref name="closestDistanceSquared"/> to a negative value.
     /// </summary>
     /// <param name="referencePoint">The reference point for finding the closest collision point.</param>
     /// <param name="closestDistanceSquared">
     /// The squared distance between the closest collision point and the reference point. Negative if no valid point is found.
     /// </param>
-    /// <returns>The closest <see cref="CollisionPoint"/>, or an empty one if none exist.</returns>
-    public CollisionPoint GetClosestCollisionPoint(Vector2 referencePoint, out float closestDistanceSquared)
+    /// <returns>The closest <see cref="IntersectionPoint"/>, or an empty one if none exist.</returns>
+    public IntersectionPoint GetClosestCollisionPoint(Vector2 referencePoint, out float closestDistanceSquared)
     {
         closestDistanceSquared = -1f;
-        if(Count <= 0) return new CollisionPoint();
+        if(Count <= 0) return new IntersectionPoint();
         
-        var result = new CollisionPoint();
+        var result = new IntersectionPoint();
         foreach (var collision in this)
         {
             if(collision.Points == null || collision.Points.Count <= 0) continue;
@@ -546,22 +546,22 @@ public class CollisionInformation : List<Collision>
     }
 
     /// <summary>
-    /// Returns the furthest <see cref="CollisionPoint"/> from the specified reference point within all valid collisions,
+    /// Returns the furthest <see cref="IntersectionPoint"/> from the specified reference point within all valid collisions,
     /// and outputs the squared distance to that point.
-    /// If no valid collision points exist, returns an empty <see cref="CollisionPoint"/>
+    /// If no valid collision points exist, returns an empty <see cref="IntersectionPoint"/>
     /// and sets <paramref name="furthestDistanceSquared"/> to a negative value.
     /// </summary>
     /// <param name="referencePoint">The reference point for finding the furthest collision point.</param>
     /// <param name="furthestDistanceSquared">
     /// The squared distance between the furthest collision point and the reference point. Negative if no valid point is found.
     /// </param>
-    /// <returns>The furthest <see cref="CollisionPoint"/>, or an empty one if none exist.</returns>
-    public CollisionPoint GetFurthestCollisionPoint(Vector2 referencePoint, out float furthestDistanceSquared)
+    /// <returns>The furthest <see cref="IntersectionPoint"/>, or an empty one if none exist.</returns>
+    public IntersectionPoint GetFurthestCollisionPoint(Vector2 referencePoint, out float furthestDistanceSquared)
     {
         furthestDistanceSquared = -1f;
-        if(Count <= 0) return new CollisionPoint();
+        if(Count <= 0) return new IntersectionPoint();
         
-        var result = new CollisionPoint();
+        var result = new IntersectionPoint();
         foreach (var collision in this)
         {
             if(collision.Points == null || collision.Points.Count <= 0) continue;

--- a/ShapeEngine/Geometry/CollisionSystem/CollisionObject.cs
+++ b/ShapeEngine/Geometry/CollisionSystem/CollisionObject.cs
@@ -500,12 +500,12 @@ public abstract class CollisionObject : PhysicsObject
     /// Returns the intersection points between this object and another <see cref="CollisionObject"/>.
     /// </summary>
     /// <param name="other">The other collision object.</param>
-    /// <returns>A <see cref="CollisionPoints"/> collection, or null if no intersection.</returns>
-    public CollisionPoints? Intersect(CollisionObject other)
+    /// <returns>A <see cref="IntersectionPoints"/> collection, or null if no intersection.</returns>
+    public IntersectionPoints? Intersect(CollisionObject other)
     {
         if (!Enabled || !other.Enabled || !HasColliders || !other.HasColliders) return null;
             
-        CollisionPoints? result = null;
+        IntersectionPoints? result = null;
         foreach (var col in Colliders)
         {
             foreach (var otherCol in other.Colliders)
@@ -523,11 +523,11 @@ public abstract class CollisionObject : PhysicsObject
     /// Returns the intersection points between this object and a specific collider.
     /// </summary>
     /// <param name="other">The other collider.</param>
-    /// <returns>A <see cref="CollisionPoints"/> collection, or null if no intersection.</returns>
-    public CollisionPoints? Intersect(Collider other)
+    /// <returns>A <see cref="IntersectionPoints"/> collection, or null if no intersection.</returns>
+    public IntersectionPoints? Intersect(Collider other)
     {
         if (!Enabled || !other.Enabled || !HasColliders) return null;
-        CollisionPoints? result = null;
+        IntersectionPoints? result = null;
         foreach (var col in Colliders)
         {
             var points = col.Intersect(other);
@@ -542,11 +542,11 @@ public abstract class CollisionObject : PhysicsObject
     /// Returns the intersection points between this object and a segment shape.
     /// </summary>
     /// <param name="shape">The segment shape.</param>
-    /// <returns>A <see cref="CollisionPoints"/> collection, or null if no intersection.</returns>
-    public CollisionPoints? Intersect(Segment shape)
+    /// <returns>A <see cref="IntersectionPoints"/> collection, or null if no intersection.</returns>
+    public IntersectionPoints? Intersect(Segment shape)
     {
         if (!Enabled || !HasColliders) return null;
-        CollisionPoints? result = null;
+        IntersectionPoints? result = null;
         foreach (var col in Colliders)
         {
             var points = col.Intersect(shape);
@@ -561,11 +561,11 @@ public abstract class CollisionObject : PhysicsObject
     /// Returns the intersection points between this object and a circle shape.
     /// </summary>
     /// <param name="shape">The circle shape.</param>
-    /// <returns>A <see cref="CollisionPoints"/> collection, or null if no intersection.</returns>
-    public CollisionPoints? Intersect(Circle shape)
+    /// <returns>A <see cref="IntersectionPoints"/> collection, or null if no intersection.</returns>
+    public IntersectionPoints? Intersect(Circle shape)
     {
         if (!Enabled || !HasColliders) return null;
-        CollisionPoints? result = null;
+        IntersectionPoints? result = null;
         foreach (var col in Colliders)
         {
             var points = col.Intersect(shape);
@@ -580,11 +580,11 @@ public abstract class CollisionObject : PhysicsObject
     /// Returns the intersection points between this object and a triangle shape.
     /// </summary>
     /// <param name="shape">The triangle shape.</param>
-    /// <returns>A <see cref="CollisionPoints"/> collection, or null if no intersection.</returns>
-    public CollisionPoints? Intersect(Triangle shape)
+    /// <returns>A <see cref="IntersectionPoints"/> collection, or null if no intersection.</returns>
+    public IntersectionPoints? Intersect(Triangle shape)
     {
         if (!Enabled || !HasColliders) return null;
-        CollisionPoints? result = null;
+        IntersectionPoints? result = null;
         foreach (var col in Colliders)
         {
             var points = col.Intersect(shape);
@@ -599,11 +599,11 @@ public abstract class CollisionObject : PhysicsObject
     /// Returns the intersection points between this object and a rectangle shape.
     /// </summary>
     /// <param name="shape">The rectangle shape.</param>
-    /// <returns>A <see cref="CollisionPoints"/> collection, or null if no intersection.</returns>
-    public CollisionPoints? Intersect(Rect shape)
+    /// <returns>A <see cref="IntersectionPoints"/> collection, or null if no intersection.</returns>
+    public IntersectionPoints? Intersect(Rect shape)
     {
         if (!Enabled || !HasColliders) return null;
-        CollisionPoints? result = null;
+        IntersectionPoints? result = null;
         foreach (var col in Colliders)
         {
             var points = col.Intersect(shape);
@@ -618,11 +618,11 @@ public abstract class CollisionObject : PhysicsObject
     /// Returns the intersection points between this object and a polygon shape.
     /// </summary>
     /// <param name="shape">The polygon shape.</param>
-    /// <returns>A <see cref="CollisionPoints"/> collection, or null if no intersection.</returns>
-    public CollisionPoints? Intersect(Polygon shape)
+    /// <returns>A <see cref="IntersectionPoints"/> collection, or null if no intersection.</returns>
+    public IntersectionPoints? Intersect(Polygon shape)
     {
         if (!Enabled || !HasColliders) return null;
-        CollisionPoints? result = null;
+        IntersectionPoints? result = null;
         foreach (var col in Colliders)
         {
             var points = col.Intersect(shape);
@@ -637,11 +637,11 @@ public abstract class CollisionObject : PhysicsObject
     /// Returns the intersection points between this object and a polyline shape.
     /// </summary>
     /// <param name="shape">The polyline shape.</param>
-    /// <returns>A <see cref="CollisionPoints"/> collection, or null if no intersection.</returns>
-    public CollisionPoints? Intersect(Polyline shape)
+    /// <returns>A <see cref="IntersectionPoints"/> collection, or null if no intersection.</returns>
+    public IntersectionPoints? Intersect(Polyline shape)
     {
         if (!Enabled || !HasColliders) return null;
-        CollisionPoints? result = null;
+        IntersectionPoints? result = null;
         foreach (var col in Colliders)
         {
             var points = col.Intersect(shape);

--- a/ShapeEngine/Geometry/CollisionSystem/CollisionPointValidationResult.cs
+++ b/ShapeEngine/Geometry/CollisionSystem/CollisionPointValidationResult.cs
@@ -8,33 +8,33 @@ namespace ShapeEngine.Geometry.CollisionSystem;
 /// <param name="furthest">The furthest collision point.</param>
 /// <param name="pointingTowards">The collision point that is pointing towards a target.</param>
 public readonly struct CollisionPointValidationResult(
-    CollisionPoint combined,
-    CollisionPoint closest,
-    CollisionPoint furthest,
-    CollisionPoint pointingTowards)
+    IntersectionPoint combined,
+    IntersectionPoint closest,
+    IntersectionPoint furthest,
+    IntersectionPoint pointingTowards)
 {
     /// <summary>
     /// The combined collision point.
     /// </summary>
-    public readonly CollisionPoint Combined = combined;
+    public readonly IntersectionPoint Combined = combined;
 
     /// <summary>
     /// The closest collision point.
     /// </summary>
-    public readonly CollisionPoint Closest = closest;
+    public readonly IntersectionPoint Closest = closest;
 
     /// <summary>
     /// The furthest collision point.
     /// </summary>
-    public readonly CollisionPoint Furthest = furthest;
+    public readonly IntersectionPoint Furthest = furthest;
 
     /// <summary>
     /// The collision point that is pointing towards a target.
     /// </summary>
-    public readonly CollisionPoint PointingTowards = pointingTowards;
+    public readonly IntersectionPoint PointingTowards = pointingTowards;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="CollisionPointValidationResult"/> struct with default values.
     /// </summary>
-    public CollisionPointValidationResult() : this(new CollisionPoint(), new CollisionPoint(), new CollisionPoint(), new CollisionPoint()) { }
+    public CollisionPointValidationResult() : this(new IntersectionPoint(), new IntersectionPoint(), new IntersectionPoint(), new IntersectionPoint()) { }
 }

--- a/ShapeEngine/Geometry/CollisionSystem/CollisionPointValidationResult.cs
+++ b/ShapeEngine/Geometry/CollisionSystem/CollisionPointValidationResult.cs
@@ -3,10 +3,10 @@ namespace ShapeEngine.Geometry.CollisionSystem;
 /// <summary>
 /// Represents the result of validating collision points, containing various relevant points.
 /// </summary>
-/// <param name="combined">The combined (average) collision point.</param>
-/// <param name="closest">The closest collision point.</param>
-/// <param name="furthest">The furthest collision point.</param>
-/// <param name="pointingTowards">The collision point that is pointing towards a target.</param>
+/// <param name="combined">The combined (average) intersection point.</param>
+/// <param name="closest">The closest intersection point.</param>
+/// <param name="furthest">The furthest intersection point.</param>
+/// <param name="pointingTowards">The intersection point that is pointing towards a target.</param>
 public readonly struct CollisionPointValidationResult(
     IntersectionPoint combined,
     IntersectionPoint closest,
@@ -14,22 +14,22 @@ public readonly struct CollisionPointValidationResult(
     IntersectionPoint pointingTowards)
 {
     /// <summary>
-    /// The combined collision point.
+    /// The combined intersection point.
     /// </summary>
     public readonly IntersectionPoint Combined = combined;
 
     /// <summary>
-    /// The closest collision point.
+    /// The closest intersection point.
     /// </summary>
     public readonly IntersectionPoint Closest = closest;
 
     /// <summary>
-    /// The furthest collision point.
+    /// The furthest intersection point.
     /// </summary>
     public readonly IntersectionPoint Furthest = furthest;
 
     /// <summary>
-    /// The collision point that is pointing towards a target.
+    /// The intersection point that is pointing towards a target.
     /// </summary>
     public readonly IntersectionPoint PointingTowards = pointingTowards;
 

--- a/ShapeEngine/Geometry/CollisionSystem/CollisionPointsFilterType.cs
+++ b/ShapeEngine/Geometry/CollisionSystem/CollisionPointsFilterType.cs
@@ -6,37 +6,37 @@ namespace ShapeEngine.Geometry.CollisionSystem;
 public enum CollisionPointsFilterType
 {
     /// <summary>
-    /// Selects the first collision point in the list.
+    /// Selects the first intersection point in the list.
     /// </summary>
     First,
 
     /// <summary>
-    /// Selects the collision point closest to the reference point.
+    /// Selects the intersection point closest to the reference point.
     /// </summary>
     Closest,
 
     /// <summary>
-    /// Selects the collision point furthest from the reference point.
+    /// Selects the intersection point furthest from the reference point.
     /// </summary>
     Furthest,
 
     /// <summary>
-    /// Computes the average (combined) collision point.
+    /// Computes the average (combined) intersection point.
     /// </summary>
     Combined,
 
     /// <summary>
-    /// Selects the collision point whose normal points most towards the reference position.
+    /// Selects the intersection point whose normal points most towards the reference position.
     /// </summary>
     PointingTowards,
 
     /// <summary>
-    /// Selects the collision point whose normal points most away from the reference position.
+    /// Selects the intersection point whose normal points most away from the reference position.
     /// </summary>
     PointingAway,
 
     /// <summary>
-    /// Selects a random collision point from the list.
+    /// Selects a random intersection point from the list.
     /// </summary>
     Random
 }

--- a/ShapeEngine/Geometry/CollisionSystem/IntersectSpaceEntry.cs
+++ b/ShapeEngine/Geometry/CollisionSystem/IntersectSpaceEntry.cs
@@ -6,10 +6,10 @@ namespace ShapeEngine.Geometry.CollisionSystem;
 /// Represents an entry in the intersection space, containing collision points and information about the other collider involved in the intersection.
 /// </summary>
 /// <remarks>
-/// This class extends <see cref="CollisionPoints"/> and is used to store collision points resulting from intersection tests with another collider.
+/// This class extends <see cref="IntersectionPoints"/> and is used to store collision points resulting from intersection tests with another collider.
 /// It also stores the velocity of the other collider at the time of intersection.
 /// </remarks>
-public class IntersectSpaceEntry : CollisionPoints
+public class IntersectSpaceEntry : IntersectionPoints
 {
     /// <summary>
     /// The collider that this entry represents as the other collider in the intersection.
@@ -35,7 +35,7 @@ public class IntersectSpaceEntry : CollisionPoints
     /// </summary>
     /// <param name="otherCollider">The other collider involved in the intersection.</param>
     /// <param name="points">The list of collision points to add to this entry.</param>
-    public IntersectSpaceEntry(Collider otherCollider, List<CollisionPoint> points) : base(points.Count)
+    public IntersectSpaceEntry(Collider otherCollider, List<IntersectionPoint> points) : base(points.Count)
     {
         OtherCollider = otherCollider;
         OtherVel = otherCollider.Velocity;
@@ -48,16 +48,16 @@ public class IntersectSpaceEntry : CollisionPoints
     /// <summary>
     /// Gets the collision point whose normal is most closely facing towards the position of the other collider.
     /// </summary>
-    /// <returns>The <see cref="CollisionPoint"/> facing towards the other collider's position.</returns>
-    public CollisionPoint GetCollisionPointFacingTowardsPoint()
+    /// <returns>The <see cref="IntersectionPoint"/> facing towards the other collider's position.</returns>
+    public IntersectionPoint GetCollisionPointFacingTowardsPoint()
     {
         return GetCollisionPointFacingTowardsPoint(OtherCollider.CurTransform.Position);
     }
     /// <summary>
     /// Gets the collision point whose normal is most closely facing towards the velocity direction of the other collider.
     /// </summary>
-    /// <returns>The <see cref="CollisionPoint"/> facing towards the other collider's velocity direction.</returns>
-    public CollisionPoint GetCollisionPointFacingTowardsDir()
+    /// <returns>The <see cref="IntersectionPoint"/> facing towards the other collider's velocity direction.</returns>
+    public IntersectionPoint GetCollisionPointFacingTowardsDir()
     {
         return GetCollisionPointFacingTowardsDir(OtherVel);
     }
@@ -69,29 +69,29 @@ public class IntersectSpaceEntry : CollisionPoints
     /// <summary>
     /// Validates the collision points in this entry using the other collider's velocity as the reference direction and its position as the reference point.
     /// </summary>
-    /// <param name="combined">An averaged <see cref="CollisionPoint"/> of all remaining valid collision points.</param>
-    /// <param name="closest">The <see cref="CollisionPoint"/> that is closest to the reference point.</param>
+    /// <param name="combined">An averaged <see cref="IntersectionPoint"/> of all remaining valid collision points.</param>
+    /// <param name="closest">The <see cref="IntersectionPoint"/> that is closest to the reference point.</param>
     /// <returns>Returns <c>true</c> if there are valid points remaining after validation; otherwise, <c>false</c>.</returns>
     /// <remarks>
     /// Removes:
-    /// - Invalid <see cref="CollisionPoint"/>s
+    /// - Invalid <see cref="IntersectionPoint"/>s
     /// - Points with normals facing in the same direction as the reference direction
-    /// - Points with normals facing in the opposite direction as the reference point (from <see cref="CollisionPoint"/> towards the reference point)
+    /// - Points with normals facing in the opposite direction as the reference point (from <see cref="IntersectionPoint"/> towards the reference point)
     /// </remarks>
-    public bool ValidateByOther( out CollisionPoint combined, out CollisionPoint closest)
+    public bool ValidateByOther( out IntersectionPoint combined, out IntersectionPoint closest)
     {
         return Validate(OtherVel, OtherCollider.CurTransform.Position, out combined, out closest);
     }
     /// <summary>
     /// Validates the collision points in this entry using the other collider's velocity as the reference direction and its position as the reference point.
     /// </summary>
-    /// <param name="validationResult">The result containing the combined <see cref="CollisionPoint"/>, the closest and furthest points from the reference point, and the point with normal facing towards the reference point.</param>
+    /// <param name="validationResult">The result containing the combined <see cref="IntersectionPoint"/>, the closest and furthest points from the reference point, and the point with normal facing towards the reference point.</param>
     /// <returns>Returns <c>true</c> if there are valid points remaining after validation; otherwise, <c>false</c>.</returns>
     /// <remarks>
     /// Removes:
-    /// - Invalid <see cref="CollisionPoint"/>s
+    /// - Invalid <see cref="IntersectionPoint"/>s
     /// - Points with normals facing in the same direction as the reference direction
-    /// - Points with normals facing in the opposite direction as the reference point (from <see cref="CollisionPoint"/> towards the reference point)
+    /// - Points with normals facing in the opposite direction as the reference point (from <see cref="IntersectionPoint"/> towards the reference point)
     /// </remarks>
     public bool ValidateByOther(out CollisionPointValidationResult validationResult)
     {

--- a/ShapeEngine/Geometry/CollisionSystem/IntersectSpaceEntry.cs
+++ b/ShapeEngine/Geometry/CollisionSystem/IntersectSpaceEntry.cs
@@ -46,7 +46,7 @@ public class IntersectSpaceEntry : IntersectionPoints
     #region Pointing Towards
     
     /// <summary>
-    /// Gets the collision point whose normal is most closely facing towards the position of the other collider.
+    /// Gets the intersection point whose normal is most closely facing towards the position of the other collider.
     /// </summary>
     /// <returns>The <see cref="IntersectionPoint"/> facing towards the other collider's position.</returns>
     public IntersectionPoint GetCollisionPointFacingTowardsPoint()
@@ -54,7 +54,7 @@ public class IntersectSpaceEntry : IntersectionPoints
         return GetCollisionPointFacingTowardsPoint(OtherCollider.CurTransform.Position);
     }
     /// <summary>
-    /// Gets the collision point whose normal is most closely facing towards the velocity direction of the other collider.
+    /// Gets the intersection point whose normal is most closely facing towards the velocity direction of the other collider.
     /// </summary>
     /// <returns>The <see cref="IntersectionPoint"/> facing towards the other collider's velocity direction.</returns>
     public IntersectionPoint GetCollisionPointFacingTowardsDir()

--- a/ShapeEngine/Geometry/CollisionSystem/IntersectSpaceRegister.cs
+++ b/ShapeEngine/Geometry/CollisionSystem/IntersectSpaceRegister.cs
@@ -57,7 +57,7 @@ public class IntersectSpaceRegister : List<IntersectSpaceEntry>
     }
 
     /// <summary>
-    /// Calculates the average collision point and normal from all entries in the register.
+    /// Calculates the average intersection point and normal from all entries in the register.
     /// </summary>
     /// <returns>A <see cref="IntersectionPoint"/> representing the average point and normal.</returns>
     public IntersectionPoint GetAverageCollisionPoint()
@@ -202,10 +202,10 @@ public class IntersectSpaceRegister : List<IntersectSpaceEntry>
     
     #region Closest/Furthest Entry
     /// <summary>
-    /// Gets the entry whose closest collision point is nearest to the reference point.
+    /// Gets the entry whose closest intersection point is nearest to the reference point.
     /// </summary>
     /// <param name="referencePoint">The point to compare distances from.</param>
-    /// <param name="closestDistanceSquared">The squared distance to the closest collision point.</param>
+    /// <param name="closestDistanceSquared">The squared distance to the closest intersection point.</param>
     /// <returns>The closest <see cref="IntersectSpaceEntry"/> or null if none exist.</returns>
     public IntersectSpaceEntry? GetClosestEntry(Vector2 referencePoint, out float closestDistanceSquared)
     {
@@ -233,10 +233,10 @@ public class IntersectSpaceRegister : List<IntersectSpaceEntry>
         return closestEntry;
     }
     /// <summary>
-    /// Gets the entry whose furthest collision point is furthest from the reference point.
+    /// Gets the entry whose furthest intersection point is furthest from the reference point.
     /// </summary>
     /// <param name="referencePoint">The point to compare distances from.</param>
-    /// <param name="furthestDistanceSquared">The squared distance to the furthest collision point.</param>
+    /// <param name="furthestDistanceSquared">The squared distance to the furthest intersection point.</param>
     /// <returns>The furthest <see cref="IntersectSpaceEntry"/> or null if none exist.</returns>
     public IntersectSpaceEntry? GetFurthestEntry(Vector2 referencePoint, out float furthestDistanceSquared)
     {
@@ -265,12 +265,12 @@ public class IntersectSpaceRegister : List<IntersectSpaceEntry>
     }
     #endregion
     
-    #region Closest/Furthest Collision Point
+    #region Closest/Furthest Intersection Point
     /// <summary>
-    /// Gets the collision point in all entries that is closest to the reference point.
+    /// Gets the intersection point in all entries that is closest to the reference point.
     /// </summary>
     /// <param name="referencePoint">The point to compare distances from.</param>
-    /// <param name="closestDistanceSquared">The squared distance to the closest collision point.</param>
+    /// <param name="closestDistanceSquared">The squared distance to the closest intersection point.</param>
     /// <returns>The closest <see cref="IntersectionPoint"/> or a default value if none exist.</returns>
     public IntersectionPoint GetClosestCollisionPoint(Vector2 referencePoint, out float closestDistanceSquared)
     {
@@ -292,10 +292,10 @@ public class IntersectSpaceRegister : List<IntersectSpaceEntry>
         return closestPoint;
     }
     /// <summary>
-    /// Gets the collision point in all entries that is furthest from the reference point.
+    /// Gets the intersection point in all entries that is furthest from the reference point.
     /// </summary>
     /// <param name="referencePoint">The point to compare distances from.</param>
-    /// <param name="furthestDistanceSquared">The squared distance to the furthest collision point.</param>
+    /// <param name="furthestDistanceSquared">The squared distance to the furthest intersection point.</param>
     /// <returns>The furthest <see cref="IntersectionPoint"/> or a default value if none exist.</returns>
     public IntersectionPoint GetFurthestCollisionPoint(Vector2 referencePoint, out float furthestDistanceSquared)
     {
@@ -320,7 +320,7 @@ public class IntersectSpaceRegister : List<IntersectSpaceEntry>
     
     #region Pointing Towards
     /// <summary>
-    /// Gets the collision point whose normal is most closely facing towards the specified reference point.
+    /// Gets the intersection point whose normal is most closely facing towards the specified reference point.
     /// </summary>
     /// <param name="referencePoint">The point to compare direction against.</param>
     /// <returns>The <see cref="IntersectionPoint"/> facing most towards the reference point, or a default value if none exist.</returns>
@@ -348,7 +348,7 @@ public class IntersectSpaceRegister : List<IntersectSpaceEntry>
         return pointing;
     }
     /// <summary>
-    /// Gets the collision point whose normal is most closely facing towards the specified reference direction.
+    /// Gets the intersection point whose normal is most closely facing towards the specified reference direction.
     /// </summary>
     /// <param name="referenceDirection">The direction to compare against.</param>
     /// <returns>The <see cref="IntersectionPoint"/> facing most towards the reference direction, or a default value if none exist.</returns>
@@ -375,7 +375,7 @@ public class IntersectSpaceRegister : List<IntersectSpaceEntry>
         return pointing;
     }
     /// <summary>
-    /// Gets the collision point whose normal is most closely facing towards the position of the associated collision object.
+    /// Gets the intersection point whose normal is most closely facing towards the position of the associated collision object.
     /// </summary>
     /// <returns>The <see cref="IntersectionPoint"/> facing most towards the object's position.</returns>
     public IntersectionPoint GetCollisionPointFacingTowardsPoint()
@@ -383,7 +383,7 @@ public class IntersectSpaceRegister : List<IntersectSpaceEntry>
         return GetCollisionPointFacingTowardsPoint(OtherCollisionObject.Transform.Position);
     }
     /// <summary>
-    /// Gets the collision point whose normal is most closely facing towards the velocity of the associated collision object.
+    /// Gets the intersection point whose normal is most closely facing towards the velocity of the associated collision object.
     /// </summary>
     /// <returns>The <see cref="IntersectionPoint"/> facing most towards the object's velocity.</returns>
     public IntersectionPoint GetCollisionPointFacingTowardsDir()
@@ -397,8 +397,8 @@ public class IntersectSpaceRegister : List<IntersectSpaceEntry>
     /// <summary>
     /// Validates all entries using the specified reference direction, removing invalid or misaligned collision points.
     /// </summary>
-    /// <param name="referenceDirection">The direction to check collision point normals against.</param>
-    /// <param name="combined">The averaged collision point of all remaining valid points.</param>
+    /// <param name="referenceDirection">The direction to check intersection point normals against.</param>
+    /// <param name="combined">The averaged intersection point of all remaining valid points.</param>
     /// <returns>True if there are valid points remaining; otherwise, false.</returns>
     /// <remarks>
     /// Removes:
@@ -443,9 +443,9 @@ public class IntersectSpaceRegister : List<IntersectSpaceEntry>
     /// <summary>
     /// Validates all entries using the specified reference direction and point, removing invalid or misaligned collision points.
     /// </summary>
-    /// <param name="referenceDirection">The direction to check collision point normals against.</param>
+    /// <param name="referenceDirection">The direction to check intersection point normals against.</param>
     /// <param name="referencePoint">The point to check direction from.</param>
-    /// <param name="combined">The averaged collision point of all remaining valid points.</param>
+    /// <param name="combined">The averaged intersection point of all remaining valid points.</param>
     /// <returns>True if there are valid points remaining; otherwise, false.</returns>
     /// <remarks>
     /// Removes:
@@ -491,10 +491,10 @@ public class IntersectSpaceRegister : List<IntersectSpaceEntry>
     /// <summary>
     /// Validates all entries and provides both the averaged and closest collision points.
     /// </summary>
-    /// <param name="referenceDirection">The direction to check collision point normals against.</param>
+    /// <param name="referenceDirection">The direction to check intersection point normals against.</param>
     /// <param name="referencePoint">The point to check direction from.</param>
-    /// <param name="combined">The averaged collision point of all remaining valid points.</param>
-    /// <param name="closest">The closest collision point to the reference point.</param>
+    /// <param name="combined">The averaged intersection point of all remaining valid points.</param>
+    /// <param name="closest">The closest intersection point to the reference point.</param>
     /// <returns>True if there are valid points remaining; otherwise, false.</returns>
     /// <remarks>
     /// Removes:
@@ -550,8 +550,8 @@ public class IntersectSpaceRegister : List<IntersectSpaceEntry>
     /// Validates all entries using only a reference point, providing the averaged and closest collision points.
     /// </summary>
     /// <param name="referencePoint">The point to check direction from.</param>
-    /// <param name="combined">The averaged collision point of all remaining valid points.</param>
-    /// <param name="closest">The closest collision point to the reference point.</param>
+    /// <param name="combined">The averaged intersection point of all remaining valid points.</param>
+    /// <param name="closest">The closest intersection point to the reference point.</param>
     /// <returns>True if there are valid points remaining; otherwise, false.</returns>
     /// <remarks>
     /// Removes:
@@ -678,7 +678,7 @@ public class IntersectSpaceRegister : List<IntersectSpaceEntry>
     /// <summary>
     /// Validates all entries using both a reference direction and point, providing a detailed validation result.
     /// </summary>
-    /// <param name="referenceDirection">The direction to check collision point normals against.</param>
+    /// <param name="referenceDirection">The direction to check intersection point normals against.</param>
     /// <param name="referencePoint">The point to check direction from.</param>
     /// <param name="validationResult">The result containing combined, closest, furthest, and pointing-towards collision points.</param>
     /// <returns>True if there are valid points remaining; otherwise, false.</returns>
@@ -799,7 +799,7 @@ public class IntersectSpaceRegister : List<IntersectSpaceEntry>
     /// - Uses Object.Velocity as reference direction.
     /// - Uses Object.Transform.Position as reference point.
     /// </summary>
-    /// <param name="validationResult">The result of the combined IntersectionPoint, and the  closest/furthest collision point from the reference point, and the IntersectionPoint with normal facing towards the referencePoint.</param>
+    /// <param name="validationResult">The result of the combined IntersectionPoint, and the  closest/furthest intersection point from the reference point, and the IntersectionPoint with normal facing towards the referencePoint.</param>
     /// <returns>Returns true if there are valid points remaining</returns>
     public bool ValidateByOther(out CollisionPointValidationResult validationResult)
     {

--- a/ShapeEngine/Geometry/CollisionSystem/IntersectSpaceRegister.cs
+++ b/ShapeEngine/Geometry/CollisionSystem/IntersectSpaceRegister.cs
@@ -59,8 +59,8 @@ public class IntersectSpaceRegister : List<IntersectSpaceEntry>
     /// <summary>
     /// Calculates the average collision point and normal from all entries in the register.
     /// </summary>
-    /// <returns>A <see cref="CollisionPoint"/> representing the average point and normal.</returns>
-    public CollisionPoint GetAverageCollisionPoint()
+    /// <returns>A <see cref="IntersectionPoint"/> representing the average point and normal.</returns>
+    public IntersectionPoint GetAverageCollisionPoint()
     {
         var avgPoint = new Vector2();
         var avgNormal = new Vector2();
@@ -70,7 +70,7 @@ public class IntersectSpaceRegister : List<IntersectSpaceEntry>
             avgPoint += sum.Point;
             avgNormal += sum.Normal;
         }
-        return new CollisionPoint(avgPoint / Count, avgNormal.Normalize());
+        return new IntersectionPoint(avgPoint / Count, avgNormal.Normalize());
     }
     #endregion
     
@@ -271,8 +271,8 @@ public class IntersectSpaceRegister : List<IntersectSpaceEntry>
     /// </summary>
     /// <param name="referencePoint">The point to compare distances from.</param>
     /// <param name="closestDistanceSquared">The squared distance to the closest collision point.</param>
-    /// <returns>The closest <see cref="CollisionPoint"/> or a default value if none exist.</returns>
-    public CollisionPoint GetClosestCollisionPoint(Vector2 referencePoint, out float closestDistanceSquared)
+    /// <returns>The closest <see cref="IntersectionPoint"/> or a default value if none exist.</returns>
+    public IntersectionPoint GetClosestCollisionPoint(Vector2 referencePoint, out float closestDistanceSquared)
     {
         closestDistanceSquared = -1;
         if(Count <= 0) return new();
@@ -296,8 +296,8 @@ public class IntersectSpaceRegister : List<IntersectSpaceEntry>
     /// </summary>
     /// <param name="referencePoint">The point to compare distances from.</param>
     /// <param name="furthestDistanceSquared">The squared distance to the furthest collision point.</param>
-    /// <returns>The furthest <see cref="CollisionPoint"/> or a default value if none exist.</returns>
-    public CollisionPoint GetFurthestCollisionPoint(Vector2 referencePoint, out float furthestDistanceSquared)
+    /// <returns>The furthest <see cref="IntersectionPoint"/> or a default value if none exist.</returns>
+    public IntersectionPoint GetFurthestCollisionPoint(Vector2 referencePoint, out float furthestDistanceSquared)
     {
         furthestDistanceSquared = -1;
         if(Count <= 0) return new();
@@ -323,12 +323,12 @@ public class IntersectSpaceRegister : List<IntersectSpaceEntry>
     /// Gets the collision point whose normal is most closely facing towards the specified reference point.
     /// </summary>
     /// <param name="referencePoint">The point to compare direction against.</param>
-    /// <returns>The <see cref="CollisionPoint"/> facing most towards the reference point, or a default value if none exist.</returns>
-    public CollisionPoint GetCollisionPointFacingTowardsPoint(Vector2 referencePoint)
+    /// <returns>The <see cref="IntersectionPoint"/> facing most towards the reference point, or a default value if none exist.</returns>
+    public IntersectionPoint GetCollisionPointFacingTowardsPoint(Vector2 referencePoint)
     {
         if(Count <= 0) return new();
         if(Count == 1) return this[0].GetCollisionPointFacingTowardsPoint(referencePoint);        
-        var pointing  = new CollisionPoint();
+        var pointing  = new IntersectionPoint();
         var maxDot = -1f;
         for (int i = Count - 1; i >= 0; i--)
         {
@@ -351,12 +351,12 @@ public class IntersectSpaceRegister : List<IntersectSpaceEntry>
     /// Gets the collision point whose normal is most closely facing towards the specified reference direction.
     /// </summary>
     /// <param name="referenceDirection">The direction to compare against.</param>
-    /// <returns>The <see cref="CollisionPoint"/> facing most towards the reference direction, or a default value if none exist.</returns>
-    public CollisionPoint GetCollisionPointFacingTowardsDir(Vector2 referenceDirection)
+    /// <returns>The <see cref="IntersectionPoint"/> facing most towards the reference direction, or a default value if none exist.</returns>
+    public IntersectionPoint GetCollisionPointFacingTowardsDir(Vector2 referenceDirection)
     {
         if(Count <= 0) return new();
         if(Count == 1) return this[0].GetCollisionPointFacingTowardsDir(referenceDirection);        
-        var pointing  = new CollisionPoint();
+        var pointing  = new IntersectionPoint();
         var maxDot = -1f;
         for (int i = Count - 1; i >= 0; i--)
         {
@@ -377,16 +377,16 @@ public class IntersectSpaceRegister : List<IntersectSpaceEntry>
     /// <summary>
     /// Gets the collision point whose normal is most closely facing towards the position of the associated collision object.
     /// </summary>
-    /// <returns>The <see cref="CollisionPoint"/> facing most towards the object's position.</returns>
-    public CollisionPoint GetCollisionPointFacingTowardsPoint()
+    /// <returns>The <see cref="IntersectionPoint"/> facing most towards the object's position.</returns>
+    public IntersectionPoint GetCollisionPointFacingTowardsPoint()
     {
         return GetCollisionPointFacingTowardsPoint(OtherCollisionObject.Transform.Position);
     }
     /// <summary>
     /// Gets the collision point whose normal is most closely facing towards the velocity of the associated collision object.
     /// </summary>
-    /// <returns>The <see cref="CollisionPoint"/> facing most towards the object's velocity.</returns>
-    public CollisionPoint GetCollisionPointFacingTowardsDir()
+    /// <returns>The <see cref="IntersectionPoint"/> facing most towards the object's velocity.</returns>
+    public IntersectionPoint GetCollisionPointFacingTowardsDir()
     {
         return GetCollisionPointFacingTowardsDir(OtherCollisionObject.Velocity);
     }
@@ -402,15 +402,15 @@ public class IntersectSpaceRegister : List<IntersectSpaceEntry>
     /// <returns>True if there are valid points remaining; otherwise, false.</returns>
     /// <remarks>
     /// Removes:
-    /// - Invalid <see cref="CollisionPoint"/>s
+    /// - Invalid <see cref="IntersectionPoint"/>s
     /// - Points with normals facing in the same direction as the reference direction
-    /// - Points with normals facing in the opposite direction as the reference point (from CollisionPoint towards the reference point)
+    /// - Points with normals facing in the opposite direction as the reference point (from IntersectionPoint towards the reference point)
     /// </remarks>
-    public bool Validate(Vector2 referenceDirection, out CollisionPoint combined)
+    public bool Validate(Vector2 referenceDirection, out IntersectionPoint combined)
     {
         if (Count <= 0)
         {
-            combined = new CollisionPoint();
+            combined = new IntersectionPoint();
             return false;
         }
         
@@ -420,7 +420,7 @@ public class IntersectSpaceRegister : List<IntersectSpaceEntry>
         for (int i = Count - 1; i >= 0; i--)
         {
             var entry = this[i];
-            var valid = entry.Validate(referenceDirection, out CollisionPoint combinedEntryPoint);
+            var valid = entry.Validate(referenceDirection, out IntersectionPoint combinedEntryPoint);
             if (!valid)
             {
                 RemoveAt(i);
@@ -433,10 +433,10 @@ public class IntersectSpaceRegister : List<IntersectSpaceEntry>
 
         if (Count <= 0)
         {
-            combined = new CollisionPoint();
+            combined = new IntersectionPoint();
             return false;
         }
-        combined = new CollisionPoint(avgPoint / count, avgNormal.Normalize());
+        combined = new IntersectionPoint(avgPoint / count, avgNormal.Normalize());
         
         return true;
     }
@@ -449,15 +449,15 @@ public class IntersectSpaceRegister : List<IntersectSpaceEntry>
     /// <returns>True if there are valid points remaining; otherwise, false.</returns>
     /// <remarks>
     /// Removes:
-    /// - Invalid <see cref="CollisionPoint"/>s
+    /// - Invalid <see cref="IntersectionPoint"/>s
     /// - Points with normals facing in the same direction as the reference direction
-    /// - Points with normals facing in the opposite direction as the reference point (from CollisionPoint towards the reference point)
+    /// - Points with normals facing in the opposite direction as the reference point (from IntersectionPoint towards the reference point)
     /// </remarks>
-    public bool Validate(Vector2 referenceDirection, Vector2 referencePoint, out CollisionPoint combined)
+    public bool Validate(Vector2 referenceDirection, Vector2 referencePoint, out IntersectionPoint combined)
     {
         if (Count <= 0)
         {
-            combined = new CollisionPoint();
+            combined = new IntersectionPoint();
             return false;
         }
         
@@ -468,7 +468,7 @@ public class IntersectSpaceRegister : List<IntersectSpaceEntry>
         {
             var entry = this[i];
             // var valid = entry.ValidateSelf(out var combinedEntryPoint, out var closestToEntry);
-            var valid = entry.Validate(referenceDirection, referencePoint, out CollisionPoint combinedEntryPoint);
+            var valid = entry.Validate(referenceDirection, referencePoint, out IntersectionPoint combinedEntryPoint);
             if (!valid)
             {
                 RemoveAt(i);
@@ -481,11 +481,11 @@ public class IntersectSpaceRegister : List<IntersectSpaceEntry>
         
         if (Count <= 0)
         {
-            combined = new CollisionPoint();
+            combined = new IntersectionPoint();
             return false;
         }
         
-        combined = new CollisionPoint(avgPoint / count, avgNormal.Normalize());
+        combined = new IntersectionPoint(avgPoint / count, avgNormal.Normalize());
         return true;
     }
     /// <summary>
@@ -498,29 +498,29 @@ public class IntersectSpaceRegister : List<IntersectSpaceEntry>
     /// <returns>True if there are valid points remaining; otherwise, false.</returns>
     /// <remarks>
     /// Removes:
-    /// - Invalid <see cref="CollisionPoint"/>s
+    /// - Invalid <see cref="IntersectionPoint"/>s
     /// - Points with normals facing in the same direction as the reference direction
-    /// - Points with normals facing in the opposite direction as the reference point (from CollisionPoint towards the reference point)
+    /// - Points with normals facing in the opposite direction as the reference point (from IntersectionPoint towards the reference point)
     /// </remarks>
-    public bool Validate(Vector2 referenceDirection, Vector2 referencePoint, out CollisionPoint combined, out CollisionPoint closest)
+    public bool Validate(Vector2 referenceDirection, Vector2 referencePoint, out IntersectionPoint combined, out IntersectionPoint closest)
     {
         if (Count <= 0)
         {
-            combined = new CollisionPoint();
-            closest = new CollisionPoint();
+            combined = new IntersectionPoint();
+            closest = new IntersectionPoint();
             return false;
         }
         
         var avgPoint = new Vector2();
         var avgNormal = new Vector2();
-        closest  = new CollisionPoint();
+        closest  = new IntersectionPoint();
         var closestDistanceSquared = -1f;
         var count = 0;
         for (int i = Count - 1; i >= 0; i--)
         {
             var entry = this[i];
             // var valid = entry.ValidateSelf(out var combinedEntryPoint, out var closestToEntry);
-            var valid = entry.Validate(referenceDirection, referencePoint, out CollisionPoint combinedEntryPoint, out CollisionPoint closestToEntry);
+            var valid = entry.Validate(referenceDirection, referencePoint, out IntersectionPoint combinedEntryPoint, out IntersectionPoint closestToEntry);
             if (!valid)
             {
                 RemoveAt(i);
@@ -539,11 +539,11 @@ public class IntersectSpaceRegister : List<IntersectSpaceEntry>
         
         if (Count <= 0)
         {
-            combined = new CollisionPoint();
+            combined = new IntersectionPoint();
             return false;
         }
         
-        combined = new CollisionPoint(avgPoint / count, avgNormal.Normalize());
+        combined = new IntersectionPoint(avgPoint / count, avgNormal.Normalize());
         return true;
     }
     /// <summary>
@@ -555,22 +555,22 @@ public class IntersectSpaceRegister : List<IntersectSpaceEntry>
     /// <returns>True if there are valid points remaining; otherwise, false.</returns>
     /// <remarks>
     /// Removes:
-    /// - Invalid <see cref="CollisionPoint"/>s
+    /// - Invalid <see cref="IntersectionPoint"/>s
     /// - Points with normals facing in the same direction as the reference direction
-    /// - Points with normals facing in the opposite direction as the reference point (from CollisionPoint towards the reference point)
+    /// - Points with normals facing in the opposite direction as the reference point (from IntersectionPoint towards the reference point)
     /// </remarks>
-    public bool Validate(Vector2 referencePoint, out CollisionPoint combined, out CollisionPoint closest)
+    public bool Validate(Vector2 referencePoint, out IntersectionPoint combined, out IntersectionPoint closest)
     {
         if (Count <= 0)
         {
-            combined = new CollisionPoint();
-            closest = new CollisionPoint();
+            combined = new IntersectionPoint();
+            closest = new IntersectionPoint();
             return false;
         }
         
         var avgPoint = new Vector2();
         var avgNormal = new Vector2();
-        closest  = new CollisionPoint();
+        closest  = new IntersectionPoint();
         var closestDistanceSquared = -1f;
         var count = 0;
         for (int i = Count - 1; i >= 0; i--)
@@ -595,11 +595,11 @@ public class IntersectSpaceRegister : List<IntersectSpaceEntry>
         
         if (Count <= 0)
         {
-            combined = new CollisionPoint();
+            combined = new IntersectionPoint();
             return false;
         }
         
-        combined = new CollisionPoint(avgPoint / count, avgNormal.Normalize());
+        combined = new IntersectionPoint(avgPoint / count, avgNormal.Normalize());
         return true;
     }
     /// <summary>
@@ -610,9 +610,9 @@ public class IntersectSpaceRegister : List<IntersectSpaceEntry>
     /// <returns>True if there are valid points remaining; otherwise, false.</returns>
     /// <remarks>
     /// Removes:
-    /// - Invalid <see cref="CollisionPoint"/>s
+    /// - Invalid <see cref="IntersectionPoint"/>s
     /// - Points with normals facing in the same direction as the reference direction
-    /// - Points with normals facing in the opposite direction as the reference point (from CollisionPoint towards the reference point)
+    /// - Points with normals facing in the opposite direction as the reference point (from IntersectionPoint towards the reference point)
     /// </remarks>
     public bool Validate(Vector2 referencePoint, out CollisionPointValidationResult validationResult)
     {
@@ -624,9 +624,9 @@ public class IntersectSpaceRegister : List<IntersectSpaceEntry>
         
         var avgPoint = new Vector2();
         var avgNormal = new Vector2();
-        var closest  = new CollisionPoint();
-        var furthest  = new CollisionPoint();
-        var pointing  = new CollisionPoint();
+        var closest  = new IntersectionPoint();
+        var furthest  = new IntersectionPoint();
+        var pointing  = new IntersectionPoint();
         var maxDot = -1f;
         var closestDistanceSquared = -1f;
         var furthestDistanceSquared = -1f;
@@ -671,7 +671,7 @@ public class IntersectSpaceRegister : List<IntersectSpaceEntry>
             return false;
         }
         
-        var combined = new CollisionPoint(avgPoint / count, avgNormal.Normalize());
+        var combined = new IntersectionPoint(avgPoint / count, avgNormal.Normalize());
         validationResult = new CollisionPointValidationResult(combined, closest, furthest, pointing);
         return true;
     }
@@ -684,9 +684,9 @@ public class IntersectSpaceRegister : List<IntersectSpaceEntry>
     /// <returns>True if there are valid points remaining; otherwise, false.</returns>
     /// <remarks>
     /// Removes:
-    /// - Invalid <see cref="CollisionPoint"/>s
+    /// - Invalid <see cref="IntersectionPoint"/>s
     /// - Points with normals facing in the same direction as the reference direction
-    /// - Points with normals facing in the opposite direction as the reference point (from CollisionPoint towards the reference point)
+    /// - Points with normals facing in the opposite direction as the reference point (from IntersectionPoint towards the reference point)
     /// </remarks>
     public bool Validate(Vector2 referenceDirection, Vector2 referencePoint, out CollisionPointValidationResult validationResult)
     {
@@ -698,9 +698,9 @@ public class IntersectSpaceRegister : List<IntersectSpaceEntry>
         
         var avgPoint = new Vector2();
         var avgNormal = new Vector2();
-        var closest  = new CollisionPoint();
-        var furthest  = new CollisionPoint();
-        var pointing  = new CollisionPoint();
+        var closest  = new IntersectionPoint();
+        var furthest  = new IntersectionPoint();
+        var pointing  = new IntersectionPoint();
         var maxDot = -1f;
         var closestDistanceSquared = -1f;
         var furthestDistanceSquared = -1f;
@@ -744,7 +744,7 @@ public class IntersectSpaceRegister : List<IntersectSpaceEntry>
             return false;
         }
         
-        var combined = new CollisionPoint(avgPoint / count, avgNormal.Normalize());
+        var combined = new IntersectionPoint(avgPoint / count, avgNormal.Normalize());
         validationResult = new CollisionPointValidationResult(combined, closest, furthest, pointing);
         return true;
     }
@@ -752,20 +752,20 @@ public class IntersectSpaceRegister : List<IntersectSpaceEntry>
     
     /// <summary>
     /// Removes:
-    /// - invalid CollisionPoints
-    /// - CollisionPoints with normals facing in the same direction as the reference direction
-    /// - CollisionPoints with normals facing in the opposite direction as the reference point (from CollisionPoint towards the reference point)
+    /// - invalid IntersectionPoints
+    /// - IntersectionPoints with normals facing in the same direction as the reference direction
+    /// - IntersectionPoints with normals facing in the opposite direction as the reference point (from IntersectionPoint towards the reference point)
     /// - Uses Object.Velocity as reference direction.
     /// - Uses Object.Transform.Position as reference point.
     /// </summary>
-    /// <param name="combined">An averaged CollisionPoint of all remaining CollisionPoints of all entries.</param>
-    /// <param name="closest">The CollisionPoint that is closest to the referencePoint.</param>
+    /// <param name="combined">An averaged IntersectionPoint of all remaining IntersectionPoints of all entries.</param>
+    /// <param name="closest">The IntersectionPoint that is closest to the referencePoint.</param>
     /// <returns>Returns true if there are valid points remaining</returns>
-    public bool ValidateByOther(out CollisionPoint combined, out CollisionPoint closest)
+    public bool ValidateByOther(out IntersectionPoint combined, out IntersectionPoint closest)
     {
         var avgPoint = new Vector2();
         var avgNormal = new Vector2();
-        closest  = new CollisionPoint();
+        closest  = new IntersectionPoint();
         var closestDistanceSquared = -1f;
         var count = 0;
         for (int i = Count - 1; i >= 0; i--)
@@ -788,26 +788,26 @@ public class IntersectSpaceRegister : List<IntersectSpaceEntry>
                 closest = closestToEntry;
             }
         }
-        combined = new CollisionPoint(avgPoint / count, avgNormal.Normalize());
+        combined = new IntersectionPoint(avgPoint / count, avgNormal.Normalize());
         return true;
     }
     /// <summary>
     /// Removes:
-    /// - invalid CollisionPoints
-    /// - CollisionPoints with normals facing in the same direction as the reference direction
-    /// - CollisionPoints with normals facing in the opposite direction as the reference point (from CollisionPoint towards the reference point)
+    /// - invalid IntersectionPoints
+    /// - IntersectionPoints with normals facing in the same direction as the reference direction
+    /// - IntersectionPoints with normals facing in the opposite direction as the reference point (from IntersectionPoint towards the reference point)
     /// - Uses Object.Velocity as reference direction.
     /// - Uses Object.Transform.Position as reference point.
     /// </summary>
-    /// <param name="validationResult">The result of the combined CollisionPoint, and the  closest/furthest collision point from the reference point, and the CollisionPoint with normal facing towards the referencePoint.</param>
+    /// <param name="validationResult">The result of the combined IntersectionPoint, and the  closest/furthest collision point from the reference point, and the IntersectionPoint with normal facing towards the referencePoint.</param>
     /// <returns>Returns true if there are valid points remaining</returns>
     public bool ValidateByOther(out CollisionPointValidationResult validationResult)
     {
         var avgPoint = new Vector2();
         var avgNormal = new Vector2();
-        var closest  = new CollisionPoint();
-        var furthest  = new CollisionPoint();
-        var pointing  = new CollisionPoint();
+        var closest  = new IntersectionPoint();
+        var furthest  = new IntersectionPoint();
+        var pointing  = new IntersectionPoint();
         var maxDot = -1f;
         var closestDistanceSquared = -1f;
         var furthestDistanceSquared = -1f;
@@ -845,7 +845,7 @@ public class IntersectSpaceRegister : List<IntersectSpaceEntry>
              furthest = result.Furthest;
             }
         }
-        var combined = new CollisionPoint(avgPoint / count, avgNormal.Normalize());
+        var combined = new IntersectionPoint(avgPoint / count, avgNormal.Normalize());
         validationResult = new CollisionPointValidationResult(combined, closest, furthest, pointing);
         return true;
     }

--- a/ShapeEngine/Geometry/CollisionSystem/IntersectSpaceResult.cs
+++ b/ShapeEngine/Geometry/CollisionSystem/IntersectSpaceResult.cs
@@ -155,15 +155,15 @@ public class IntersectSpaceResult : List<IntersectSpaceRegister>
     /// <returns>True if there are valid points remaining; otherwise, false.</returns>
     /// <remarks>
     /// Removes:
-    /// - Invalid <see cref="CollisionPoint"/>s
+    /// - Invalid <see cref="IntersectionPoint"/>s
     /// - Points with normals facing in the same direction as the reference direction
     /// - Points with normals facing in the opposite direction as the reference point
     /// </remarks>
-    public bool Validate(Vector2 referenceDirection, out CollisionPoint combined)
+    public bool Validate(Vector2 referenceDirection, out IntersectionPoint combined)
     {
         if (Count <= 0)
         {
-            combined = new CollisionPoint();
+            combined = new IntersectionPoint();
             return false;
         }
         
@@ -173,7 +173,7 @@ public class IntersectSpaceResult : List<IntersectSpaceRegister>
         for (int i = Count - 1; i >= 0; i--)
         {
             var register = this[i];
-            var valid = register.Validate(referenceDirection, out CollisionPoint combinedEntryPoint);
+            var valid = register.Validate(referenceDirection, out IntersectionPoint combinedEntryPoint);
             if (!valid)
             {
                 RemoveAt(i);
@@ -186,10 +186,10 @@ public class IntersectSpaceResult : List<IntersectSpaceRegister>
 
         if (Count <= 0)
         {
-            combined = new CollisionPoint();
+            combined = new IntersectionPoint();
             return false;
         }
-        combined = new CollisionPoint(avgPoint / count, avgNormal.Normalize());
+        combined = new IntersectionPoint(avgPoint / count, avgNormal.Normalize());
         
         return true;
     }
@@ -202,15 +202,15 @@ public class IntersectSpaceResult : List<IntersectSpaceRegister>
     /// <returns>True if there are valid points remaining; otherwise, false.</returns>
     /// <remarks>
     /// Removes:
-    /// - Invalid <see cref="CollisionPoint"/>s
+    /// - Invalid <see cref="IntersectionPoint"/>s
     /// - Points with normals facing in the same direction as the reference direction
     /// - Points with normals facing in the opposite direction as the reference point
     /// </remarks>
-    public bool Validate(Vector2 referenceDirection, Vector2 referencePoint, out CollisionPoint combined)
+    public bool Validate(Vector2 referenceDirection, Vector2 referencePoint, out IntersectionPoint combined)
     {
         if (Count <= 0)
         {
-            combined = new CollisionPoint();
+            combined = new IntersectionPoint();
             return false;
         }
         
@@ -220,7 +220,7 @@ public class IntersectSpaceResult : List<IntersectSpaceRegister>
         for (int i = Count - 1; i >= 0; i--)
         {
             var register = this[i];
-            var valid = register.Validate(referenceDirection, referencePoint, out CollisionPoint combinedEntryPoint);
+            var valid = register.Validate(referenceDirection, referencePoint, out IntersectionPoint combinedEntryPoint);
             if (!valid)
             {
                 RemoveAt(i);
@@ -233,11 +233,11 @@ public class IntersectSpaceResult : List<IntersectSpaceRegister>
         
         if (Count <= 0)
         {
-            combined = new CollisionPoint();
+            combined = new IntersectionPoint();
             return false;
         }
         
-        combined = new CollisionPoint(avgPoint / count, avgNormal.Normalize());
+        combined = new IntersectionPoint(avgPoint / count, avgNormal.Normalize());
         return true;
     }
     /// <summary>
@@ -250,22 +250,22 @@ public class IntersectSpaceResult : List<IntersectSpaceRegister>
     /// <returns>True if there are valid points remaining; otherwise, false.</returns>
     /// <remarks>
     /// Removes:
-    /// - Invalid <see cref="CollisionPoint"/>s
+    /// - Invalid <see cref="IntersectionPoint"/>s
     /// - Points with normals facing in the same direction as the reference direction
     /// - Points with normals facing in the opposite direction as the reference point
     /// </remarks>
-    public bool Validate(Vector2 referenceDirection, Vector2 referencePoint, out CollisionPoint combined, out CollisionPoint closest)
+    public bool Validate(Vector2 referenceDirection, Vector2 referencePoint, out IntersectionPoint combined, out IntersectionPoint closest)
     {
         if (Count <= 0)
         {
-            combined = new CollisionPoint();
-            closest = new CollisionPoint();
+            combined = new IntersectionPoint();
+            closest = new IntersectionPoint();
             return false;
         }
         
         var avgPoint = new Vector2();
         var avgNormal = new Vector2();
-        closest  = new CollisionPoint();
+        closest  = new IntersectionPoint();
         var closestDistanceSquared = -1f;
         var count = 0;
         for (int i = Count - 1; i >= 0; i--)
@@ -291,11 +291,11 @@ public class IntersectSpaceResult : List<IntersectSpaceRegister>
         
         if (Count <= 0)
         {
-            combined = new CollisionPoint();
+            combined = new IntersectionPoint();
             return false;
         }
         
-        combined = new CollisionPoint(avgPoint / count, avgNormal.Normalize());
+        combined = new IntersectionPoint(avgPoint / count, avgNormal.Normalize());
         return true;
     }
     /// <summary>
@@ -307,22 +307,22 @@ public class IntersectSpaceResult : List<IntersectSpaceRegister>
     /// <returns>True if there are valid points remaining; otherwise, false.</returns>
     /// <remarks>
     /// Removes:
-    /// - Invalid <see cref="CollisionPoint"/>s
+    /// - Invalid <see cref="IntersectionPoint"/>s
     /// - Points with normals facing in the same direction as the reference direction
     /// - Points with normals facing in the opposite direction as the reference point
     /// </remarks>
-    public bool Validate(Vector2 referencePoint, out CollisionPoint combined, out CollisionPoint closest)
+    public bool Validate(Vector2 referencePoint, out IntersectionPoint combined, out IntersectionPoint closest)
     {
         if (Count <= 0)
         {
-            combined = new CollisionPoint();
-            closest = new CollisionPoint();
+            combined = new IntersectionPoint();
+            closest = new IntersectionPoint();
             return false;
         }
         
         var avgPoint = new Vector2();
         var avgNormal = new Vector2();
-        closest  = new CollisionPoint();
+        closest  = new IntersectionPoint();
         var closestDistanceSquared = -1f;
         var count = 0;
         for (int i = Count - 1; i >= 0; i--)
@@ -347,11 +347,11 @@ public class IntersectSpaceResult : List<IntersectSpaceRegister>
         
         if (Count <= 0)
         {
-            combined = new CollisionPoint();
+            combined = new IntersectionPoint();
             return false;
         }
         
-        combined = new CollisionPoint(avgPoint / count, avgNormal.Normalize());
+        combined = new IntersectionPoint(avgPoint / count, avgNormal.Normalize());
         return true;
     }
     /// <summary>
@@ -362,7 +362,7 @@ public class IntersectSpaceResult : List<IntersectSpaceRegister>
     /// <returns>True if there are valid points remaining; otherwise, false.</returns>
     /// <remarks>
     /// Removes:
-    /// - Invalid <see cref="CollisionPoint"/>s
+    /// - Invalid <see cref="IntersectionPoint"/>s
     /// - Points with normals facing in the same direction as the reference direction
     /// - Points with normals facing in the opposite direction as the reference point
     /// </remarks>
@@ -376,9 +376,9 @@ public class IntersectSpaceResult : List<IntersectSpaceRegister>
         
         var avgPoint = new Vector2();
         var avgNormal = new Vector2();
-        var closest  = new CollisionPoint();
-        var furthest  = new CollisionPoint();
-        var pointing  = new CollisionPoint();
+        var closest  = new IntersectionPoint();
+        var furthest  = new IntersectionPoint();
+        var pointing  = new IntersectionPoint();
         var maxDot = -1f;
         var closestDistanceSquared = -1f;
         var furthestDistanceSquared = -1f;
@@ -423,7 +423,7 @@ public class IntersectSpaceResult : List<IntersectSpaceRegister>
             return false;
         }
         
-        var combined = new CollisionPoint(avgPoint / count, avgNormal.Normalize());
+        var combined = new IntersectionPoint(avgPoint / count, avgNormal.Normalize());
         validationResult = new CollisionPointValidationResult(combined, closest, furthest, pointing);
         return true;
     }
@@ -436,7 +436,7 @@ public class IntersectSpaceResult : List<IntersectSpaceRegister>
     /// <returns>True if there are valid points remaining; otherwise, false.</returns>
     /// <remarks>
     /// Removes:
-    /// - Invalid <see cref="CollisionPoint"/>s
+    /// - Invalid <see cref="IntersectionPoint"/>s
     /// - Points with normals facing in the same direction as the reference direction
     /// - Points with normals facing in the opposite direction as the reference point
     /// </remarks>
@@ -450,9 +450,9 @@ public class IntersectSpaceResult : List<IntersectSpaceRegister>
         
         var avgPoint = new Vector2();
         var avgNormal = new Vector2();
-        var closest  = new CollisionPoint();
-        var furthest  = new CollisionPoint();
-        var pointing  = new CollisionPoint();
+        var closest  = new IntersectionPoint();
+        var furthest  = new IntersectionPoint();
+        var pointing  = new IntersectionPoint();
         var maxDot = -1f;
         var closestDistanceSquared = -1f;
         var furthestDistanceSquared = -1f;
@@ -496,7 +496,7 @@ public class IntersectSpaceResult : List<IntersectSpaceRegister>
             return false;
         }
         
-        var combined = new CollisionPoint(avgPoint / count, avgNormal.Normalize());
+        var combined = new IntersectionPoint(avgPoint / count, avgNormal.Normalize());
         validationResult = new CollisionPointValidationResult(combined, closest, furthest, pointing);
         return true;
     }
@@ -776,8 +776,8 @@ public class IntersectSpaceResult : List<IntersectSpaceRegister>
     /// Gets the collision point in all registers that is closest to the origin.
     /// </summary>
     /// <param name="closestDistanceSquared">The squared distance to the closest collision point.</param>
-    /// <returns>The closest <see cref="CollisionPoint"/> or a default value if none exist.</returns>
-    public CollisionPoint GetClosestCollisionPoint(out float closestDistanceSquared)
+    /// <returns>The closest <see cref="IntersectionPoint"/> or a default value if none exist.</returns>
+    public IntersectionPoint GetClosestCollisionPoint(out float closestDistanceSquared)
     {
         closestDistanceSquared = -1;
         if (Count <= 0) return new();
@@ -788,8 +788,8 @@ public class IntersectSpaceResult : List<IntersectSpaceRegister>
     /// </summary>
     /// <param name="position">The point to compare distances from.</param>
     /// <param name="closestDistanceSquared">The squared distance to the closest collision point.</param>
-    /// <returns>The closest <see cref="CollisionPoint"/> or a default value if none exist.</returns>
-    public CollisionPoint GetClosestCollisionPoint(Vector2 position, out float closestDistanceSquared)
+    /// <returns>The closest <see cref="IntersectionPoint"/> or a default value if none exist.</returns>
+    public IntersectionPoint GetClosestCollisionPoint(Vector2 position, out float closestDistanceSquared)
     {
         closestDistanceSquared = -1;
         if (Count <= 0) return new();
@@ -815,8 +815,8 @@ public class IntersectSpaceResult : List<IntersectSpaceRegister>
     /// Gets the collision point in all registers that is furthest from the origin.
     /// </summary>
     /// <param name="furthestDistanceSquared">The squared distance to the furthest collision point.</param>
-    /// <returns>The furthest <see cref="CollisionPoint"/> or a default value if none exist.</returns>
-    public CollisionPoint GetFurthestCollisionPoint(out float furthestDistanceSquared)
+    /// <returns>The furthest <see cref="IntersectionPoint"/> or a default value if none exist.</returns>
+    public IntersectionPoint GetFurthestCollisionPoint(out float furthestDistanceSquared)
     {
         furthestDistanceSquared = -1;
         if (Count <= 0) return new();
@@ -827,8 +827,8 @@ public class IntersectSpaceResult : List<IntersectSpaceRegister>
     /// </summary>
     /// <param name="position">The point to compare distances from.</param>
     /// <param name="furthestDistanceSquared">The squared distance to the furthest collision point.</param>
-    /// <returns>The furthest <see cref="CollisionPoint"/> or a default value if none exist.</returns>
-    public CollisionPoint GetFurthestCollisionPoint(Vector2 position, out float furthestDistanceSquared)
+    /// <returns>The furthest <see cref="IntersectionPoint"/> or a default value if none exist.</returns>
+    public IntersectionPoint GetFurthestCollisionPoint(Vector2 position, out float furthestDistanceSquared)
     {
         furthestDistanceSquared = -1;
         if (Count <= 0) return new();
@@ -857,12 +857,12 @@ public class IntersectSpaceResult : List<IntersectSpaceRegister>
     /// Gets the collision point whose normal is most closely facing towards the specified reference point.
     /// </summary>
     /// <param name="referencePoint">The point to compare direction against.</param>
-    /// <returns>The <see cref="CollisionPoint"/> facing most towards the reference point, or a default value if none exist.</returns>
-    public CollisionPoint GetCollisionPointFacingTowardsPoint(Vector2 referencePoint)
+    /// <returns>The <see cref="IntersectionPoint"/> facing most towards the reference point, or a default value if none exist.</returns>
+    public IntersectionPoint GetCollisionPointFacingTowardsPoint(Vector2 referencePoint)
     {
      if(Count <= 0) return new();
      if(Count == 1) return this[0].GetCollisionPointFacingTowardsPoint(referencePoint);        
-     var pointing  = new CollisionPoint();
+     var pointing  = new IntersectionPoint();
      var maxDot = -1f;
      for (int i = Count - 1; i >= 0; i--)
      {
@@ -885,12 +885,12 @@ public class IntersectSpaceResult : List<IntersectSpaceRegister>
     /// Gets the collision point whose normal is most closely facing towards the specified reference direction.
     /// </summary>
     /// <param name="referenceDirection">The direction to compare against.</param>
-    /// <returns>The <see cref="CollisionPoint"/> facing most towards the reference direction, or a default value if none exist.</returns>
-    public CollisionPoint GetCollisionPointFacingTowardsDir(Vector2 referenceDirection)
+    /// <returns>The <see cref="IntersectionPoint"/> facing most towards the reference direction, or a default value if none exist.</returns>
+    public IntersectionPoint GetCollisionPointFacingTowardsDir(Vector2 referenceDirection)
     {
      if(Count <= 0) return new();
      if(Count == 1) return this[0].GetCollisionPointFacingTowardsDir(referenceDirection);        
-     var pointing  = new CollisionPoint();
+     var pointing  = new IntersectionPoint();
      var maxDot = -1f;
      for (int i = Count - 1; i >= 0; i--)
      {
@@ -911,8 +911,8 @@ public class IntersectSpaceResult : List<IntersectSpaceRegister>
     /// <summary>
     /// Gets the collision point whose normal is most closely facing towards the origin.
     /// </summary>
-    /// <returns>The <see cref="CollisionPoint"/> facing most towards the origin.</returns>
-    public CollisionPoint GetCollisionPointFacingTowardsOrigin()
+    /// <returns>The <see cref="IntersectionPoint"/> facing most towards the origin.</returns>
+    public IntersectionPoint GetCollisionPointFacingTowardsOrigin()
     {
      return GetCollisionPointFacingTowardsPoint(Origin);
     }

--- a/ShapeEngine/Geometry/CollisionSystem/IntersectSpaceResult.cs
+++ b/ShapeEngine/Geometry/CollisionSystem/IntersectSpaceResult.cs
@@ -150,8 +150,8 @@ public class IntersectSpaceResult : List<IntersectSpaceRegister>
     /// <summary>
     /// Validates all registers using the specified reference direction, removing invalid or misaligned collision points.
     /// </summary>
-    /// <param name="referenceDirection">The direction to check collision point normals against.</param>
-    /// <param name="combined">The averaged collision point of all remaining valid points.</param>
+    /// <param name="referenceDirection">The direction to check intersection point normals against.</param>
+    /// <param name="combined">The averaged intersection point of all remaining valid points.</param>
     /// <returns>True if there are valid points remaining; otherwise, false.</returns>
     /// <remarks>
     /// Removes:
@@ -196,9 +196,9 @@ public class IntersectSpaceResult : List<IntersectSpaceRegister>
     /// <summary>
     /// Validates all registers using the specified reference direction and point, removing invalid or misaligned collision points.
     /// </summary>
-    /// <param name="referenceDirection">The direction to check collision point normals against.</param>
+    /// <param name="referenceDirection">The direction to check intersection point normals against.</param>
     /// <param name="referencePoint">The point to check direction from.</param>
-    /// <param name="combined">The averaged collision point of all remaining valid points.</param>
+    /// <param name="combined">The averaged intersection point of all remaining valid points.</param>
     /// <returns>True if there are valid points remaining; otherwise, false.</returns>
     /// <remarks>
     /// Removes:
@@ -243,10 +243,10 @@ public class IntersectSpaceResult : List<IntersectSpaceRegister>
     /// <summary>
     /// Validates all registers and provides both the averaged and closest collision points.
     /// </summary>
-    /// <param name="referenceDirection">The direction to check collision point normals against.</param>
+    /// <param name="referenceDirection">The direction to check intersection point normals against.</param>
     /// <param name="referencePoint">The point to check direction from.</param>
-    /// <param name="combined">The averaged collision point of all remaining valid points.</param>
-    /// <param name="closest">The closest collision point to the reference point.</param>
+    /// <param name="combined">The averaged intersection point of all remaining valid points.</param>
+    /// <param name="closest">The closest intersection point to the reference point.</param>
     /// <returns>True if there are valid points remaining; otherwise, false.</returns>
     /// <remarks>
     /// Removes:
@@ -302,8 +302,8 @@ public class IntersectSpaceResult : List<IntersectSpaceRegister>
     /// Validates all registers using only a reference point, providing the averaged and closest collision points.
     /// </summary>
     /// <param name="referencePoint">The point to check direction from.</param>
-    /// <param name="combined">The averaged collision point of all remaining valid points.</param>
-    /// <param name="closest">The closest collision point to the reference point.</param>
+    /// <param name="combined">The averaged intersection point of all remaining valid points.</param>
+    /// <param name="closest">The closest intersection point to the reference point.</param>
     /// <returns>True if there are valid points remaining; otherwise, false.</returns>
     /// <remarks>
     /// Removes:
@@ -430,7 +430,7 @@ public class IntersectSpaceResult : List<IntersectSpaceRegister>
     /// <summary>
     /// Validates all registers using both a reference direction and point, providing a detailed validation result.
     /// </summary>
-    /// <param name="referenceDirection">The direction to check collision point normals against.</param>
+    /// <param name="referenceDirection">The direction to check intersection point normals against.</param>
     /// <param name="referencePoint">The point to check direction from.</param>
     /// <param name="validationResult">The result containing combined, closest, furthest, and pointing-towards collision points.</param>
     /// <returns>True if there are valid points remaining; otherwise, false.</returns>
@@ -773,9 +773,9 @@ public class IntersectSpaceResult : List<IntersectSpaceRegister>
     
     #region Closest/Furthest Collision Points
     /// <summary>
-    /// Gets the collision point in all registers that is closest to the origin.
+    /// Gets the intersection point in all registers that is closest to the origin.
     /// </summary>
-    /// <param name="closestDistanceSquared">The squared distance to the closest collision point.</param>
+    /// <param name="closestDistanceSquared">The squared distance to the closest intersection point.</param>
     /// <returns>The closest <see cref="IntersectionPoint"/> or a default value if none exist.</returns>
     public IntersectionPoint GetClosestCollisionPoint(out float closestDistanceSquared)
     {
@@ -784,10 +784,10 @@ public class IntersectSpaceResult : List<IntersectSpaceRegister>
         return GetClosestCollisionPoint(Origin, out closestDistanceSquared);
     }
     /// <summary>
-    /// Gets the collision point in all registers that is closest to the specified position.
+    /// Gets the intersection point in all registers that is closest to the specified position.
     /// </summary>
     /// <param name="position">The point to compare distances from.</param>
-    /// <param name="closestDistanceSquared">The squared distance to the closest collision point.</param>
+    /// <param name="closestDistanceSquared">The squared distance to the closest intersection point.</param>
     /// <returns>The closest <see cref="IntersectionPoint"/> or a default value if none exist.</returns>
     public IntersectionPoint GetClosestCollisionPoint(Vector2 position, out float closestDistanceSquared)
     {
@@ -812,9 +812,9 @@ public class IntersectSpaceResult : List<IntersectSpaceRegister>
         return closestPoint;
     }
     /// <summary>
-    /// Gets the collision point in all registers that is furthest from the origin.
+    /// Gets the intersection point in all registers that is furthest from the origin.
     /// </summary>
-    /// <param name="furthestDistanceSquared">The squared distance to the furthest collision point.</param>
+    /// <param name="furthestDistanceSquared">The squared distance to the furthest intersection point.</param>
     /// <returns>The furthest <see cref="IntersectionPoint"/> or a default value if none exist.</returns>
     public IntersectionPoint GetFurthestCollisionPoint(out float furthestDistanceSquared)
     {
@@ -823,10 +823,10 @@ public class IntersectSpaceResult : List<IntersectSpaceRegister>
         return GetFurthestCollisionPoint(Origin, out furthestDistanceSquared);
     }
     /// <summary>
-    /// Gets the collision point in all registers that is furthest from the specified position.
+    /// Gets the intersection point in all registers that is furthest from the specified position.
     /// </summary>
     /// <param name="position">The point to compare distances from.</param>
-    /// <param name="furthestDistanceSquared">The squared distance to the furthest collision point.</param>
+    /// <param name="furthestDistanceSquared">The squared distance to the furthest intersection point.</param>
     /// <returns>The furthest <see cref="IntersectionPoint"/> or a default value if none exist.</returns>
     public IntersectionPoint GetFurthestCollisionPoint(Vector2 position, out float furthestDistanceSquared)
     {
@@ -854,7 +854,7 @@ public class IntersectSpaceResult : List<IntersectSpaceRegister>
     
     #region Point Towards
     /// <summary>
-    /// Gets the collision point whose normal is most closely facing towards the specified reference point.
+    /// Gets the intersection point whose normal is most closely facing towards the specified reference point.
     /// </summary>
     /// <param name="referencePoint">The point to compare direction against.</param>
     /// <returns>The <see cref="IntersectionPoint"/> facing most towards the reference point, or a default value if none exist.</returns>
@@ -882,7 +882,7 @@ public class IntersectSpaceResult : List<IntersectSpaceRegister>
      return pointing;
     }
     /// <summary>
-    /// Gets the collision point whose normal is most closely facing towards the specified reference direction.
+    /// Gets the intersection point whose normal is most closely facing towards the specified reference direction.
     /// </summary>
     /// <param name="referenceDirection">The direction to compare against.</param>
     /// <returns>The <see cref="IntersectionPoint"/> facing most towards the reference direction, or a default value if none exist.</returns>
@@ -909,7 +909,7 @@ public class IntersectSpaceResult : List<IntersectSpaceRegister>
      return pointing;
     }
     /// <summary>
-    /// Gets the collision point whose normal is most closely facing towards the origin.
+    /// Gets the intersection point whose normal is most closely facing towards the origin.
     /// </summary>
     /// <returns>The <see cref="IntersectionPoint"/> facing most towards the origin.</returns>
     public IntersectionPoint GetCollisionPointFacingTowardsOrigin()

--- a/ShapeEngine/Geometry/CollisionSystem/IntersectionPoint.cs
+++ b/ShapeEngine/Geometry/CollisionSystem/IntersectionPoint.cs
@@ -7,7 +7,7 @@ using ShapeEngine.StaticLib;
 namespace ShapeEngine.Geometry.CollisionSystem;
 
 /// <summary>
-/// Represents a single collision point, including its position and normal vector.
+/// Represents a single intersection point, including its position and normal vector.
 /// </summary>
 /// <remarks>
 /// Provides utility methods for combining, comparing, and manipulating collision points and their normals.
@@ -16,15 +16,15 @@ public readonly struct IntersectionPoint : IEquatable<IntersectionPoint>
 {
     #region Members
     /// <summary>
-    /// Gets whether this collision point is valid (normal is not zero).
+    /// Gets whether this intersection point is valid (normal is not zero).
     /// </summary>
     public bool Valid => Normal.X != 0f || Normal.Y != 0f;
     /// <summary>
-    /// The position of the collision point.
+    /// The position of the intersection point.
     /// </summary>
     public readonly Vector2 Point;
     /// <summary>
-    /// The normal vector at the collision point.
+    /// The normal vector at the intersection point.
     /// </summary>
     public readonly Vector2 Normal;
 
@@ -44,8 +44,8 @@ public readonly struct IntersectionPoint : IEquatable<IntersectionPoint>
     /// <summary>
     /// Initializes a new instance of the <see cref="IntersectionPoint"/> struct with the specified point and normal.
     /// </summary>
-    /// <param name="p">The position of the collision point.</param>
-    /// <param name="n">The normal vector at the collision point.</param>
+    /// <param name="p">The position of the intersection point.</param>
+    /// <param name="n">The normal vector at the intersection point.</param>
     public IntersectionPoint(Vector2 p, Vector2 n)
     {
         Point = p; 
@@ -56,26 +56,26 @@ public readonly struct IntersectionPoint : IEquatable<IntersectionPoint>
     
     #region Public Functions
     /// <summary>
-    /// Gets a segment representing the normal at this collision point.
+    /// Gets a segment representing the normal at this intersection point.
     /// </summary>
     /// <param name="length">The length of the segment.</param>
-    /// <returns>A segment from the collision point in the direction of the normal.</returns>
+    /// <returns>A segment from the intersection point in the direction of the normal.</returns>
     public Segment GetNormalSegment(float length) => new Segment(Point, Point + Normal * length);
     /// <summary>
-    /// Gets a ray representing the normal at this collision point.
+    /// Gets a ray representing the normal at this intersection point.
     /// </summary>
-    /// <returns>A ray from the collision point in the direction of the normal.</returns>
+    /// <returns>A ray from the intersection point in the direction of the normal.</returns>
     public Ray GetNormalRay() => new Ray(Point, Normal);
     /// <summary>
-    /// Gets a line representing the normal at this collision point.
+    /// Gets a line representing the normal at this intersection point.
     /// </summary>
-    /// <returns>A line from the collision point in the direction of the normal.</returns>
+    /// <returns>A line from the intersection point in the direction of the normal.</returns>
     public Line GetNormalLine() => new Line(Point, Normal);
     
     /// <summary>
-    /// Determines if this collision point is closer to the reference point than the current minimum distance squared.
+    /// Determines if this intersection point is closer to the reference point than the current minimum distance squared.
     /// </summary>
-    /// <param name="p">The collision point to check.</param>
+    /// <param name="p">The intersection point to check.</param>
     /// <param name="referencePoint">The reference point.</param>
     /// <param name="curMinDisSquared">The current minimum distance squared.</param>
     /// <param name="newMinDisSquared">The new minimum distance squared, if this point is closer.</param>
@@ -93,9 +93,9 @@ public readonly struct IntersectionPoint : IEquatable<IntersectionPoint>
         return false;
     }
     /// <summary>
-    /// Determines if this collision point is further from the reference point than the current maximum distance squared.
+    /// Determines if this intersection point is further from the reference point than the current maximum distance squared.
     /// </summary>
-    /// <param name="p">The collision point to check.</param>
+    /// <param name="p">The intersection point to check.</param>
     /// <param name="referencePoint">The reference point.</param>
     /// <param name="curMaxDisSquared">The current maximum distance squared.</param>
     /// <param name="newMaxDisSquared">The new maximum distance squared, if this point is further.</param>
@@ -114,9 +114,9 @@ public readonly struct IntersectionPoint : IEquatable<IntersectionPoint>
     }
 
     /// <summary>
-    /// Returns true if the reference direction is pointing in the same direction as the normal of the collision point. Dot values greater than 0 mean pointing towards.
+    /// Returns true if the reference direction is pointing in the same direction as the normal of the intersection point. Dot values greater than 0 mean pointing towards.
     /// </summary>
-    /// <param name="p">The collision point to check.</param>
+    /// <param name="p">The intersection point to check.</param>
     /// <param name="referenceDir">The reference direction to check against.</param>
     /// <param name="curDot">The cur maximum dot value from the previous collision points. If 0 returns true automatically with the new dot.</param>
     /// <param name="newDot">The new maximum dot value. If the normal of p is pointing more in the same direction of the reference direction than cur dot suggests. </param>
@@ -134,9 +134,9 @@ public readonly struct IntersectionPoint : IEquatable<IntersectionPoint>
         return false;
     }
     /// <summary>
-    /// Returns true if the reference direction is pointing in the opposite  direction as the normal of the collision point. Dot values smaller than 0 mean pointing away.
+    /// Returns true if the reference direction is pointing in the opposite  direction as the normal of the intersection point. Dot values smaller than 0 mean pointing away.
     /// </summary>
-    /// <param name="p">The collision point to check.</param>
+    /// <param name="p">The intersection point to check.</param>
     /// <param name="referenceDir">The reference direction to check against.</param>
     /// <param name="curDot">The cur minimum dot value from the previous collision points. If 0 return true automatically with the new dot.</param>
     /// <param name="newDot">The new minimum dot value. If the normal from p is pointing more in the opposite direction of the reference direction than cur dot suggests.</param>
@@ -154,25 +154,25 @@ public readonly struct IntersectionPoint : IEquatable<IntersectionPoint>
         return false;
     }
     /// <summary>
-    /// Combines this collision point with another by averaging their positions and normals.
+    /// Combines this intersection point with another by averaging their positions and normals.
     /// </summary>
-    /// <param name="other">The other collision point to combine with.</param>
-    /// <returns>A new collision point representing the combination of this point and the other.</returns>
+    /// <param name="other">The other intersection point to combine with.</param>
+    /// <returns>A new intersection point representing the combination of this point and the other.</returns>
     public IntersectionPoint Combine(IntersectionPoint other) => new((Point + other.Point) / 2, (Normal + other.Normal).Normalize());
     
     /// <summary>
     /// Static method to combine two collision points by averaging their positions and normals.
     /// </summary>
-    /// <param name="a">The first collision point.</param>
-    /// <param name="b">The second collision point.</param>
-    /// <returns>A new collision point representing the combination of the two points.</returns>
+    /// <param name="a">The first intersection point.</param>
+    /// <param name="b">The second intersection point.</param>
+    /// <returns>A new intersection point representing the combination of the two points.</returns>
     public static IntersectionPoint Combine(IntersectionPoint a, IntersectionPoint b) => new((a.Point + b.Point) / 2, (a.Normal + b.Normal).Normalize());
 
     /// <summary>
     /// Static method to combine multiple collision points by averaging their positions and normals.
     /// </summary>
     /// <param name="points">The array of collision points to combine.</param>
-    /// <returns>A new collision point representing the combination of all provided points.</returns>
+    /// <returns>A new intersection point representing the combination of all provided points.</returns>
     public static IntersectionPoint Combine(params IntersectionPoint[] points)
     {
         if(points.Length == 0) return new();
@@ -187,36 +187,36 @@ public readonly struct IntersectionPoint : IEquatable<IntersectionPoint>
     }
     
     /// <summary>
-    /// Checks for equality with another collision point.
+    /// Checks for equality with another intersection point.
     /// </summary>
-    /// <param name="other">The other collision point to compare with.</param>
+    /// <param name="other">The other intersection point to compare with.</param>
     /// <returns>True if the points and normals are equal, false otherwise.</returns>
     public bool Equals(IntersectionPoint other)
     {
         return other.Point == Point && other.Normal == Normal;
     }
     /// <summary>
-    /// Gets the hash code for this collision point.
+    /// Gets the hash code for this intersection point.
     /// </summary>
-    /// <returns>A hash code representing this collision point.</returns>
+    /// <returns>A hash code representing this intersection point.</returns>
     public override int GetHashCode()
     {
         return HashCode.Combine(Point, Normal);
     }
 
     /// <summary>
-    /// Flips the normal of the collision point, keeping the position the same.
+    /// Flips the normal of the intersection point, keeping the position the same.
     /// </summary>
-    /// <returns>A new collision point with the normal flipped.</returns>
+    /// <returns>A new intersection point with the normal flipped.</returns>
     public IntersectionPoint FlipNormal()
     {
         return new(Point, Normal.Flip());
     }
     /// <summary>
-    /// Flips the normal of the collision point if the direction to the reference point is facing the opposite way of the normal.
+    /// Flips the normal of the intersection point if the direction to the reference point is facing the opposite way of the normal.
     /// </summary>
     /// <param name="referencePoint">The reference point to check the direction against.</param>
-    /// <returns>This collision point if the normal is not facing the opposite direction of the reference point, otherwise a new collision point with the normal flipped.</returns>
+    /// <returns>This intersection point if the normal is not facing the opposite direction of the reference point, otherwise a new intersection point with the normal flipped.</returns>
     public IntersectionPoint FlipNormal(Vector2 referencePoint)
     {
         Vector2 dir = referencePoint - Point;
@@ -243,31 +243,31 @@ public readonly struct IntersectionPoint : IEquatable<IntersectionPoint>
     #region Math
 
     /// <summary>
-    /// Rotates the normal of the collision point by the given angle in radians.
+    /// Rotates the normal of the intersection point by the given angle in radians.
     /// </summary>
     /// <param name="angleRad">The angle in radians to rotate the normal.</param>
-    /// <returns>A new collision point with the normal rotated by the given angle.</returns>
+    /// <returns>A new intersection point with the normal rotated by the given angle.</returns>
     public IntersectionPoint RotateNormal(float angleRad) => !Valid ? this : new(Point, Normal.Rotate(angleRad));
 
     /// <summary>
-    /// Rotates the normal of the collision point by the given angle in degrees.
+    /// Rotates the normal of the intersection point by the given angle in degrees.
     /// </summary>
     /// <param name="angleDeg">The angle in degrees to rotate the normal.</param>
-    /// <returns>A new collision point with the normal rotated by the given angle.</returns>
+    /// <returns>A new intersection point with the normal rotated by the given angle.</returns>
     public IntersectionPoint RotateNormalDeg(float angleDeg) => !Valid ? this : new(Point, Normal.Rotate(angleDeg * ShapeMath.DEGTORAD));
 
     /// <summary>
-    /// Sets a new point for the collision point, keeping the normal the same.
+    /// Sets a new point for the intersection point, keeping the normal the same.
     /// </summary>
-    /// <param name="newPoint">The new position for the collision point.</param>
-    /// <returns>A new collision point with the updated position.</returns>
+    /// <param name="newPoint">The new position for the intersection point.</param>
+    /// <returns>A new intersection point with the updated position.</returns>
     public IntersectionPoint SetPoint(Vector2 newPoint) => new(newPoint, Normal);
 
     /// <summary>
-    /// Sets a new normal for the collision point.
+    /// Sets a new normal for the intersection point.
     /// </summary>
-    /// <param name="newNormal">The new normal vector for the collision point.</param>
-    /// <returns>A new collision point with the updated normal.</returns>
+    /// <param name="newNormal">The new normal vector for the intersection point.</param>
+    /// <returns>A new intersection point with the updated normal.</returns>
     public IntersectionPoint SetNormal(Vector2 newNormal) => new(Point, newNormal.Normalize());
 
     #endregion

--- a/ShapeEngine/Geometry/CollisionSystem/IntersectionPoint.cs
+++ b/ShapeEngine/Geometry/CollisionSystem/IntersectionPoint.cs
@@ -12,7 +12,7 @@ namespace ShapeEngine.Geometry.CollisionSystem;
 /// <remarks>
 /// Provides utility methods for combining, comparing, and manipulating collision points and their normals.
 /// </remarks>
-public readonly struct CollisionPoint : IEquatable<CollisionPoint>
+public readonly struct IntersectionPoint : IEquatable<IntersectionPoint>
 {
     #region Members
     /// <summary>
@@ -33,20 +33,20 @@ public readonly struct CollisionPoint : IEquatable<CollisionPoint>
     #region Constructors
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="CollisionPoint"/> struct with default values (zero point and zero normal).
+    /// Initializes a new instance of the <see cref="IntersectionPoint"/> struct with default values (zero point and zero normal).
     /// </summary>
-    public CollisionPoint() 
+    public IntersectionPoint() 
     { 
         Point = new(); 
         Normal = new();
     }
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="CollisionPoint"/> struct with the specified point and normal.
+    /// Initializes a new instance of the <see cref="IntersectionPoint"/> struct with the specified point and normal.
     /// </summary>
     /// <param name="p">The position of the collision point.</param>
     /// <param name="n">The normal vector at the collision point.</param>
-    public CollisionPoint(Vector2 p, Vector2 n)
+    public IntersectionPoint(Vector2 p, Vector2 n)
     {
         Point = p; 
         Normal = n;
@@ -80,7 +80,7 @@ public readonly struct CollisionPoint : IEquatable<CollisionPoint>
     /// <param name="curMinDisSquared">The current minimum distance squared.</param>
     /// <param name="newMinDisSquared">The new minimum distance squared, if this point is closer.</param>
     /// <returns>True if this point is closer, false otherwise.</returns>
-    public static bool IsCloser(CollisionPoint p, Vector2 referencePoint, float curMinDisSquared, out float newMinDisSquared)
+    public static bool IsCloser(IntersectionPoint p, Vector2 referencePoint, float curMinDisSquared, out float newMinDisSquared)
     {
         var disSquared = (p.Point - referencePoint).LengthSquared();
         if (disSquared < curMinDisSquared || curMinDisSquared < 0)
@@ -100,7 +100,7 @@ public readonly struct CollisionPoint : IEquatable<CollisionPoint>
     /// <param name="curMaxDisSquared">The current maximum distance squared.</param>
     /// <param name="newMaxDisSquared">The new maximum distance squared, if this point is further.</param>
     /// <returns>True if this point is further away, false otherwise.</returns>
-    public static bool IsFurther(CollisionPoint p, Vector2 referencePoint, float curMaxDisSquared, out float newMaxDisSquared)
+    public static bool IsFurther(IntersectionPoint p, Vector2 referencePoint, float curMaxDisSquared, out float newMaxDisSquared)
     {
         var disSquared = (p.Point - referencePoint).LengthSquared();
         if (disSquared > curMaxDisSquared || curMaxDisSquared < 0)
@@ -121,7 +121,7 @@ public readonly struct CollisionPoint : IEquatable<CollisionPoint>
     /// <param name="curDot">The cur maximum dot value from the previous collision points. If 0 returns true automatically with the new dot.</param>
     /// <param name="newDot">The new maximum dot value. If the normal of p is pointing more in the same direction of the reference direction than cur dot suggests. </param>
     /// <returns></returns>
-    public static bool IsPointingTowards(CollisionPoint p, Vector2 referenceDir, float curDot, out float newDot)
+    public static bool IsPointingTowards(IntersectionPoint p, Vector2 referenceDir, float curDot, out float newDot)
     {
         var dot = p.Normal.Dot(referenceDir);
         if (dot > curDot || curDot == 0f)
@@ -141,7 +141,7 @@ public readonly struct CollisionPoint : IEquatable<CollisionPoint>
     /// <param name="curDot">The cur minimum dot value from the previous collision points. If 0 return true automatically with the new dot.</param>
     /// <param name="newDot">The new minimum dot value. If the normal from p is pointing more in the opposite direction of the reference direction than cur dot suggests.</param>
     /// <returns></returns>
-    public static bool IsPointingAway(CollisionPoint p, Vector2 referenceDir, float curDot, out float newDot)
+    public static bool IsPointingAway(IntersectionPoint p, Vector2 referenceDir, float curDot, out float newDot)
     {
         var dot = p.Normal.Dot(referenceDir);
         if (dot < curDot || curDot == 0f)
@@ -158,7 +158,7 @@ public readonly struct CollisionPoint : IEquatable<CollisionPoint>
     /// </summary>
     /// <param name="other">The other collision point to combine with.</param>
     /// <returns>A new collision point representing the combination of this point and the other.</returns>
-    public CollisionPoint Combine(CollisionPoint other) => new((Point + other.Point) / 2, (Normal + other.Normal).Normalize());
+    public IntersectionPoint Combine(IntersectionPoint other) => new((Point + other.Point) / 2, (Normal + other.Normal).Normalize());
     
     /// <summary>
     /// Static method to combine two collision points by averaging their positions and normals.
@@ -166,14 +166,14 @@ public readonly struct CollisionPoint : IEquatable<CollisionPoint>
     /// <param name="a">The first collision point.</param>
     /// <param name="b">The second collision point.</param>
     /// <returns>A new collision point representing the combination of the two points.</returns>
-    public static CollisionPoint Combine(CollisionPoint a, CollisionPoint b) => new((a.Point + b.Point) / 2, (a.Normal + b.Normal).Normalize());
+    public static IntersectionPoint Combine(IntersectionPoint a, IntersectionPoint b) => new((a.Point + b.Point) / 2, (a.Normal + b.Normal).Normalize());
 
     /// <summary>
     /// Static method to combine multiple collision points by averaging their positions and normals.
     /// </summary>
     /// <param name="points">The array of collision points to combine.</param>
     /// <returns>A new collision point representing the combination of all provided points.</returns>
-    public static CollisionPoint Combine(params CollisionPoint[] points)
+    public static IntersectionPoint Combine(params IntersectionPoint[] points)
     {
         if(points.Length == 0) return new();
         var avgPoint = Vector2.Zero;
@@ -191,7 +191,7 @@ public readonly struct CollisionPoint : IEquatable<CollisionPoint>
     /// </summary>
     /// <param name="other">The other collision point to compare with.</param>
     /// <returns>True if the points and normals are equal, false otherwise.</returns>
-    public bool Equals(CollisionPoint other)
+    public bool Equals(IntersectionPoint other)
     {
         return other.Point == Point && other.Normal == Normal;
     }
@@ -208,7 +208,7 @@ public readonly struct CollisionPoint : IEquatable<CollisionPoint>
     /// Flips the normal of the collision point, keeping the position the same.
     /// </summary>
     /// <returns>A new collision point with the normal flipped.</returns>
-    public CollisionPoint FlipNormal()
+    public IntersectionPoint FlipNormal()
     {
         return new(Point, Normal.Flip());
     }
@@ -217,7 +217,7 @@ public readonly struct CollisionPoint : IEquatable<CollisionPoint>
     /// </summary>
     /// <param name="referencePoint">The reference point to check the direction against.</param>
     /// <returns>This collision point if the normal is not facing the opposite direction of the reference point, otherwise a new collision point with the normal flipped.</returns>
-    public CollisionPoint FlipNormal(Vector2 referencePoint)
+    public IntersectionPoint FlipNormal(Vector2 referencePoint)
     {
         Vector2 dir = referencePoint - Point;
         if (dir.IsFacingTheOppositeDirection(Normal)) return FlipNormal();
@@ -247,28 +247,28 @@ public readonly struct CollisionPoint : IEquatable<CollisionPoint>
     /// </summary>
     /// <param name="angleRad">The angle in radians to rotate the normal.</param>
     /// <returns>A new collision point with the normal rotated by the given angle.</returns>
-    public CollisionPoint RotateNormal(float angleRad) => !Valid ? this : new(Point, Normal.Rotate(angleRad));
+    public IntersectionPoint RotateNormal(float angleRad) => !Valid ? this : new(Point, Normal.Rotate(angleRad));
 
     /// <summary>
     /// Rotates the normal of the collision point by the given angle in degrees.
     /// </summary>
     /// <param name="angleDeg">The angle in degrees to rotate the normal.</param>
     /// <returns>A new collision point with the normal rotated by the given angle.</returns>
-    public CollisionPoint RotateNormalDeg(float angleDeg) => !Valid ? this : new(Point, Normal.Rotate(angleDeg * ShapeMath.DEGTORAD));
+    public IntersectionPoint RotateNormalDeg(float angleDeg) => !Valid ? this : new(Point, Normal.Rotate(angleDeg * ShapeMath.DEGTORAD));
 
     /// <summary>
     /// Sets a new point for the collision point, keeping the normal the same.
     /// </summary>
     /// <param name="newPoint">The new position for the collision point.</param>
     /// <returns>A new collision point with the updated position.</returns>
-    public CollisionPoint SetPoint(Vector2 newPoint) => new(newPoint, Normal);
+    public IntersectionPoint SetPoint(Vector2 newPoint) => new(newPoint, Normal);
 
     /// <summary>
     /// Sets a new normal for the collision point.
     /// </summary>
     /// <param name="newNormal">The new normal vector for the collision point.</param>
     /// <returns>A new collision point with the updated normal.</returns>
-    public CollisionPoint SetNormal(Vector2 newNormal) => new(Point, newNormal.Normalize());
+    public IntersectionPoint SetNormal(Vector2 newNormal) => new(Point, newNormal.Normalize());
 
     #endregion
     
@@ -280,7 +280,7 @@ public readonly struct CollisionPoint : IEquatable<CollisionPoint>
     /// <param name="a"></param>
     /// <param name="b"></param>
     /// <returns></returns>
-    public static CollisionPoint operator +(CollisionPoint a, CollisionPoint b)
+    public static IntersectionPoint operator +(IntersectionPoint a, IntersectionPoint b)
     {
         return new(a.Point + b.Point, (a.Normal + b.Normal).Normalize());
     }
@@ -291,7 +291,7 @@ public readonly struct CollisionPoint : IEquatable<CollisionPoint>
     /// <param name="a"></param>
     /// <param name="b"></param>
     /// <returns></returns>
-    public static CollisionPoint operator -(CollisionPoint a, CollisionPoint b)
+    public static IntersectionPoint operator -(IntersectionPoint a, IntersectionPoint b)
     {
         return new(a.Point - b.Point, (a.Normal - b.Normal).Normalize());
     }
@@ -302,7 +302,7 @@ public readonly struct CollisionPoint : IEquatable<CollisionPoint>
     /// <param name="a"></param>
     /// <param name="scalar"></param>
     /// <returns></returns>
-    public static CollisionPoint operator *(CollisionPoint a, float scalar)
+    public static IntersectionPoint operator *(IntersectionPoint a, float scalar)
     {
         return new(a.Point * scalar, a.Normal);
     }
@@ -313,7 +313,7 @@ public readonly struct CollisionPoint : IEquatable<CollisionPoint>
     /// <param name="a"></param>
     /// <param name="scalar"></param>
     /// <returns></returns>
-    public static CollisionPoint operator /(CollisionPoint a, float scalar)
+    public static IntersectionPoint operator /(IntersectionPoint a, float scalar)
     {
         return new(a.Point / scalar, a.Normal);
     }
@@ -324,7 +324,7 @@ public readonly struct CollisionPoint : IEquatable<CollisionPoint>
     /// <param name="a"></param>
     /// <param name="b"></param>
     /// <returns></returns>
-    public static CollisionPoint operator +(CollisionPoint a, Vector2  b)
+    public static IntersectionPoint operator +(IntersectionPoint a, Vector2  b)
     {
         return new(a.Point + b, a.Normal);
     }
@@ -335,7 +335,7 @@ public readonly struct CollisionPoint : IEquatable<CollisionPoint>
     /// <param name="a"></param>
     /// <param name="b"></param>
     /// <returns></returns>
-    public static CollisionPoint operator -(CollisionPoint a, Vector2  b)
+    public static IntersectionPoint operator -(IntersectionPoint a, Vector2  b)
     {
         return new(a.Point - b, a.Normal);
     }
@@ -346,7 +346,7 @@ public readonly struct CollisionPoint : IEquatable<CollisionPoint>
     /// <param name="a"></param>
     /// <param name="b"></param>
     /// <returns></returns>
-    public static CollisionPoint operator *(CollisionPoint a, Vector2 b)
+    public static IntersectionPoint operator *(IntersectionPoint a, Vector2 b)
     {
         return new(a.Point * b, a.Normal);
     }
@@ -357,11 +357,39 @@ public readonly struct CollisionPoint : IEquatable<CollisionPoint>
     /// <param name="a"></param>
     /// <param name="b"></param>
     /// <returns></returns>
-    public static CollisionPoint operator /(CollisionPoint a, Vector2 b)
+    public static IntersectionPoint operator /(IntersectionPoint a, Vector2 b)
     {
         return new(a.Point / b, a.Normal);
     }
-    
-    
+
+    /// <inheritdoc />
+    public override bool Equals(object? obj)
+    {
+        return obj is IntersectionPoint point && Equals(point);
+    }
+
+    /// <summary>
+    /// Determines whether two <see cref="IntersectionPoint"/> instances are equal by comparing their points and normals.
+    /// </summary>
+    /// <param name="left">The first <see cref="IntersectionPoint"/> to compare.</param>
+    /// <param name="right">The second <see cref="IntersectionPoint"/> to compare.</param>
+    /// <returns>True if both the point and normal are equal; otherwise, false.</returns>
+    public static bool operator ==(IntersectionPoint left, IntersectionPoint right)
+    {
+        return left.Equals(right);
+    }
+
+    /// <summary>
+    /// Determines whether two <see cref="IntersectionPoint"/> instances are not equal by comparing their points and normals.
+    /// </summary>
+    /// <param name="left">The first <see cref="IntersectionPoint"/> to compare.</param>
+    /// <param name="right">The second <see cref="IntersectionPoint"/> to compare.</param>
+    /// <returns>True if either the point or normal are not equal; otherwise, false.</returns>
+    public static bool operator !=(IntersectionPoint left, IntersectionPoint right)
+    {
+        return !(left == right);
+    }
+
+
     #endregion
 }

--- a/ShapeEngine/Geometry/CollisionSystem/IntersectionPoints.cs
+++ b/ShapeEngine/Geometry/CollisionSystem/IntersectionPoints.cs
@@ -51,11 +51,11 @@ public class IntersectionPoints : ShapeList<IntersectionPoint>
 
     #region Members
     /// <summary>
-    /// Gets the first collision point in the list, or an empty <see cref="IntersectionPoint"/> if the list is empty.
+    /// Gets the first intersection point in the list, or an empty <see cref="IntersectionPoint"/> if the list is empty.
     /// </summary>
     public IntersectionPoint First => Count > 0 ? this[0] : new IntersectionPoint();
     /// <summary>
-    /// Gets the last collision point in the list, or an empty <see cref="IntersectionPoint"/> if the list is empty.
+    /// Gets the last intersection point in the list, or an empty <see cref="IntersectionPoint"/> if the list is empty.
     /// </summary>
     public IntersectionPoint Last => Count > 0 ? this[Count - 1] : new IntersectionPoint();
     /// <summary>
@@ -288,7 +288,7 @@ public class IntersectionPoints : ShapeList<IntersectionPoint>
     /// </summary>
     /// <param name="referenceDirection">The direction to check IntersectionPoint normals against.</param>
     /// <param name="referencePoint">The direction from the reference point towards to IntersectionPoint  to check IntersectionPoint Normals against.</param>
-    /// <param name="validationResult">The result of the combined IntersectionPoint, and the  closest/furthest collision point from the reference point, and the IntersectionPoint with normal facing towards the referencePoint.</param>
+    /// <param name="validationResult">The result of the combined IntersectionPoint, and the  closest/furthest intersection point from the reference point, and the IntersectionPoint with normal facing towards the referencePoint.</param>
     /// <returns>Returns true if there are valid points remaining</returns>
     public bool Validate(Vector2 referenceDirection, Vector2 referencePoint,  out CollisionPointValidationResult validationResult)
     {
@@ -433,7 +433,7 @@ public class IntersectionPoints : ShapeList<IntersectionPoint>
     /// Removes all invalid <see cref="IntersectionPoint"/> instances from the list.
     /// </summary>
     /// <param name="referencePoint">The direction from the reference point towards to IntersectionPoint  to check IntersectionPoint Normals against.</param>
-    /// <param name="validationResult">The result of the combined IntersectionPoint, and the  closest/furthest collision point from the reference point, and the IntersectionPoint with normal facing towards the referencePoint.</param>
+    /// <param name="validationResult">The result of the combined IntersectionPoint, and the  closest/furthest intersection point from the reference point, and the IntersectionPoint with normal facing towards the referencePoint.</param>
     /// <returns>Returns true if there are valid points remaining</returns>
     public bool Validate(Vector2 referencePoint,  out CollisionPointValidationResult validationResult)
     {
@@ -591,11 +591,11 @@ public class IntersectionPoints : ShapeList<IntersectionPoint>
     #region IntersectionPoint
     /// <summary>
     /// Filters the IntersectionPoints list based on a given filter type and reference point.
-    /// PointingTowards and PointingAway calculate the direction from the collision point to the reference point.
-    /// PointingTowards uses the normal that is facing the same direction as the direction from the collision point to the reference point.
-    /// PointingAway uses the normal that is facing the opposite direction as the direction from the collision point to the reference point.
+    /// PointingTowards and PointingAway calculate the direction from the intersection point to the reference point.
+    /// PointingTowards uses the normal that is facing the same direction as the direction from the intersection point to the reference point.
+    /// PointingAway uses the normal that is facing the opposite direction as the direction from the intersection point to the reference point.
     /// </summary>
-    /// <param name="filterType">The filter type for selecting a collision point.</param>
+    /// <param name="filterType">The filter type for selecting a intersection point.</param>
     /// <param name="referencePoint">The reference point that is used for closest, furthest, pointing towards, and pointing away calculations.</param>
     /// <returns></returns>
     public IntersectionPoint Filter(CollisionPointsFilterType filterType, Vector2 referencePoint = new())
@@ -680,7 +680,7 @@ public class IntersectionPoints : ShapeList<IntersectionPoint>
     /// PointingTowards uses the Normal that is facing the same direction as the referenceDirection.
     /// PointingAway uses the Normal that is facing the opposite direction as the reference direction.
     /// </summary>
-    /// <param name="filterType">The filter type for selecting a collision point.</param>
+    /// <param name="filterType">The filter type for selecting a intersection point.</param>
     /// <param name="referencePoint">The reference point that is used for closest and furthest calculations.</param>
     /// <param name="referenceDirection">The reference direction that is used for pointing towards and pointing away calculations.</param>
     /// <returns></returns>
@@ -724,7 +724,7 @@ public class IntersectionPoints : ShapeList<IntersectionPoint>
     }
     
     /// <summary>
-    /// Gets the combined collision point, averaging the position and normal of all valid collision points.
+    /// Gets the combined intersection point, averaging the position and normal of all valid collision points.
     /// </summary>
     /// <returns>The combined IntersectionPoint.</returns>
     public IntersectionPoint GetCombinedCollisionPoint()
@@ -743,7 +743,7 @@ public class IntersectionPoints : ShapeList<IntersectionPoint>
         return new(avgPoint / count, avgNormal.Normalize());
     }
     /// <summary>
-    /// Gets the closest collision point to the specified reference point.
+    /// Gets the closest intersection point to the specified reference point.
     /// </summary>
     /// <param name="referencePoint">The reference point to measure distance against.</param>
     /// <returns>The closest IntersectionPoint.</returns>
@@ -769,7 +769,7 @@ public class IntersectionPoints : ShapeList<IntersectionPoint>
         return closest;
     }
     /// <summary>
-    /// Gets the furthest collision point from the specified reference point.
+    /// Gets the furthest intersection point from the specified reference point.
     /// </summary>
     /// <param name="referencePoint">The reference point to measure distance against.</param>
     /// <returns>The furthest IntersectionPoint.</returns>
@@ -795,7 +795,7 @@ public class IntersectionPoints : ShapeList<IntersectionPoint>
         return furthest;
     }
     /// <summary>
-    /// Gets the closest collision point to the specified reference point, and outputs the distance squared to that point.
+    /// Gets the closest intersection point to the specified reference point, and outputs the distance squared to that point.
     /// </summary>
     /// <param name="referencePoint">The reference point to measure distance against.</param>
     /// <param name="closestDistanceSquared">The distance squared to the closest IntersectionPoint.</param>
@@ -823,7 +823,7 @@ public class IntersectionPoints : ShapeList<IntersectionPoint>
         return closest;
     }
     /// <summary>
-    /// Gets the furthest collision point from the specified reference point, and outputs the distance squared to that point.
+    /// Gets the furthest intersection point from the specified reference point, and outputs the distance squared to that point.
     /// </summary>
     /// <param name="referencePoint">The reference point to measure distance against.</param>
     /// <param name="furthestDistanceSquared">The distance squared to the furthest IntersectionPoint.</param>
@@ -851,7 +851,7 @@ public class IntersectionPoints : ShapeList<IntersectionPoint>
     }
 
     /// <summary>
-    /// Finds the <see cref="IntersectionPoint"/> whose normal most closely faces the direction from the collision point to the specified reference point.
+    /// Finds the <see cref="IntersectionPoint"/> whose normal most closely faces the direction from the intersection point to the specified reference point.
     /// Calculates the dot product between each normal and the direction vector to the reference point, returning the point with the highest value.
     /// </summary>
     /// <param name="referencePoint">The point to which normals should be compared.</param>
@@ -883,7 +883,7 @@ public class IntersectionPoints : ShapeList<IntersectionPoint>
     /// <summary>
     /// Finds the <see cref="IntersectionPoint"/> whose normal most closely aligns with the specified reference direction.
     /// </summary>
-    /// <param name="referenceDir">The direction to compare against each collision point's normal.</param>
+    /// <param name="referenceDir">The direction to compare against each intersection point's normal.</param>
     /// <returns>The <see cref="IntersectionPoint"/> with the most aligned normal, or an empty point if none are valid.</returns>
     public IntersectionPoint GetCollisionPointFacingTowardsDir(Vector2 referenceDir)
     {

--- a/ShapeEngine/Geometry/CollisionSystem/IntersectionPoints.cs
+++ b/ShapeEngine/Geometry/CollisionSystem/IntersectionPoints.cs
@@ -7,43 +7,43 @@ using ShapeEngine.StaticLib;
 namespace ShapeEngine.Geometry.CollisionSystem;
 
 /// <summary>
-/// Represents a list of <see cref="CollisionPoint"/>s, providing validation, filtering, and sorting utilities for collision detection.
+/// Represents a list of <see cref="IntersectionPoint"/>s, providing validation, filtering, and sorting utilities for collision detection.
 /// </summary>
 /// <remarks>
 /// Used to aggregate, validate, and process multiple collision points resulting from shape intersections.
 /// </remarks>
-public class CollisionPoints : ShapeList<CollisionPoint>
+public class IntersectionPoints : ShapeList<IntersectionPoint>
 {
     #region Constructors
     /// <summary>
-    /// Initializes a new instance of the <see cref="CollisionPoints"/> class with an optional capacity.
+    /// Initializes a new instance of the <see cref="IntersectionPoints"/> class with an optional capacity.
     /// </summary>
     /// <param name="capacity">The initial capacity of the list.</param>
-    public CollisionPoints(int capacity = 0) : base(capacity)
+    public IntersectionPoints(int capacity = 0) : base(capacity)
     {
         
     }
     /// <summary>
-    /// Initializes a new instance of the <see cref="CollisionPoints"/> class with the specified points.
+    /// Initializes a new instance of the <see cref="IntersectionPoints"/> class with the specified points.
     /// </summary>
     /// <param name="points">The collision points to add.</param>
-    public CollisionPoints(params CollisionPoint[] points) : base(points.Length) { AddRange(points); }
+    public IntersectionPoints(params IntersectionPoint[] points) : base(points.Length) { AddRange(points); }
     /// <summary>
-    /// Initializes a new instance of the <see cref="CollisionPoints"/> class from an enumerable and count.
+    /// Initializes a new instance of the <see cref="IntersectionPoints"/> class from an enumerable and count.
     /// </summary>
     /// <param name="points">The collision points to add.</param>
     /// <param name="count">The number of points to add.</param>
-    public CollisionPoints(IEnumerable<CollisionPoint> points, int count) : base(count)  { AddRange(points); }
+    public IntersectionPoints(IEnumerable<IntersectionPoint> points, int count) : base(count)  { AddRange(points); }
     /// <summary>
-    /// Initializes a new instance of the <see cref="CollisionPoints"/> class from a list of points.
+    /// Initializes a new instance of the <see cref="IntersectionPoints"/> class from a list of points.
     /// </summary>
     /// <param name="points">The collision points to add.</param>
-    public CollisionPoints(List<CollisionPoint> points) : base(points.Count)  { AddRange(points); }
+    public IntersectionPoints(List<IntersectionPoint> points) : base(points.Count)  { AddRange(points); }
     /// <summary>
-    /// Initializes a new instance of the <see cref="CollisionPoints"/> class by copying another <see cref="CollisionPoints"/>.
+    /// Initializes a new instance of the <see cref="IntersectionPoints"/> class by copying another <see cref="IntersectionPoints"/>.
     /// </summary>
-    /// <param name="other">The <see cref="CollisionPoints"/> to copy.</param>
-    public CollisionPoints(CollisionPoints other) : base(other.Count)
+    /// <param name="other">The <see cref="IntersectionPoints"/> to copy.</param>
+    public IntersectionPoints(IntersectionPoints other) : base(other.Count)
     {
         AddRange(other);
     }
@@ -51,13 +51,13 @@ public class CollisionPoints : ShapeList<CollisionPoint>
 
     #region Members
     /// <summary>
-    /// Gets the first collision point in the list, or an empty <see cref="CollisionPoint"/> if the list is empty.
+    /// Gets the first collision point in the list, or an empty <see cref="IntersectionPoint"/> if the list is empty.
     /// </summary>
-    public CollisionPoint First => Count > 0 ? this[0] : new CollisionPoint();
+    public IntersectionPoint First => Count > 0 ? this[0] : new IntersectionPoint();
     /// <summary>
-    /// Gets the last collision point in the list, or an empty <see cref="CollisionPoint"/> if the list is empty.
+    /// Gets the last collision point in the list, or an empty <see cref="IntersectionPoint"/> if the list is empty.
     /// </summary>
-    public CollisionPoint Last => Count > 0 ? this[Count - 1] : new CollisionPoint();
+    public IntersectionPoint Last => Count > 0 ? this[Count - 1] : new IntersectionPoint();
     /// <summary>
     /// Gets whether the list contains any valid collision points.
     /// </summary>
@@ -68,13 +68,13 @@ public class CollisionPoints : ShapeList<CollisionPoint>
 
     /// <summary>
     /// Removes:
-    ///     - invalid CollisionPoints
+    ///     - invalid IntersectionPoints
     /// </summary>
-    /// <param name="combined">An averaged CollisionPoint of all remaining CollisionPoints.</param>
+    /// <param name="combined">An averaged IntersectionPoint of all remaining IntersectionPoints.</param>
     /// <returns>Returns true if there are valid points remaining</returns>
-    public bool Validate(out CollisionPoint combined)
+    public bool Validate(out IntersectionPoint combined)
     {
-        combined = new CollisionPoint();
+        combined = new IntersectionPoint();
         
         if (Count <= 0) return false;
         if (Count == 1)
@@ -110,20 +110,20 @@ public class CollisionPoints : ShapeList<CollisionPoint>
         
         avgPoint /= count;
         avgNormal = avgNormal.Normalize();
-        combined = new CollisionPoint(avgPoint, avgNormal);
+        combined = new IntersectionPoint(avgPoint, avgNormal);
         return true;
     }
     /// <summary>
     /// Removes:
-    /// - invalid CollisionPoints
-    /// - CollisionPoints with normals facing in the same direction as the reference direction
+    /// - invalid IntersectionPoints
+    /// - IntersectionPoints with normals facing in the same direction as the reference direction
     /// </summary>
-    /// <param name="referenceDirection">The direction to check CollisionPoint Normals against.</param>
-    /// <param name="combined">An averaged CollisionPoint of all remaining CollisionPoints.</param>
+    /// <param name="referenceDirection">The direction to check IntersectionPoint Normals against.</param>
+    /// <param name="combined">An averaged IntersectionPoint of all remaining IntersectionPoints.</param>
     /// <returns>Returns true if there are valid points remaining</returns>
-    public bool Validate(Vector2 referenceDirection, out CollisionPoint combined)
+    public bool Validate(Vector2 referenceDirection, out IntersectionPoint combined)
     {
-        combined = new CollisionPoint();
+        combined = new IntersectionPoint();
         
         if (Count <= 0) return false;
         if (Count == 1)
@@ -160,22 +160,22 @@ public class CollisionPoints : ShapeList<CollisionPoint>
         
         avgPoint /= count;
         avgNormal = avgNormal.Normalize();
-        combined = new CollisionPoint(avgPoint, avgNormal);
+        combined = new IntersectionPoint(avgPoint, avgNormal);
         return true;
     }
     /// <summary>
     /// Removes:
-    /// - invalid CollisionPoints
-    /// - CollisionPoints with normals facing in the same direction as the reference direction
-    /// - CollisionPoints with normals facing in the opposite direction as the reference point (from CollisionPoint towards the reference point)
+    /// - invalid IntersectionPoints
+    /// - IntersectionPoints with normals facing in the same direction as the reference direction
+    /// - IntersectionPoints with normals facing in the opposite direction as the reference point (from IntersectionPoint towards the reference point)
     /// </summary>
-    /// <param name="referenceDirection">The direction to check CollisionPoint normals against.</param>
-    /// <param name="referencePoint">The direction from the reference point towards to CollisionPoint  to check CollisionPoint Normals against.</param>
-    /// <param name="combined">An averaged CollisionPoint of all remaining CollisionPoints.</param>
+    /// <param name="referenceDirection">The direction to check IntersectionPoint normals against.</param>
+    /// <param name="referencePoint">The direction from the reference point towards to IntersectionPoint  to check IntersectionPoint Normals against.</param>
+    /// <param name="combined">An averaged IntersectionPoint of all remaining IntersectionPoints.</param>
     /// <returns>Returns true if there are valid points remaining</returns>
-    public bool Validate(Vector2 referenceDirection, Vector2 referencePoint,  out CollisionPoint combined)
+    public bool Validate(Vector2 referenceDirection, Vector2 referencePoint,  out IntersectionPoint combined)
     {
-        combined = new CollisionPoint();
+        combined = new IntersectionPoint();
         
         if (Count <= 0) return false;
         if (Count == 1)
@@ -212,24 +212,24 @@ public class CollisionPoints : ShapeList<CollisionPoint>
         
         avgPoint /= count;
         avgNormal = avgNormal.Normalize();
-        combined = new CollisionPoint(avgPoint, avgNormal);
+        combined = new IntersectionPoint(avgPoint, avgNormal);
         return true;
     }
     /// <summary>
     /// Removes:
-    /// - invalid CollisionPoints
-    /// - CollisionPoints with normals facing in the same direction as the reference direction
-    /// - CollisionPoints with normals facing in the opposite direction as the reference point (from CollisionPoint towards the reference point)
+    /// - invalid IntersectionPoints
+    /// - IntersectionPoints with normals facing in the same direction as the reference direction
+    /// - IntersectionPoints with normals facing in the opposite direction as the reference point (from IntersectionPoint towards the reference point)
     /// </summary>
-    /// <param name="referenceDirection">The direction to check CollisionPoint normals against.</param>
-    /// <param name="referencePoint">The direction from the reference point towards to CollisionPoint  to check CollisionPoint Normals against.</param>
-    /// <param name="combined">An averaged CollisionPoint of all remaining CollisionPoints.</param>
-    /// <param name="closest">The CollisionPoint that is closest to the referencePoint.</param>
+    /// <param name="referenceDirection">The direction to check IntersectionPoint normals against.</param>
+    /// <param name="referencePoint">The direction from the reference point towards to IntersectionPoint  to check IntersectionPoint Normals against.</param>
+    /// <param name="combined">An averaged IntersectionPoint of all remaining IntersectionPoints.</param>
+    /// <param name="closest">The IntersectionPoint that is closest to the referencePoint.</param>
     /// <returns>Returns true if there are valid points remaining</returns>
-    public bool Validate(Vector2 referenceDirection, Vector2 referencePoint,  out CollisionPoint combined, out CollisionPoint closest)
+    public bool Validate(Vector2 referenceDirection, Vector2 referencePoint,  out IntersectionPoint combined, out IntersectionPoint closest)
     {
-        combined = new CollisionPoint();
-        closest = new CollisionPoint();
+        combined = new IntersectionPoint();
+        closest = new IntersectionPoint();
         
         if (Count <= 0) return false;
         if (Count == 1)
@@ -277,25 +277,25 @@ public class CollisionPoints : ShapeList<CollisionPoint>
         
         avgPoint /= count;
         avgNormal = avgNormal.Normalize();
-        combined = new CollisionPoint(avgPoint, avgNormal);
+        combined = new IntersectionPoint(avgPoint, avgNormal);
         return true;
     }
     /// <summary>
     /// Removes:
-    /// - invalid CollisionPoints
-    /// - CollisionPoints with normals facing in the same direction as the reference direction
-    /// - CollisionPoints with normals facing in the opposite direction as the reference point (from CollisionPoint towards the reference point)
+    /// - invalid IntersectionPoints
+    /// - IntersectionPoints with normals facing in the same direction as the reference direction
+    /// - IntersectionPoints with normals facing in the opposite direction as the reference point (from IntersectionPoint towards the reference point)
     /// </summary>
-    /// <param name="referenceDirection">The direction to check CollisionPoint normals against.</param>
-    /// <param name="referencePoint">The direction from the reference point towards to CollisionPoint  to check CollisionPoint Normals against.</param>
-    /// <param name="validationResult">The result of the combined CollisionPoint, and the  closest/furthest collision point from the reference point, and the CollisionPoint with normal facing towards the referencePoint.</param>
+    /// <param name="referenceDirection">The direction to check IntersectionPoint normals against.</param>
+    /// <param name="referencePoint">The direction from the reference point towards to IntersectionPoint  to check IntersectionPoint Normals against.</param>
+    /// <param name="validationResult">The result of the combined IntersectionPoint, and the  closest/furthest collision point from the reference point, and the IntersectionPoint with normal facing towards the referencePoint.</param>
     /// <returns>Returns true if there are valid points remaining</returns>
     public bool Validate(Vector2 referenceDirection, Vector2 referencePoint,  out CollisionPointValidationResult validationResult)
     {
-        CollisionPoint combined;
-        CollisionPoint closest;
-        CollisionPoint furthest;
-        CollisionPoint pointingTowards;
+        IntersectionPoint combined;
+        IntersectionPoint closest;
+        IntersectionPoint furthest;
+        IntersectionPoint pointingTowards;
         validationResult = new CollisionPointValidationResult();
         
         if (Count <= 0) return false;
@@ -364,21 +364,21 @@ public class CollisionPoints : ShapeList<CollisionPoint>
         
         avgPoint /= count;
         avgNormal = avgNormal.Normalize();
-        combined = new CollisionPoint(avgPoint, avgNormal);
+        combined = new IntersectionPoint(avgPoint, avgNormal);
         validationResult = new CollisionPointValidationResult(combined, closest, furthest, pointingTowards);
         return true;
     }
     /// <summary>
-    /// Removes all invalid <see cref="CollisionPoint"/> instances from the list.
+    /// Removes all invalid <see cref="IntersectionPoint"/> instances from the list.
     /// </summary>
-    /// <param name="referencePoint">The direction from the reference point towards to CollisionPoint  to check CollisionPoint Normals against.</param>
-    /// <param name="combined">An averaged CollisionPoint of all remaining CollisionPoints.</param>
-    /// <param name="closest">The CollisionPoint that is closest to the referencePoint.</param>
+    /// <param name="referencePoint">The direction from the reference point towards to IntersectionPoint  to check IntersectionPoint Normals against.</param>
+    /// <param name="combined">An averaged IntersectionPoint of all remaining IntersectionPoints.</param>
+    /// <param name="closest">The IntersectionPoint that is closest to the referencePoint.</param>
     /// <returns>Returns true if there are valid points remaining</returns>
-    public bool Validate(Vector2 referencePoint,  out CollisionPoint combined, out CollisionPoint closest)
+    public bool Validate(Vector2 referencePoint,  out IntersectionPoint combined, out IntersectionPoint closest)
     {
-        combined = new CollisionPoint();
-        closest = new CollisionPoint();
+        combined = new IntersectionPoint();
+        closest = new IntersectionPoint();
         
         if (Count <= 0) return false;
         if (Count == 1)
@@ -426,21 +426,21 @@ public class CollisionPoints : ShapeList<CollisionPoint>
         
         avgPoint /= count;
         avgNormal = avgNormal.Normalize();
-        combined = new CollisionPoint(avgPoint, avgNormal);
+        combined = new IntersectionPoint(avgPoint, avgNormal);
         return true;
     }
     /// <summary>
-    /// Removes all invalid <see cref="CollisionPoint"/> instances from the list.
+    /// Removes all invalid <see cref="IntersectionPoint"/> instances from the list.
     /// </summary>
-    /// <param name="referencePoint">The direction from the reference point towards to CollisionPoint  to check CollisionPoint Normals against.</param>
-    /// <param name="validationResult">The result of the combined CollisionPoint, and the  closest/furthest collision point from the reference point, and the CollisionPoint with normal facing towards the referencePoint.</param>
+    /// <param name="referencePoint">The direction from the reference point towards to IntersectionPoint  to check IntersectionPoint Normals against.</param>
+    /// <param name="validationResult">The result of the combined IntersectionPoint, and the  closest/furthest collision point from the reference point, and the IntersectionPoint with normal facing towards the referencePoint.</param>
     /// <returns>Returns true if there are valid points remaining</returns>
     public bool Validate(Vector2 referencePoint,  out CollisionPointValidationResult validationResult)
     {
-        CollisionPoint combined;
-        CollisionPoint closest;
-        CollisionPoint furthest;
-        CollisionPoint pointingTowards;
+        IntersectionPoint combined;
+        IntersectionPoint closest;
+        IntersectionPoint furthest;
+        IntersectionPoint pointingTowards;
         validationResult = new CollisionPointValidationResult();
         
         if (Count <= 0) return false;
@@ -512,7 +512,7 @@ public class CollisionPoints : ShapeList<CollisionPoint>
         
         avgPoint /= count;
         avgNormal = avgNormal.Normalize();
-        combined = new CollisionPoint(avgPoint, avgNormal);
+        combined = new IntersectionPoint(avgPoint, avgNormal);
         validationResult = new CollisionPointValidationResult(combined, closest, furthest, pointingTowards);
         return true;
     }
@@ -522,7 +522,7 @@ public class CollisionPoints : ShapeList<CollisionPoint>
     #region Flip Normals
 
     /// <summary>
-    /// Flips the normal of every <see cref="CollisionPoint"/> in the list.
+    /// Flips the normal of every <see cref="IntersectionPoint"/> in the list.
     /// </summary>
     public void FlipAllNormals()
     {
@@ -533,7 +533,7 @@ public class CollisionPoints : ShapeList<CollisionPoint>
     }
 
     /// <summary>
-    /// Flips the normal of each <see cref="CollisionPoint"/> so that it faces towards the specified reference point.
+    /// Flips the normal of each <see cref="IntersectionPoint"/> so that it faces towards the specified reference point.
     /// </summary>
     /// <param name="referencePoint">The point towards which normals should be flipped.</param>
     public void FlipNormalsTowardsPoint(Vector2 referencePoint)
@@ -548,7 +548,7 @@ public class CollisionPoints : ShapeList<CollisionPoint>
     }
 
     /// <summary>
-    /// Flips the normal of each <see cref="CollisionPoint"/> so that it faces towards the specified reference direction.
+    /// Flips the normal of each <see cref="IntersectionPoint"/> so that it faces towards the specified reference direction.
     /// </summary>
     /// <param name="referenceDirection">The direction towards which normals should be flipped.</param>
     public void FlipNormalsTowardsDirection(Vector2 referenceDirection)
@@ -565,17 +565,17 @@ public class CollisionPoints : ShapeList<CollisionPoint>
     #region Equality
     
     /// <summary>
-    /// Returns a hash code for the current <see cref="CollisionPoints"/> instance.
+    /// Returns a hash code for the current <see cref="IntersectionPoints"/> instance.
     /// </summary>
     /// <returns>A hash code for the current object.</returns>
     public override int GetHashCode() { return Game.GetHashCode(this); }
     
     /// <summary>
-    /// Determines whether the specified <see cref="CollisionPoints"/> is equal to the current <see cref="CollisionPoints"/>.
+    /// Determines whether the specified <see cref="IntersectionPoints"/> is equal to the current <see cref="IntersectionPoints"/>.
     /// </summary>
-    /// <param name="other">The <see cref="CollisionPoints"/> to compare with the current instance.</param>
-    /// <returns><c>true</c> if the specified <see cref="CollisionPoints"/> is equal to the current instance; otherwise, <c>false</c>.</returns>
-    public bool Equals(CollisionPoints? other)
+    /// <param name="other">The <see cref="IntersectionPoints"/> to compare with the current instance.</param>
+    /// <returns><c>true</c> if the specified <see cref="IntersectionPoints"/> is equal to the current instance; otherwise, <c>false</c>.</returns>
+    public bool Equals(IntersectionPoints? other)
     {
         if (other == null) return false;
         if (Count != other.Count) return false;
@@ -588,9 +588,9 @@ public class CollisionPoints : ShapeList<CollisionPoint>
     
     #endregion
     
-    #region CollisionPoint
+    #region IntersectionPoint
     /// <summary>
-    /// Filters the CollisionPoints list based on a given filter type and reference point.
+    /// Filters the IntersectionPoints list based on a given filter type and reference point.
     /// PointingTowards and PointingAway calculate the direction from the collision point to the reference point.
     /// PointingTowards uses the normal that is facing the same direction as the direction from the collision point to the reference point.
     /// PointingAway uses the normal that is facing the opposite direction as the direction from the collision point to the reference point.
@@ -598,7 +598,7 @@ public class CollisionPoints : ShapeList<CollisionPoint>
     /// <param name="filterType">The filter type for selecting a collision point.</param>
     /// <param name="referencePoint">The reference point that is used for closest, furthest, pointing towards, and pointing away calculations.</param>
     /// <returns></returns>
-    public CollisionPoint Filter(CollisionPointsFilterType filterType, Vector2 referencePoint = new())
+    public IntersectionPoint Filter(CollisionPointsFilterType filterType, Vector2 referencePoint = new())
     {
         if (this.Count <= 0) return new();
         if (this.Count == 1) return this[0];
@@ -607,7 +607,7 @@ public class CollisionPoints : ShapeList<CollisionPoint>
         {
             case CollisionPointsFilterType.First: return this[0];
             case CollisionPointsFilterType.Closest:
-                CollisionPoint closest = new();
+                IntersectionPoint closest = new();
                 float minDisSquared = -1f;
                 foreach (var point in this)
                 {
@@ -620,7 +620,7 @@ public class CollisionPoints : ShapeList<CollisionPoint>
                 }
                 return closest;
             case CollisionPointsFilterType.Furthest:
-                CollisionPoint furthest = new();
+                IntersectionPoint furthest = new();
                 float maxDisSquared = -1f;
                 foreach (var point in this)
                 {
@@ -633,7 +633,7 @@ public class CollisionPoints : ShapeList<CollisionPoint>
                 }
                 return furthest;
             case CollisionPointsFilterType.Combined:
-                CollisionPoint combined = new();
+                IntersectionPoint combined = new();
                 foreach (var point in this)
                 {
                     if(combined.Valid) combined = combined.Combine(point);
@@ -641,7 +641,7 @@ public class CollisionPoints : ShapeList<CollisionPoint>
                 }
                 return combined;
             case CollisionPointsFilterType.PointingTowards:
-                CollisionPoint pointingTowards = new();
+                IntersectionPoint pointingTowards = new();
                 float maxDot = -1f;
                 foreach (var point in this)
                 {
@@ -655,7 +655,7 @@ public class CollisionPoints : ShapeList<CollisionPoint>
                 }
                 return pointingTowards;
             case CollisionPointsFilterType.PointingAway:
-                CollisionPoint pointingAway = new();
+                IntersectionPoint pointingAway = new();
                 float minDot = -1f;
                 foreach (var point in this)
                 {
@@ -674,7 +674,7 @@ public class CollisionPoints : ShapeList<CollisionPoint>
     }
   
     /// <summary>
-    /// Filters the CollisionPoints list based on a given filter type and reference point.
+    /// Filters the IntersectionPoints list based on a given filter type and reference point.
     /// Closest and Furthest use the reference point.
     /// PointingTowards and PointingAway use the reference direction.
     /// PointingTowards uses the Normal that is facing the same direction as the referenceDirection.
@@ -684,14 +684,14 @@ public class CollisionPoints : ShapeList<CollisionPoint>
     /// <param name="referencePoint">The reference point that is used for closest and furthest calculations.</param>
     /// <param name="referenceDirection">The reference direction that is used for pointing towards and pointing away calculations.</param>
     /// <returns></returns>
-    public CollisionPoint Filter(CollisionPointsFilterType filterType, Vector2 referencePoint, Vector2 referenceDirection)
+    public IntersectionPoint Filter(CollisionPointsFilterType filterType, Vector2 referencePoint, Vector2 referenceDirection)
     {
         if (this.Count <= 0) return new();
         if (this.Count == 1) return this[0];
 
         if (filterType == CollisionPointsFilterType.PointingTowards)
         {
-            CollisionPoint pointingTowards = new();
+            IntersectionPoint pointingTowards = new();
             float maxDot = -1f;
             foreach (var point in this)
             {
@@ -707,7 +707,7 @@ public class CollisionPoints : ShapeList<CollisionPoint>
         }
         if (filterType == CollisionPointsFilterType.PointingAway)
         {
-            CollisionPoint pointingAway = new();
+            IntersectionPoint pointingAway = new();
             float minDot = -1f;
             foreach (var point in this)
             {
@@ -726,8 +726,8 @@ public class CollisionPoints : ShapeList<CollisionPoint>
     /// <summary>
     /// Gets the combined collision point, averaging the position and normal of all valid collision points.
     /// </summary>
-    /// <returns>The combined CollisionPoint.</returns>
-    public CollisionPoint GetCombinedCollisionPoint()
+    /// <returns>The combined IntersectionPoint.</returns>
+    public IntersectionPoint GetCombinedCollisionPoint()
     {
         var avgPoint = new Vector2();
         var avgNormal = new Vector2();
@@ -746,13 +746,13 @@ public class CollisionPoints : ShapeList<CollisionPoint>
     /// Gets the closest collision point to the specified reference point.
     /// </summary>
     /// <param name="referencePoint">The reference point to measure distance against.</param>
-    /// <returns>The closest CollisionPoint.</returns>
-    public CollisionPoint GetClosestCollisionPoint(Vector2 referencePoint)
+    /// <returns>The closest IntersectionPoint.</returns>
+    public IntersectionPoint GetClosestCollisionPoint(Vector2 referencePoint)
     {
         if (!Valid) return new();
         if(Count == 1) return this[0];
 
-        var closest = new CollisionPoint();
+        var closest = new IntersectionPoint();
         var closestDistanceSquared = -1f; // (closest.Point - referencePoint).LengthSquared();
         for (var i = 0; i < Count; i++)
         {
@@ -772,13 +772,13 @@ public class CollisionPoints : ShapeList<CollisionPoint>
     /// Gets the furthest collision point from the specified reference point.
     /// </summary>
     /// <param name="referencePoint">The reference point to measure distance against.</param>
-    /// <returns>The furthest CollisionPoint.</returns>
-    public CollisionPoint GetFurthestCollisionPoint(Vector2 referencePoint)
+    /// <returns>The furthest IntersectionPoint.</returns>
+    public IntersectionPoint GetFurthestCollisionPoint(Vector2 referencePoint)
     {
         if (!Valid) return new();
         if(Count == 1) return this[0];
 
-        var furthest = new CollisionPoint();
+        var furthest = new IntersectionPoint();
         var furthestDistanceSquared = -1f;
         for (var i = 0; i < Count; i++)
         {
@@ -798,15 +798,15 @@ public class CollisionPoints : ShapeList<CollisionPoint>
     /// Gets the closest collision point to the specified reference point, and outputs the distance squared to that point.
     /// </summary>
     /// <param name="referencePoint">The reference point to measure distance against.</param>
-    /// <param name="closestDistanceSquared">The distance squared to the closest CollisionPoint.</param>
-    /// <returns>The closest CollisionPoint.</returns>
-    public CollisionPoint GetClosestCollisionPoint(Vector2 referencePoint, out float closestDistanceSquared)
+    /// <param name="closestDistanceSquared">The distance squared to the closest IntersectionPoint.</param>
+    /// <returns>The closest IntersectionPoint.</returns>
+    public IntersectionPoint GetClosestCollisionPoint(Vector2 referencePoint, out float closestDistanceSquared)
     {
         closestDistanceSquared = -1;
         if (!Valid) return new();
         if(Count == 1) return this[0];
 
-        var closest = new CollisionPoint();
+        var closest = new IntersectionPoint();
         closestDistanceSquared = -1f; // (closest.Point - referencePoint).LengthSquared();
         for (var i = 0; i < Count; i++)
         {
@@ -826,15 +826,15 @@ public class CollisionPoints : ShapeList<CollisionPoint>
     /// Gets the furthest collision point from the specified reference point, and outputs the distance squared to that point.
     /// </summary>
     /// <param name="referencePoint">The reference point to measure distance against.</param>
-    /// <param name="furthestDistanceSquared">The distance squared to the furthest CollisionPoint.</param>
-    /// <returns>The furthest CollisionPoint.</returns>
-    public CollisionPoint GetFurthestCollisionPoint(Vector2 referencePoint, out float furthestDistanceSquared)
+    /// <param name="furthestDistanceSquared">The distance squared to the furthest IntersectionPoint.</param>
+    /// <returns>The furthest IntersectionPoint.</returns>
+    public IntersectionPoint GetFurthestCollisionPoint(Vector2 referencePoint, out float furthestDistanceSquared)
     {
         furthestDistanceSquared = -1;
         if (!Valid) return new();
         if(Count == 1) return this[0];
 
-        var furthest = new CollisionPoint();
+        var furthest = new IntersectionPoint();
         furthestDistanceSquared = (furthest.Point - referencePoint).LengthSquared();
         for (var i = 0; i < Count; i++)
         {
@@ -851,17 +851,17 @@ public class CollisionPoints : ShapeList<CollisionPoint>
     }
 
     /// <summary>
-    /// Finds the <see cref="CollisionPoint"/> whose normal most closely faces the direction from the collision point to the specified reference point.
+    /// Finds the <see cref="IntersectionPoint"/> whose normal most closely faces the direction from the collision point to the specified reference point.
     /// Calculates the dot product between each normal and the direction vector to the reference point, returning the point with the highest value.
     /// </summary>
     /// <param name="referencePoint">The point to which normals should be compared.</param>
-    /// <returns>The <see cref="CollisionPoint"/> with the most aligned normal, or an empty point if none are valid.</returns>
-    public CollisionPoint GetCollisionPointFacingTowardsPoint(Vector2 referencePoint)
+    /// <returns>The <see cref="IntersectionPoint"/> with the most aligned normal, or an empty point if none are valid.</returns>
+    public IntersectionPoint GetCollisionPointFacingTowardsPoint(Vector2 referencePoint)
     {
         if (!Valid) return new();
         if(Count == 1) return this[0];
 
-        var best = new CollisionPoint();
+        var best = new IntersectionPoint();
         var maxDot = -10f;
         
         for (var i = 0; i < Count; i++)
@@ -881,16 +881,16 @@ public class CollisionPoints : ShapeList<CollisionPoint>
     }
    
     /// <summary>
-    /// Finds the <see cref="CollisionPoint"/> whose normal most closely aligns with the specified reference direction.
+    /// Finds the <see cref="IntersectionPoint"/> whose normal most closely aligns with the specified reference direction.
     /// </summary>
     /// <param name="referenceDir">The direction to compare against each collision point's normal.</param>
-    /// <returns>The <see cref="CollisionPoint"/> with the most aligned normal, or an empty point if none are valid.</returns>
-    public CollisionPoint GetCollisionPointFacingTowardsDir(Vector2 referenceDir)
+    /// <returns>The <see cref="IntersectionPoint"/> with the most aligned normal, or an empty point if none are valid.</returns>
+    public IntersectionPoint GetCollisionPointFacingTowardsDir(Vector2 referenceDir)
     {
         if (!Valid) return new();
         if(Count == 1) return this[0];
 
-        var best = new CollisionPoint();
+        var best = new IntersectionPoint();
         var maxDot = -10f;
         
         for (var i = 0; i < Count; i++)
@@ -912,10 +912,10 @@ public class CollisionPoints : ShapeList<CollisionPoint>
     
     #region Public
     /// <summary>
-    /// Creates a copy of the current <see cref="CollisionPoints"/> instance.
+    /// Creates a copy of the current <see cref="IntersectionPoints"/> instance.
     /// </summary>
-    /// <returns>A new <see cref="CollisionPoints"/> instance with the same elements.</returns>
-    public new CollisionPoints Copy() => new(this);
+    /// <returns>A new <see cref="IntersectionPoints"/> instance with the same elements.</returns>
+    public new IntersectionPoints Copy() => new(this);
 
     /// <summary>
     /// Sorts the collision points so that the closest point to the specified reference point comes first.
@@ -1070,12 +1070,12 @@ public class CollisionPoints : ShapeList<CollisionPoint>
         return new(uniqueVertices);
     }
     /// <summary>
-    /// Returns a new <see cref="CollisionPoints"/> instance containing unique collision points.
+    /// Returns a new <see cref="IntersectionPoints"/> instance containing unique collision points.
     /// </summary>
-    /// <returns>A <see cref="CollisionPoints"/> collection with unique collision points.</returns>
-    public CollisionPoints GetUniqueCollisionPoints()
+    /// <returns>A <see cref="IntersectionPoints"/> collection with unique collision points.</returns>
+    public IntersectionPoints GetUniqueCollisionPoints()
     {
-        var unique = new HashSet<CollisionPoint>();
+        var unique = new HashSet<IntersectionPoint>();
         for (var i = 0; i < Count; i++)
         {
             unique.Add(this[i]);

--- a/ShapeEngine/Geometry/CustomDrawing.cs
+++ b/ShapeEngine/Geometry/CustomDrawing.cs
@@ -45,7 +45,7 @@ public static class CustomDrawing
     /// <param name="intersectColorRgba">The color used for intersection points.</param>
     /// <param name="normalColorRgba">The color used for normal vectors.</param>
     /// <remarks>
-    /// Each collision point is visualized as a small circle, and its normal is drawn as a line.
+    /// Each intersection point is visualized as a small circle, and its normal is drawn as a line.
     /// </remarks>
     public static void Draw(this IntersectionPoints colPoints, float lineThickness, ColorRgba intersectColorRgba, ColorRgba normalColorRgba)
     {

--- a/ShapeEngine/Geometry/CustomDrawing.cs
+++ b/ShapeEngine/Geometry/CustomDrawing.cs
@@ -47,7 +47,7 @@ public static class CustomDrawing
     /// <remarks>
     /// Each collision point is visualized as a small circle, and its normal is drawn as a line.
     /// </remarks>
-    public static void Draw(this CollisionPoints colPoints, float lineThickness, ColorRgba intersectColorRgba, ColorRgba normalColorRgba)
+    public static void Draw(this IntersectionPoints colPoints, float lineThickness, ColorRgba intersectColorRgba, ColorRgba normalColorRgba)
     {
         if ( colPoints.Count <= 0) return;
         

--- a/ShapeEngine/Geometry/LineDef/LineClosestPoint.cs
+++ b/ShapeEngine/Geometry/LineDef/LineClosestPoint.cs
@@ -20,11 +20,11 @@ public readonly partial struct Line
     /// </summary>
     /// <param name="point">The point from which the closest point on the line is sought.</param>
     /// <param name="disSquared">Outputs the squared distance between the closest point on the line and the given point.</param>
-    /// <returns>A <see cref="CollisionPoint"/> representing the closest point on the line and its normal.</returns>
+    /// <returns>A <see cref="IntersectionPoint"/> representing the closest point on the line and its normal.</returns>
     /// <remarks>
     /// The normal is oriented to face the point if it is on the same side as the line's normal, otherwise it is flipped.
     /// </remarks>
-    public CollisionPoint GetClosestPoint(Vector2 point, out float disSquared)
+    public IntersectionPoint GetClosestPoint(Vector2 point, out float disSquared)
     {
         // Normalize the direction vector of the line
         var normalizedLineDirection = Direction.Normalize();

--- a/ShapeEngine/Geometry/LineDef/LineIntersectShape.cs
+++ b/ShapeEngine/Geometry/LineDef/LineIntersectShape.cs
@@ -18,17 +18,17 @@ public readonly partial struct Line
     /// </summary>
     /// <param name="segment">The <see cref="Segment"/> to check for intersection.</param>
     /// <returns>
-    /// A <see cref="CollisionPoints"/> object containing the intersection point, or null if no intersection exists.
+    /// A <see cref="IntersectionPoints"/> object containing the intersection point, or null if no intersection exists.
     /// </returns>
     /// <remarks>
     /// This is a convenience method that uses the line's point and direction.
     /// </remarks>
-    public CollisionPoints? IntersectShape(Segment segment)
+    public IntersectionPoints? IntersectShape(Segment segment)
     {
         var result = IntersectLineSegment(Point, Direction, segment.Start, segment.End, segment.Normal);
         if (result.Valid)
         {
-            var colPoints = new CollisionPoints();
+            var colPoints = new IntersectionPoints();
             colPoints.Add(result);
             return colPoints;
         }
@@ -41,17 +41,17 @@ public readonly partial struct Line
     /// </summary>
     /// <param name="line">The <see cref="Line"/> to check for intersection.</param>
     /// <returns>
-    /// A <see cref="CollisionPoints"/> object containing the intersection point, or null if no intersection exists.
+    /// A <see cref="IntersectionPoints"/> object containing the intersection point, or null if no intersection exists.
     /// </returns>
     /// <remarks>
     /// This is a convenience method that uses the line's point and direction.
     /// </remarks>
-    public CollisionPoints? IntersectShape(Line line)
+    public IntersectionPoints? IntersectShape(Line line)
     {
         var result = IntersectLineLine(Point, Direction, line.Point, line.Direction, line.Normal);
         if (result.Valid)
         {
-            var colPoints = new CollisionPoints();
+            var colPoints = new IntersectionPoints();
             colPoints.Add(result);
             return colPoints;
         }
@@ -64,17 +64,17 @@ public readonly partial struct Line
     /// </summary>
     /// <param name="ray">The <see cref="Ray"/> to check for intersection.</param>
     /// <returns>
-    /// A <see cref="CollisionPoints"/> object containing the intersection point, or null if no intersection exists.
+    /// A <see cref="IntersectionPoints"/> object containing the intersection point, or null if no intersection exists.
     /// </returns>
     /// <remarks>
     /// This is a convenience method that uses the line's point and direction.
     /// </remarks>
-    public CollisionPoints? IntersectShape(Ray ray)
+    public IntersectionPoints? IntersectShape(Ray ray)
     {
         var result = IntersectLineRay(Point, Direction, ray.Point, ray.Direction, ray.Normal);
         if (result.Valid)
         {
-            var colPoints = new CollisionPoints();
+            var colPoints = new IntersectionPoints();
             colPoints.Add(result);
             return colPoints;
         }
@@ -87,17 +87,17 @@ public readonly partial struct Line
     /// </summary>
     /// <param name="circle">The <see cref="Circle"/> to check for intersection.</param>
     /// <returns>
-    /// A <see cref="CollisionPoints"/> object containing the intersection points, or null if no intersection exists.
+    /// A <see cref="IntersectionPoints"/> object containing the intersection points, or null if no intersection exists.
     /// </returns>
     /// <remarks>
     /// This is a convenience method that uses the line's point and direction.
     /// </remarks>
-    public CollisionPoints? IntersectShape(Circle circle)
+    public IntersectionPoints? IntersectShape(Circle circle)
     {
         var result = IntersectLineCircle(Point, Direction, circle.Center, circle.Radius);
         if (result.a.Valid || result.b.Valid)
         {
-            var colPoints = new CollisionPoints();
+            var colPoints = new IntersectionPoints();
             if (result.a.Valid)
             {
                 colPoints.Add(result.a);
@@ -119,17 +119,17 @@ public readonly partial struct Line
     /// </summary>
     /// <param name="t">The <see cref="Triangle"/> to check for intersection.</param>
     /// <returns>
-    /// A <see cref="CollisionPoints"/> object containing the intersection points, or null if no intersection exists.
+    /// A <see cref="IntersectionPoints"/> object containing the intersection points, or null if no intersection exists.
     /// </returns>
     /// <remarks>
     /// This is a convenience method that uses the line's point and direction.
     /// </remarks>
-    public CollisionPoints? IntersectShape(Triangle t)
+    public IntersectionPoints? IntersectShape(Triangle t)
     {
         var result = IntersectLineTriangle(Point, Direction, t.A, t.B, t.C);
         if (result.a.Valid || result.b.Valid)
         {
-            var colPoints = new CollisionPoints();
+            var colPoints = new IntersectionPoints();
             if (result.a.Valid)
             {
                 colPoints.Add(result.a);
@@ -151,17 +151,17 @@ public readonly partial struct Line
     /// </summary>
     /// <param name="q">The <see cref="Quad"/> to check for intersection.</param>
     /// <returns>
-    /// A <see cref="CollisionPoints"/> object containing the intersection points, or null if no intersection exists.
+    /// A <see cref="IntersectionPoints"/> object containing the intersection points, or null if no intersection exists.
     /// </returns>
     /// <remarks>
     /// This is a convenience method that uses the line's point and direction.
     /// </remarks>
-    public CollisionPoints? IntersectShape(Quad q)
+    public IntersectionPoints? IntersectShape(Quad q)
     {
         var result = IntersectLineQuad(Point, Direction, q.A, q.B, q.C, q.D);
         if (result.a.Valid || result.b.Valid)
         {
-            var colPoints = new CollisionPoints();
+            var colPoints = new IntersectionPoints();
             if (result.a.Valid)
             {
                 colPoints.Add(result.a);
@@ -183,12 +183,12 @@ public readonly partial struct Line
     /// </summary>
     /// <param name="r">The <see cref="Rect"/> to check for intersection.</param>
     /// <returns>
-    /// A <see cref="CollisionPoints"/> object containing the intersection points, or null if no intersection exists.
+    /// A <see cref="IntersectionPoints"/> object containing the intersection points, or null if no intersection exists.
     /// </returns>
     /// <remarks>
     /// This is a convenience method that uses the line's point and direction.
     /// </remarks>
-    public CollisionPoints? IntersectShape(Rect r)
+    public IntersectionPoints? IntersectShape(Rect r)
     {
         //a test to see if 2 rays in opposite directions work
         // var result1 = Ray.IntersectRayRect(Point, Direction, r.A, r.B, r.C, r.D);
@@ -196,7 +196,7 @@ public readonly partial struct Line
         //
         // if (result1.a.Valid || result1.b.Valid || result2.a.Valid || result2.b.Valid)
         // {
-        //     var colPoints = new CollisionPoints();
+        //     var colPoints = new IntersectionPoints();
         //     if (result1.a.Valid)
         //     {
         //         colPoints.Add(result1.a);
@@ -221,7 +221,7 @@ public readonly partial struct Line
         var result = IntersectLineQuad(Point, Direction, r.A, r.B, r.C, r.D);
         if (result.a.Valid || result.b.Valid)
         {
-            var colPoints = new CollisionPoints();
+            var colPoints = new IntersectionPoints();
             if (result.a.Valid)
             {
                 colPoints.Add(result.a);
@@ -246,12 +246,12 @@ public readonly partial struct Line
     /// The maximum number of collision points to return. Use -1 for no limit.
     /// </param>
     /// <returns>
-    /// A <see cref="CollisionPoints"/> object containing the intersection points, or null if no intersections exist.
+    /// A <see cref="IntersectionPoints"/> object containing the intersection points, or null if no intersections exist.
     /// </returns>
     /// <remarks>
     /// This method iterates through all edges of the polygon and checks for intersections with the line.
     /// </remarks>
-    public CollisionPoints? IntersectShape(Polygon p, int maxCollisionPoints = -1) => IntersectLinePolygon(Point, Direction, p, maxCollisionPoints);
+    public IntersectionPoints? IntersectShape(Polygon p, int maxCollisionPoints = -1) => IntersectLinePolygon(Point, Direction, p, maxCollisionPoints);
 
     /// <summary>
     /// Computes the intersection points between this line and a <see cref="Polyline"/> shape.
@@ -261,12 +261,12 @@ public readonly partial struct Line
     /// The maximum number of collision points to return. Use -1 for no limit.
     /// </param>
     /// <returns>
-    /// A <see cref="CollisionPoints"/> object containing the intersection points, or null if no intersections exist.
+    /// A <see cref="IntersectionPoints"/> object containing the intersection points, or null if no intersections exist.
     /// </returns>
     /// <remarks>
     /// This method iterates through all segments of the polyline and checks for intersections with the line.
     /// </remarks>
-    public CollisionPoints? IntersectShape(Polyline pl, int maxCollisionPoints = -1) =>
+    public IntersectionPoints? IntersectShape(Polyline pl, int maxCollisionPoints = -1) =>
         IntersectLinePolyline(Point, Direction, pl, maxCollisionPoints);
 
     /// <summary>
@@ -277,19 +277,19 @@ public readonly partial struct Line
     /// The maximum number of collision points to return. Use -1 for no limit.
     /// </param>
     /// <returns>
-    /// A <see cref="CollisionPoints"/> object containing the intersection points, or null if no intersections exist.
+    /// A <see cref="IntersectionPoints"/> object containing the intersection points, or null if no intersections exist.
     /// </returns>
     /// <remarks>
     /// This method iterates through all segments in the collection and checks for intersections with the line.
     /// </remarks>
-    public CollisionPoints? IntersectShape(Segments segments, int maxCollisionPoints = -1) =>
+    public IntersectionPoints? IntersectShape(Segments segments, int maxCollisionPoints = -1) =>
         IntersectLineSegments(Point, Direction, segments, maxCollisionPoints);
 
     /// <summary>
-    /// Computes the intersection points between this line and a collider shape, populating a <see cref="CollisionPoints"/> collection.
+    /// Computes the intersection points between this line and a collider shape, populating a <see cref="IntersectionPoints"/> collection.
     /// </summary>
     /// <param name="collider">The <see cref="Collider"/> whose shape will be checked for intersection with this line.</param>
-    /// <param name="points">A reference to a <see cref="CollisionPoints"/> collection to be populated with intersection points.</param>
+    /// <param name="points">A reference to a <see cref="IntersectionPoints"/> collection to be populated with intersection points.</param>
     /// <param name="returnAfterFirstValid">
     /// If true, the function returns after finding the first valid intersection point. If false, all intersection points are found.
     /// </param>
@@ -297,7 +297,7 @@ public readonly partial struct Line
     /// <remarks>
     /// The function dispatches to the appropriate intersection method based on the collider's shape type.
     /// </remarks>
-    public int Intersect(Collider collider, ref CollisionPoints points, bool returnAfterFirstValid = false)
+    public int Intersect(Collider collider, ref IntersectionPoints points, bool returnAfterFirstValid = false)
     {
         if (!collider.Enabled) return 0;
 
@@ -339,12 +339,12 @@ public readonly partial struct Line
     /// Computes the intersection points between this line and a <see cref="Ray"/> shape.
     /// </summary>
     /// <param name="r">The <see cref="Ray"/> to check for intersection.</param>
-    /// <param name="points">A reference to a <see cref="CollisionPoints"/> collection to be populated with intersection points.</param>
+    /// <param name="points">A reference to a <see cref="IntersectionPoints"/> collection to be populated with intersection points.</param>
     /// <returns>The number of intersection points found between the line and the ray.</returns>
     /// <remarks>
     /// This method uses the line's point and direction to compute intersections with the given ray.
     /// </remarks>
-    public int IntersectShape(Ray r, ref CollisionPoints points)
+    public int IntersectShape(Ray r, ref IntersectionPoints points)
     {
         var cp = IntersectLineRay(Point, Direction, r.Point, r.Direction, r.Normal);
         if (cp.Valid)
@@ -358,12 +358,12 @@ public readonly partial struct Line
 
     /// <summary>
     /// Computes the intersection point between this line and another <see cref="Line"/> shape,
-    /// populating a <see cref="CollisionPoints"/> collection if an intersection exists.
+    /// populating a <see cref="IntersectionPoints"/> collection if an intersection exists.
     /// </summary>
     /// <param name="l">The <see cref="Line"/> to check for intersection.</param>
-    /// <param name="points">A reference to a <see cref="CollisionPoints"/> collection to be populated with intersection points.</param>
+    /// <param name="points">A reference to a <see cref="IntersectionPoints"/> collection to be populated with intersection points.</param>
     /// <returns>The number of intersection points found between the two lines (0 or 1).</returns>
-    public int IntersectShape(Line l, ref CollisionPoints points)
+    public int IntersectShape(Line l, ref IntersectionPoints points)
     {
         var cp = IntersectLineLine(Point, Direction, l.Point, l.Direction, l.Normal);
         if (cp.Valid)
@@ -376,15 +376,15 @@ public readonly partial struct Line
     }
 
     /// <summary>
-    /// Computes the intersection points between this line and a <see cref="Segment"/> shape, populating a <see cref="CollisionPoints"/> collection.
+    /// Computes the intersection points between this line and a <see cref="Segment"/> shape, populating a <see cref="IntersectionPoints"/> collection.
     /// </summary>
     /// <param name="s">The <see cref="Segment"/> to check for intersection.</param>
-    /// <param name="points">A reference to a <see cref="CollisionPoints"/> collection to be populated with intersection points.</param>
+    /// <param name="points">A reference to a <see cref="IntersectionPoints"/> collection to be populated with intersection points.</param>
     /// <returns>The number of intersection points found between the line and the segment.</returns>
     /// <remarks>
     /// This method checks if the line intersects the segment and, if so, adds the intersection point to the collection.
     /// </remarks>
-    public int IntersectShape(Segment s, ref CollisionPoints points)
+    public int IntersectShape(Segment s, ref IntersectionPoints points)
     {
         var cp = IntersectLineSegment(Point, Direction, s.Start, s.End);
         if (cp.Valid)
@@ -398,10 +398,10 @@ public readonly partial struct Line
 
     /// <summary>
     /// Computes the intersection points between this line and a <see cref="Circle"/> shape,
-    /// populating a <see cref="CollisionPoints"/> collection.
+    /// populating a <see cref="IntersectionPoints"/> collection.
     /// </summary>
     /// <param name="c">The <see cref="Circle"/> to check for intersection.</param>
-    /// <param name="points">A reference to a <see cref="CollisionPoints"/> collection to be populated with intersection points.</param>
+    /// <param name="points">A reference to a <see cref="IntersectionPoints"/> collection to be populated with intersection points.</param>
     /// <param name="returnAfterFirstValid">
     /// If true, the function returns after finding the first valid intersection point. If false, all intersection points are found.
     /// </param>
@@ -409,7 +409,7 @@ public readonly partial struct Line
     /// <remarks>
     /// This method uses the line's point and direction to compute intersections with the given circle.
     /// </remarks>
-    public int IntersectShape(Circle c, ref CollisionPoints points, bool returnAfterFirstValid = false)
+    public int IntersectShape(Circle c, ref IntersectionPoints points, bool returnAfterFirstValid = false)
     {
         var result = IntersectLineCircle(Point, Direction, c.Center, c.Radius);
 
@@ -443,10 +443,10 @@ public readonly partial struct Line
 
     /// <summary>
     /// Computes the intersection points between this line and a <see cref="Triangle"/> shape,
-    /// populating a <see cref="CollisionPoints"/> collection.
+    /// populating a <see cref="IntersectionPoints"/> collection.
     /// </summary>
     /// <param name="t">The <see cref="Triangle"/> to check for intersection.</param>
-    /// <param name="points">A reference to a <see cref="CollisionPoints"/> collection to be populated with intersection points.</param>
+    /// <param name="points">A reference to a <see cref="IntersectionPoints"/> collection to be populated with intersection points.</param>
     /// <param name="returnAfterFirstValid">
     /// If true, the function returns after finding the first valid intersection point. If false, all intersection points are found.
     /// </param>
@@ -454,7 +454,7 @@ public readonly partial struct Line
     /// <remarks>
     /// This method uses the line's point and direction to compute intersections with the given triangle.
     /// </remarks>
-    public int IntersectShape(Triangle t, ref CollisionPoints points, bool returnAfterFirstValid = false)
+    public int IntersectShape(Triangle t, ref IntersectionPoints points, bool returnAfterFirstValid = false)
     {
         var cp = IntersectLineSegment(Point, Direction, t.A, t.B);
         var count = 0;
@@ -488,10 +488,10 @@ public readonly partial struct Line
 
     /// <summary>
     /// Computes the intersection points between this line and a <see cref="Quad"/> shape,
-    /// populating a <see cref="CollisionPoints"/> collection.
+    /// populating a <see cref="IntersectionPoints"/> collection.
     /// </summary>
     /// <param name="q">The <see cref="Quad"/> to check for intersection.</param>
-    /// <param name="points">A reference to a <see cref="CollisionPoints"/> collection to be populated with intersection points.</param>
+    /// <param name="points">A reference to a <see cref="IntersectionPoints"/> collection to be populated with intersection points.</param>
     /// <param name="returnAfterFirstValid">
     /// If true, the function returns after finding the first valid intersection point. If false, all intersection points are found.
     /// </param>
@@ -499,7 +499,7 @@ public readonly partial struct Line
     /// <remarks>
     /// This method uses the line's point and direction to compute intersections with the given quad.
     /// </remarks>
-    public int IntersectShape(Quad q, ref CollisionPoints points, bool returnAfterFirstValid = false)
+    public int IntersectShape(Quad q, ref IntersectionPoints points, bool returnAfterFirstValid = false)
     {
         var cp = IntersectLineSegment(Point, Direction, q.A, q.B);
         var count = 0;
@@ -544,10 +544,10 @@ public readonly partial struct Line
 
     /// <summary>
     /// Computes the intersection points between this line and a <see cref="Rect"/> shape,
-    /// populating a <see cref="CollisionPoints"/> collection.
+    /// populating a <see cref="IntersectionPoints"/> collection.
     /// </summary>
     /// <param name="r">The <see cref="Rect"/> to check for intersection.</param>
-    /// <param name="points">A reference to a <see cref="CollisionPoints"/> collection to be populated with intersection points.</param>
+    /// <param name="points">A reference to a <see cref="IntersectionPoints"/> collection to be populated with intersection points.</param>
     /// <param name="returnAfterFirstValid">
     /// If true, the function returns after finding the first valid intersection point. If false, all intersection points are found.
     /// </param>
@@ -555,7 +555,7 @@ public readonly partial struct Line
     /// <remarks>
     /// This method uses the line's point and direction to compute intersections with the given rectangle.
     /// </remarks>
-    public int IntersectShape(Rect r, ref CollisionPoints points, bool returnAfterFirstValid = false)
+    public int IntersectShape(Rect r, ref IntersectionPoints points, bool returnAfterFirstValid = false)
     {
         var a = r.TopLeft;
         var b = r.BottomLeft;
@@ -604,10 +604,10 @@ public readonly partial struct Line
     }
 
     /// <summary>
-    /// Computes the intersection points between this line and a <see cref="Polygon"/> shape, populating a <see cref="CollisionPoints"/> collection.
+    /// Computes the intersection points between this line and a <see cref="Polygon"/> shape, populating a <see cref="IntersectionPoints"/> collection.
     /// </summary>
     /// <param name="p">The <see cref="Polygon"/> to check for intersection.</param>
-    /// <param name="points">A reference to a <see cref="CollisionPoints"/> collection to be populated with intersection points.</param>
+    /// <param name="points">A reference to a <see cref="IntersectionPoints"/> collection to be populated with intersection points.</param>
     /// <param name="returnAfterFirstValid">
     /// If true, the function returns after finding the first valid intersection point. If false, all intersection points are found.
     /// </param>
@@ -615,7 +615,7 @@ public readonly partial struct Line
     /// <remarks>
     /// This method iterates through all edges of the polygon and checks for intersections with the line.
     /// </remarks>
-    public int IntersectShape(Polygon p, ref CollisionPoints points, bool returnAfterFirstValid = false)
+    public int IntersectShape(Polygon p, ref IntersectionPoints points, bool returnAfterFirstValid = false)
     {
         if (p.Count < 3) return 0;
         var count = 0;
@@ -634,10 +634,10 @@ public readonly partial struct Line
     }
 
     /// <summary>
-    /// Computes the intersection points between this line and a <see cref="Polyline"/> shape, populating a <see cref="CollisionPoints"/> collection.
+    /// Computes the intersection points between this line and a <see cref="Polyline"/> shape, populating a <see cref="IntersectionPoints"/> collection.
     /// </summary>
     /// <param name="pl">The <see cref="Polyline"/> to check for intersection.</param>
-    /// <param name="points">A reference to a <see cref="CollisionPoints"/> collection to be populated with intersection points.</param>
+    /// <param name="points">A reference to a <see cref="IntersectionPoints"/> collection to be populated with intersection points.</param>
     /// <param name="returnAfterFirstValid">
     /// If true, the function returns after finding the first valid intersection point. If false, all intersection points are found.
     /// </param>
@@ -645,7 +645,7 @@ public readonly partial struct Line
     /// <remarks>
     /// This method iterates through all segments of the polyline and checks for intersections with the line.
     /// </remarks>
-    public int IntersectShape(Polyline pl, ref CollisionPoints points, bool returnAfterFirstValid = false)
+    public int IntersectShape(Polyline pl, ref IntersectionPoints points, bool returnAfterFirstValid = false)
     {
         if (pl.Count < 2) return 0;
         var count = 0;
@@ -665,10 +665,10 @@ public readonly partial struct Line
 
     /// <summary>
     /// Computes the intersection points between this line and a <see cref="Segments"/> collection,
-    /// populating a <see cref="CollisionPoints"/> collection.
+    /// populating a <see cref="IntersectionPoints"/> collection.
     /// </summary>
     /// <param name="shape">The <see cref="Segments"/> collection to check for intersections.</param>
-    /// <param name="points">A reference to a <see cref="CollisionPoints"/> collection to be populated with intersection points.</param>
+    /// <param name="points">A reference to a <see cref="IntersectionPoints"/> collection to be populated with intersection points.</param>
     /// <param name="returnAfterFirstValid">
     /// If true, the function returns after finding the first valid intersection point. If false, all intersection points are found.
     /// </param>
@@ -676,7 +676,7 @@ public readonly partial struct Line
     /// <remarks>
     /// This method iterates through all segments in the collection and checks for intersections with the line.
     /// </remarks>
-    public int IntersectShape(Segments shape, ref CollisionPoints points, bool returnAfterFirstValid = false)
+    public int IntersectShape(Segments shape, ref IntersectionPoints points, bool returnAfterFirstValid = false)
     {
         if (shape.Count <= 0) return 0;
         var count = 0;

--- a/ShapeEngine/Geometry/LineDef/LineIntersection.cs
+++ b/ShapeEngine/Geometry/LineDef/LineIntersection.cs
@@ -20,24 +20,24 @@ public readonly partial struct Line
     /// <param name="segmentStart">The start point of the segment.</param>
     /// <param name="segmentEnd">The end point of the segment.</param>
     /// <returns>
-    /// A <see cref="CollisionPoint"/> at the intersection, or an invalid <see cref="CollisionPoint"/> if no intersection exists.
+    /// A <see cref="IntersectionPoint"/> at the intersection, or an invalid <see cref="IntersectionPoint"/> if no intersection exists.
     /// </returns>
     /// <remarks>
     /// This is a convenience method that uses the line's point and direction.
     /// </remarks>
-    public CollisionPoint IntersectSegment(Vector2 segmentStart, Vector2 segmentEnd) => IntersectLineSegment(Point, Direction, segmentStart, segmentEnd);
+    public IntersectionPoint IntersectSegment(Vector2 segmentStart, Vector2 segmentEnd) => IntersectLineSegment(Point, Direction, segmentStart, segmentEnd);
 
     /// <summary>
     /// Computes the intersection point between this line and a segment.
     /// </summary>
     /// <param name="segment">The <see cref="Segment"/> to check for intersection.</param>
     /// <returns>
-    /// A <see cref="CollisionPoint"/> at the intersection, or an invalid <see cref="CollisionPoint"/> if no intersection exists.
+    /// A <see cref="IntersectionPoint"/> at the intersection, or an invalid <see cref="IntersectionPoint"/> if no intersection exists.
     /// </returns>
     /// <remarks>
     /// This is a convenience method that uses the line's point and direction.
     /// </remarks>
-    public CollisionPoint IntersectSegment(Segment segment) => IntersectLineSegment(Point, Direction, segment.Start, segment.End, segment.Normal);
+    public IntersectionPoint IntersectSegment(Segment segment) => IntersectLineSegment(Point, Direction, segment.Start, segment.End, segment.Normal);
 
     /// <summary>
     /// Computes the intersection point between this line and another infinite line.
@@ -45,18 +45,18 @@ public readonly partial struct Line
     /// <param name="otherPoint">A point through which the other line passes.</param>
     /// <param name="otherDirection">The direction vector of the other line.</param>
     /// <returns>
-    /// A <see cref="CollisionPoint"/> at the intersection, or an invalid <see cref="CollisionPoint"/> if the lines are parallel.
+    /// A <see cref="IntersectionPoint"/> at the intersection, or an invalid <see cref="IntersectionPoint"/> if the lines are parallel.
     /// </returns>
-    public CollisionPoint IntersectLine(Vector2 otherPoint, Vector2 otherDirection) => IntersectLineLine(Point, Direction, otherPoint, otherDirection);
+    public IntersectionPoint IntersectLine(Vector2 otherPoint, Vector2 otherDirection) => IntersectLineLine(Point, Direction, otherPoint, otherDirection);
 
     /// <summary>
     /// Computes the intersection point between this line and another infinite line.
     /// </summary>
     /// <param name="otherLine">The <see cref="Line"/> to check for intersection.</param>
     /// <returns>
-    /// A <see cref="CollisionPoint"/> at the intersection, or an invalid <see cref="CollisionPoint"/> if the lines are parallel.
+    /// A <see cref="IntersectionPoint"/> at the intersection, or an invalid <see cref="IntersectionPoint"/> if the lines are parallel.
     /// </returns>
-    public CollisionPoint IntersectLine(Line otherLine) => IntersectLineLine(Point, Direction, otherLine.Point, otherLine.Direction, otherLine.Normal);
+    public IntersectionPoint IntersectLine(Line otherLine) => IntersectLineLine(Point, Direction, otherLine.Point, otherLine.Direction, otherLine.Normal);
 
     /// <summary>
     /// Computes the intersection point between this line and a ray.
@@ -64,28 +64,28 @@ public readonly partial struct Line
     /// <param name="otherPoint">The origin point of the ray.</param>
     /// <param name="otherDirection">The direction vector of the ray.</param>
     /// <returns>
-    /// A <see cref="CollisionPoint"/> at the intersection, or an invalid <see cref="CollisionPoint"/> if the intersection does not lie in the direction of the ray.
+    /// A <see cref="IntersectionPoint"/> at the intersection, or an invalid <see cref="IntersectionPoint"/> if the intersection does not lie in the direction of the ray.
     /// </returns>
-    public CollisionPoint IntersectRay(Vector2 otherPoint, Vector2 otherDirection) => IntersectLineRay(Point, Direction, otherPoint, otherDirection);
+    public IntersectionPoint IntersectRay(Vector2 otherPoint, Vector2 otherDirection) => IntersectLineRay(Point, Direction, otherPoint, otherDirection);
 
     /// <summary>
     /// Computes the intersection point between this line and a ray.
     /// </summary>
     /// <param name="otherRay">The <see cref="Ray"/> to check for intersection.</param>
     /// <returns>
-    /// A <see cref="CollisionPoint"/> at the intersection, or an invalid <see cref="CollisionPoint"/> if the intersection does not lie in the direction of the ray.
+    /// A <see cref="IntersectionPoint"/> at the intersection, or an invalid <see cref="IntersectionPoint"/> if the intersection does not lie in the direction of the ray.
     /// </returns>
-    public CollisionPoint IntersectRay(Ray otherRay) => IntersectLineRay(Point, Direction, otherRay.Point, otherRay.Direction, otherRay.Normal);
+    public IntersectionPoint IntersectRay(Ray otherRay) => IntersectLineRay(Point, Direction, otherRay.Point, otherRay.Direction, otherRay.Normal);
 
     /// <summary>
     /// Computes the intersection points between this infinite line and a circle.
     /// </summary>
     /// <param name="otherCircle">The <see cref="Circle"/> to check for intersection.</param>
     /// <returns>
-    /// A tuple containing up to two <see cref="CollisionPoint"/> objects representing the intersection points.
+    /// A tuple containing up to two <see cref="IntersectionPoint"/> objects representing the intersection points.
     /// If no intersection exists, both points are invalid.
     /// </returns>
-    public (CollisionPoint a, CollisionPoint b) IntersectCircle(Circle otherCircle) =>
+    public (IntersectionPoint a, IntersectionPoint b) IntersectCircle(Circle otherCircle) =>
         IntersectLineCircle(Point, Direction, otherCircle.Center, otherCircle.Radius);
 
     /// <summary>
@@ -94,10 +94,10 @@ public readonly partial struct Line
     /// <param name="circleCenter">The center of the circle.</param>
     /// <param name="circleRadius">The radius of the circle.</param>
     /// <returns>
-    /// A tuple containing up to two <see cref="CollisionPoint"/> objects representing the intersection points.
+    /// A tuple containing up to two <see cref="IntersectionPoint"/> objects representing the intersection points.
     /// If no intersection exists, both points are invalid.
     /// </returns>
-    public (CollisionPoint a, CollisionPoint b) IntersectCircle(Vector2 circleCenter, float circleRadius) =>
+    public (IntersectionPoint a, IntersectionPoint b) IntersectCircle(Vector2 circleCenter, float circleRadius) =>
         IntersectLineCircle(Point, Direction, circleCenter, circleRadius);
 
     /// <summary>
@@ -107,20 +107,20 @@ public readonly partial struct Line
     /// <param name="b">The second vertex of the triangle.</param>
     /// <param name="c">The third vertex of the triangle.</param>
     /// <returns>
-    /// A tuple containing up to two <see cref="CollisionPoint"/> objects representing the intersection points.
+    /// A tuple containing up to two <see cref="IntersectionPoint"/> objects representing the intersection points.
     /// If no intersection exists, both points are invalid.
     /// </returns>
-    public (CollisionPoint a, CollisionPoint b) IntersectTriangle(Vector2 a, Vector2 b, Vector2 c) => IntersectLineTriangle(Point, Direction, a, b, c);
+    public (IntersectionPoint a, IntersectionPoint b) IntersectTriangle(Vector2 a, Vector2 b, Vector2 c) => IntersectLineTriangle(Point, Direction, a, b, c);
 
     /// <summary>
     /// Computes the intersection points between this infinite line and a triangle.
     /// </summary>
     /// <param name="triangle">The <see cref="Triangle"/> to check for intersection.</param>
     /// <returns>
-    /// A tuple containing up to two <see cref="CollisionPoint"/> objects representing the intersection points.
+    /// A tuple containing up to two <see cref="IntersectionPoint"/> objects representing the intersection points.
     /// If no intersection exists, both points are invalid.
     /// </returns>
-    public (CollisionPoint a, CollisionPoint b) IntersectTriangle(Triangle triangle) =>
+    public (IntersectionPoint a, IntersectionPoint b) IntersectTriangle(Triangle triangle) =>
         IntersectLineTriangle(Point, Direction, triangle.A, triangle.B, triangle.C);
 
     /// <summary>
@@ -131,20 +131,20 @@ public readonly partial struct Line
     /// <param name="c">The third vertex of the quadrilateral.</param>
     /// <param name="d">The fourth vertex of the quadrilateral.</param>
     /// <returns>
-    /// A tuple containing up to two <see cref="CollisionPoint"/> objects representing the intersection points.
+    /// A tuple containing up to two <see cref="IntersectionPoint"/> objects representing the intersection points.
     /// If no intersection exists, both points are invalid.
     /// </returns>
-    public (CollisionPoint a, CollisionPoint b) IntersectQuad(Vector2 a, Vector2 b, Vector2 c, Vector2 d) => IntersectLineQuad(Point, Direction, a, b, c, d);
+    public (IntersectionPoint a, IntersectionPoint b) IntersectQuad(Vector2 a, Vector2 b, Vector2 c, Vector2 d) => IntersectLineQuad(Point, Direction, a, b, c, d);
 
     /// <summary>
     /// Computes the intersection points between this infinite line and a quadrilateral.
     /// </summary>
     /// <param name="quad">The <see cref="Quad"/> to check for intersection.</param>
     /// <returns>
-    /// A tuple containing up to two <see cref="CollisionPoint"/> objects representing the intersection points.
+    /// A tuple containing up to two <see cref="IntersectionPoint"/> objects representing the intersection points.
     /// If no intersection exists, both points are invalid.
     /// </returns>
-    public (CollisionPoint a, CollisionPoint b) IntersectQuad(Quad quad) => IntersectLineQuad(Point, Direction, quad.A, quad.B, quad.C, quad.D);
+    public (IntersectionPoint a, IntersectionPoint b) IntersectQuad(Quad quad) => IntersectLineQuad(Point, Direction, quad.A, quad.B, quad.C, quad.D);
 
     /// <summary>
     /// Computes the intersection points between this infinite line and a rectangle defined by four vertices.
@@ -154,20 +154,20 @@ public readonly partial struct Line
     /// <param name="c">The third vertex of the rectangle.</param>
     /// <param name="d">The fourth vertex of the rectangle.</param>
     /// <returns>
-    /// A tuple containing up to two <see cref="CollisionPoint"/> objects representing the intersection points.
+    /// A tuple containing up to two <see cref="IntersectionPoint"/> objects representing the intersection points.
     /// If no intersection exists, both points are invalid.
     /// </returns>
-    public (CollisionPoint a, CollisionPoint b) IntersectRect(Vector2 a, Vector2 b, Vector2 c, Vector2 d) => IntersectLineQuad(Point, Direction, a, b, c, d);
+    public (IntersectionPoint a, IntersectionPoint b) IntersectRect(Vector2 a, Vector2 b, Vector2 c, Vector2 d) => IntersectLineQuad(Point, Direction, a, b, c, d);
 
     /// <summary>
     /// Computes the intersection points between this infinite line and a rectangle.
     /// </summary>
     /// <param name="rect">The <see cref="Rect"/> to check for intersection.</param>
     /// <returns>
-    /// A tuple containing up to two <see cref="CollisionPoint"/> objects representing the intersection points.
+    /// A tuple containing up to two <see cref="IntersectionPoint"/> objects representing the intersection points.
     /// If no intersection exists, both points are invalid.
     /// </returns>
-    public (CollisionPoint a, CollisionPoint b) IntersectRect(Rect rect) => IntersectLineQuad(Point, Direction, rect.A, rect.B, rect.C, rect.D);
+    public (IntersectionPoint a, IntersectionPoint b) IntersectRect(Rect rect) => IntersectLineQuad(Point, Direction, rect.A, rect.B, rect.C, rect.D);
 
     /// <summary>
     /// Computes the intersection points between this infinite line and a polygon defined by a list of vertices.
@@ -177,9 +177,9 @@ public readonly partial struct Line
     /// The maximum number of collision points to return. Use -1 for no limit.
     /// </param>
     /// <returns>
-    /// A <see cref="CollisionPoints"/> object containing the intersection points, or null if no intersections exist.
+    /// A <see cref="IntersectionPoints"/> object containing the intersection points, or null if no intersections exist.
     /// </returns>
-    public CollisionPoints? IntersectPolygon(List<Vector2> points, int maxCollisionPoints = -1) =>
+    public IntersectionPoints? IntersectPolygon(List<Vector2> points, int maxCollisionPoints = -1) =>
         IntersectLinePolygon(Point, Direction, points, maxCollisionPoints);
 
     /// <summary>
@@ -190,9 +190,9 @@ public readonly partial struct Line
     /// The maximum number of collision points to return. Use -1 for no limit.
     /// </param>
     /// <returns>
-    /// A <see cref="CollisionPoints"/> object containing the intersection points, or null if no intersections exist.
+    /// A <see cref="IntersectionPoints"/> object containing the intersection points, or null if no intersections exist.
     /// </returns>
-    public CollisionPoints? IntersectPolygon(Polygon polygon, int maxCollisionPoints = -1) =>
+    public IntersectionPoints? IntersectPolygon(Polygon polygon, int maxCollisionPoints = -1) =>
         IntersectLinePolygon(Point, Direction, polygon, maxCollisionPoints);
 
     /// <summary>
@@ -203,9 +203,9 @@ public readonly partial struct Line
     /// The maximum number of collision points to return. Use -1 for no limit.
     /// </param>
     /// <returns>
-    /// A <see cref="CollisionPoints"/> object containing the intersection points, or null if no intersections exist.
+    /// A <see cref="IntersectionPoints"/> object containing the intersection points, or null if no intersections exist.
     /// </returns>
-    public CollisionPoints? IntersectPolyline(List<Vector2> points, int maxCollisionPoints = -1) =>
+    public IntersectionPoints? IntersectPolyline(List<Vector2> points, int maxCollisionPoints = -1) =>
         IntersectLinePolyline(Point, Direction, points, maxCollisionPoints);
 
     /// <summary>
@@ -216,9 +216,9 @@ public readonly partial struct Line
     /// The maximum number of collision points to return. Use -1 for no limit.
     /// </param>
     /// <returns>
-    /// A <see cref="CollisionPoints"/> object containing the intersection points, or null if no intersections exist.
+    /// A <see cref="IntersectionPoints"/> object containing the intersection points, or null if no intersections exist.
     /// </returns>
-    public CollisionPoints? IntersectPolyline(Polyline polyline, int maxCollisionPoints = -1) =>
+    public IntersectionPoints? IntersectPolyline(Polyline polyline, int maxCollisionPoints = -1) =>
         IntersectLinePolyline(Point, Direction, polyline, maxCollisionPoints);
 
     /// <summary>
@@ -227,12 +227,12 @@ public readonly partial struct Line
     /// <param name="segments">A list of <see cref="Segment"/> objects to check for intersections.</param>
     /// <param name="maxCollisionPoints">The maximum number of collision points to return. Use -1 for no limit.</param>
     /// <returns>
-    /// A <see cref="CollisionPoints"/> object containing the intersection points, or null if no intersections exist.
+    /// A <see cref="IntersectionPoints"/> object containing the intersection points, or null if no intersections exist.
     /// </returns>
     /// <remarks>
     /// This is a convenience method that uses the line's point and direction.
     /// </remarks>
-    public CollisionPoints? IntersectSegments(List<Segment> segments, int maxCollisionPoints = -1) =>
+    public IntersectionPoints? IntersectSegments(List<Segment> segments, int maxCollisionPoints = -1) =>
         IntersectLineSegments(Point, Direction, segments, maxCollisionPoints);
 
     /// <summary>
@@ -241,12 +241,12 @@ public readonly partial struct Line
     /// <param name="segments">A <see cref="Segments"/> collection to check for intersections.</param>
     /// <param name="maxCollisionPoints">The maximum number of collision points to return. Use -1 for no limit.</param>
     /// <returns>
-    /// A <see cref="CollisionPoints"/> object containing the intersection points, or null if no intersections exist.
+    /// A <see cref="IntersectionPoints"/> object containing the intersection points, or null if no intersections exist.
     /// </returns>
     /// <remarks>
     /// This is a convenience method that uses the line's point and direction.
     /// </remarks>
-    public CollisionPoints? IntersectSegments(Segments segments, int maxCollisionPoints = -1) =>
+    public IntersectionPoints? IntersectSegments(Segments segments, int maxCollisionPoints = -1) =>
         IntersectLineSegments(Point, Direction, segments, maxCollisionPoints);
 
     /// <summary>
@@ -254,12 +254,12 @@ public readonly partial struct Line
     /// </summary>
     /// <param name="collider">The <see cref="Collider"/> whose shape will be checked for intersection with this line.</param>
     /// <returns>
-    /// A <see cref="CollisionPoints"/> object containing the intersection points, or null if no intersections exist or the collider is disabled.
+    /// A <see cref="IntersectionPoints"/> object containing the intersection points, or null if no intersections exist or the collider is disabled.
     /// </returns>
     /// <remarks>
     /// The function dispatches to the appropriate intersection method based on the collider's shape type.
     /// </remarks>
-    public CollisionPoints? Intersect(Collider collider)
+    public IntersectionPoints? Intersect(Collider collider)
     {
         if (!collider.Enabled) return null;
 

--- a/ShapeEngine/Geometry/LineDef/LineIntersectionStatic.cs
+++ b/ShapeEngine/Geometry/LineDef/LineIntersectionStatic.cs
@@ -38,13 +38,13 @@ public readonly partial struct Line
     /// <param name="segmentStart">The start point of the segment.</param>
     /// <param name="segmentEnd">The end point of the segment.</param>
     /// <returns>
-    /// A tuple containing the <see cref="CollisionPoint"/> at the intersection and the parameter t along the line.
-    /// If no intersection exists, returns an invalid <see cref="CollisionPoint"/> and t = -1.
+    /// A tuple containing the <see cref="IntersectionPoint"/> at the intersection and the parameter t along the line.
+    /// If no intersection exists, returns an invalid <see cref="IntersectionPoint"/> and t = -1.
     /// </returns>
     /// <remarks>
     /// The intersection is only valid if it lies within the segment bounds.
     /// </remarks>
-    public static (CollisionPoint p, float t) IntersectLineSegmentInfo(Vector2 linePoint, Vector2 lineDirection, Vector2 segmentStart, Vector2 segmentEnd)
+    public static (IntersectionPoint p, float t) IntersectLineSegmentInfo(Vector2 linePoint, Vector2 lineDirection, Vector2 segmentStart, Vector2 segmentEnd)
     {
         // Line AB (infinite line) represented by linePoint and lineDirection
         // Line segment CD represented by segmentStart and segmentEnd
@@ -88,15 +88,15 @@ public readonly partial struct Line
     /// <param name="lineDirection">The direction vector of the infinite line.</param>
     /// <param name="segmentStart">The start point of the segment.</param>
     /// <param name="segmentEnd">The end point of the segment.</param>
-    /// <param name="segmentNormal">The normal vector of the segment, used for the resulting <see cref="CollisionPoint"/>.</param>
+    /// <param name="segmentNormal">The normal vector of the segment, used for the resulting <see cref="IntersectionPoint"/>.</param>
     /// <returns>
-    /// A tuple containing the <see cref="CollisionPoint"/> at the intersection (with the provided normal) and the parameter t along the line.
-    /// If no intersection exists, returns an invalid <see cref="CollisionPoint"/> and t = -1.
+    /// A tuple containing the <see cref="IntersectionPoint"/> at the intersection (with the provided normal) and the parameter t along the line.
+    /// If no intersection exists, returns an invalid <see cref="IntersectionPoint"/> and t = -1.
     /// </returns>
     /// <remarks>
     /// Use this overload when the segment's normal is already known.
     /// </remarks>
-    public static (CollisionPoint p, float t) IntersectLineSegmentInfo(Vector2 linePoint, Vector2 lineDirection, Vector2 segmentStart, Vector2 segmentEnd,
+    public static (IntersectionPoint p, float t) IntersectLineSegmentInfo(Vector2 linePoint, Vector2 lineDirection, Vector2 segmentStart, Vector2 segmentEnd,
         Vector2 segmentNormal)
     {
         var result = IntersectLineSegmentInfo(linePoint, lineDirection, segmentStart, segmentEnd);
@@ -116,13 +116,13 @@ public readonly partial struct Line
     /// <param name="line2Point">A point through which the second line passes.</param>
     /// <param name="line2Direction">The direction vector of the second line.</param>
     /// <returns>
-    /// A tuple containing the <see cref="CollisionPoint"/> at the intersection and the parameter t along the first line.
-    /// If the lines are parallel, returns an invalid <see cref="CollisionPoint"/> and t = -1.
+    /// A tuple containing the <see cref="IntersectionPoint"/> at the intersection and the parameter t along the first line.
+    /// If the lines are parallel, returns an invalid <see cref="IntersectionPoint"/> and t = -1.
     /// </returns>
     /// <remarks>
     /// The intersection is valid only if the lines are not parallel.
     /// </remarks>
-    public static (CollisionPoint p, float t) IntersectLineLineInfo(Vector2 line1Point, Vector2 line1Direction, Vector2 line2Point, Vector2 line2Direction)
+    public static (IntersectionPoint p, float t) IntersectLineLineInfo(Vector2 line1Point, Vector2 line1Direction, Vector2 line2Point, Vector2 line2Direction)
     {
         // Calculate the denominator of the intersection formula
         float denominator = line1Direction.X * line2Direction.Y - line1Direction.Y * line2Direction.X;
@@ -153,15 +153,15 @@ public readonly partial struct Line
     /// <param name="line1Direction">The direction vector of the first line.</param>
     /// <param name="line2Point">A point through which the second line passes.</param>
     /// <param name="line2Direction">The direction vector of the second line.</param>
-    /// <param name="line2Normal">The normal vector of the second line, used for the resulting <see cref="CollisionPoint"/>.</param>
+    /// <param name="line2Normal">The normal vector of the second line, used for the resulting <see cref="IntersectionPoint"/>.</param>
     /// <returns>
-    /// A tuple containing the <see cref="CollisionPoint"/> at the intersection (with the provided normal) and the parameter t along the first line.
-    /// If the lines are parallel, returns an invalid <see cref="CollisionPoint"/> and t = -1.
+    /// A tuple containing the <see cref="IntersectionPoint"/> at the intersection (with the provided normal) and the parameter t along the first line.
+    /// If the lines are parallel, returns an invalid <see cref="IntersectionPoint"/> and t = -1.
     /// </returns>
     /// <remarks>
     /// Use this overload when the second line's normal is already known.
     /// </remarks>
-    public static (CollisionPoint p, float t) IntersectLineLineInfo(Vector2 line1Point, Vector2 line1Direction, Vector2 line2Point, Vector2 line2Direction,
+    public static (IntersectionPoint p, float t) IntersectLineLineInfo(Vector2 line1Point, Vector2 line1Direction, Vector2 line2Point, Vector2 line2Direction,
         Vector2 line2Normal)
     {
         var result = IntersectLineLineInfo(line1Point, line1Direction, line2Point, line2Direction);
@@ -181,13 +181,13 @@ public readonly partial struct Line
     /// <param name="rayPoint">The origin point of the ray.</param>
     /// <param name="rayDirection">The direction vector of the ray.</param>
     /// <returns>
-    /// A tuple containing the <see cref="CollisionPoint"/> at the intersection and the parameter t along the line.
-    /// If the intersection does not lie in the direction of the ray, returns an invalid <see cref="CollisionPoint"/> and t = -1.
+    /// A tuple containing the <see cref="IntersectionPoint"/> at the intersection and the parameter t along the line.
+    /// If the intersection does not lie in the direction of the ray, returns an invalid <see cref="IntersectionPoint"/> and t = -1.
     /// </returns>
     /// <remarks>
     /// The intersection is valid only if it lies in the positive direction of the ray.
     /// </remarks>
-    public static (CollisionPoint p, float t) IntersectLineRayInfo(Vector2 linePoint, Vector2 lineDirection, Vector2 rayPoint, Vector2 rayDirection)
+    public static (IntersectionPoint p, float t) IntersectLineRayInfo(Vector2 linePoint, Vector2 lineDirection, Vector2 rayPoint, Vector2 rayDirection)
     {
         // Calculate the denominator of the intersection formula
         float denominator = lineDirection.X * rayDirection.Y - lineDirection.Y * rayDirection.X;
@@ -227,15 +227,15 @@ public readonly partial struct Line
     /// <param name="lineDirection">The direction vector of the infinite line.</param>
     /// <param name="rayPoint">The origin point of the ray.</param>
     /// <param name="rayDirection">The direction vector of the ray.</param>
-    /// <param name="rayNormal">The normal vector of the ray, used for the resulting <see cref="CollisionPoint"/>.</param>
+    /// <param name="rayNormal">The normal vector of the ray, used for the resulting <see cref="IntersectionPoint"/>.</param>
     /// <returns>
-    /// A tuple containing the <see cref="CollisionPoint"/> at the intersection (with the provided normal) and the parameter t along the line.
-    /// If the intersection does not lie in the direction of the ray, returns an invalid <see cref="CollisionPoint"/> and t = -1.
+    /// A tuple containing the <see cref="IntersectionPoint"/> at the intersection (with the provided normal) and the parameter t along the line.
+    /// If the intersection does not lie in the direction of the ray, returns an invalid <see cref="IntersectionPoint"/> and t = -1.
     /// </returns>
     /// <remarks>
     /// Use this overload when the ray's normal is already known.
     /// </remarks>
-    public static (CollisionPoint p, float t) IntersectLineRayInfo(Vector2 linePoint, Vector2 lineDirection, Vector2 rayPoint, Vector2 rayDirection,
+    public static (IntersectionPoint p, float t) IntersectLineRayInfo(Vector2 linePoint, Vector2 lineDirection, Vector2 rayPoint, Vector2 rayDirection,
         Vector2 rayNormal)
     {
         var result = IntersectLineRayInfo(linePoint, lineDirection, rayPoint, rayDirection);
@@ -255,12 +255,12 @@ public readonly partial struct Line
     /// <param name="segmentStart">The start point of the segment.</param>
     /// <param name="segmentEnd">The end point of the segment.</param>
     /// <returns>
-    /// A <see cref="CollisionPoint"/> at the intersection, or an invalid <see cref="CollisionPoint"/> if no intersection exists.
+    /// A <see cref="IntersectionPoint"/> at the intersection, or an invalid <see cref="IntersectionPoint"/> if no intersection exists.
     /// </returns>
     /// <remarks>
     /// The intersection is valid only if it lies within the segment bounds.
     /// </remarks>
-    public static CollisionPoint IntersectLineSegment(Vector2 linePoint, Vector2 lineDirection, Vector2 segmentStart, Vector2 segmentEnd)
+    public static IntersectionPoint IntersectLineSegment(Vector2 linePoint, Vector2 lineDirection, Vector2 segmentStart, Vector2 segmentEnd)
     {
         var result = Ray.IntersectRaySegment(linePoint, lineDirection, segmentStart, segmentEnd);
         if (result.Valid) return result;
@@ -313,14 +313,14 @@ public readonly partial struct Line
     /// <param name="lineDirection">The direction vector of the infinite line.</param>
     /// <param name="segmentStart">The start point of the segment.</param>
     /// <param name="segmentEnd">The end point of the segment.</param>
-    /// <param name="segmentNormal">The normal vector of the segment, used for the resulting <see cref="CollisionPoint"/>.</param>
+    /// <param name="segmentNormal">The normal vector of the segment, used for the resulting <see cref="IntersectionPoint"/>.</param>
     /// <returns>
-    /// A <see cref="CollisionPoint"/> at the intersection (with the provided normal), or an invalid <see cref="CollisionPoint"/> if no intersection exists.
+    /// A <see cref="IntersectionPoint"/> at the intersection (with the provided normal), or an invalid <see cref="IntersectionPoint"/> if no intersection exists.
     /// </returns>
     /// <remarks>
     /// Use this overload when the segment's normal is already known.
     /// </remarks>
-    public static CollisionPoint IntersectLineSegment(Vector2 linePoint, Vector2 lineDirection, Vector2 segmentStart, Vector2 segmentEnd, Vector2 segmentNormal)
+    public static IntersectionPoint IntersectLineSegment(Vector2 linePoint, Vector2 lineDirection, Vector2 segmentStart, Vector2 segmentEnd, Vector2 segmentNormal)
     {
         var result = IntersectLineSegment(linePoint, lineDirection, segmentStart, segmentEnd);
         if (result.Valid)
@@ -339,12 +339,12 @@ public readonly partial struct Line
     /// <param name="line2Point">A point through which the second line passes.</param>
     /// <param name="line2Direction">The direction vector of the second line.</param>
     /// <returns>
-    /// A <see cref="CollisionPoint"/> at the intersection, or an invalid <see cref="CollisionPoint"/> if the lines are parallel.
+    /// A <see cref="IntersectionPoint"/> at the intersection, or an invalid <see cref="IntersectionPoint"/> if the lines are parallel.
     /// </returns>
     /// <remarks>
     /// The intersection is valid only if the lines are not parallel.
     /// </remarks>
-    public static CollisionPoint IntersectLineLine(Vector2 line1Point, Vector2 line1Direction, Vector2 line2Point, Vector2 line2Direction)
+    public static IntersectionPoint IntersectLineLine(Vector2 line1Point, Vector2 line1Direction, Vector2 line2Point, Vector2 line2Direction)
     {
         // Calculate the denominator of the intersection formula
         float denominator = line1Direction.X * line2Direction.Y - line1Direction.Y * line2Direction.X;
@@ -375,11 +375,11 @@ public readonly partial struct Line
     /// <param name="line1Direction">The direction vector of the first line.</param>
     /// <param name="line2Point">A point through which the second line passes.</param>
     /// <param name="line2Direction">The direction vector of the second line.</param>
-    /// <param name="line2Normal">The normal vector of the second line, used for the resulting <see cref="CollisionPoint"/>.</param>
+    /// <param name="line2Normal">The normal vector of the second line, used for the resulting <see cref="IntersectionPoint"/>.</param>
     /// <returns>
-    /// A <see cref="CollisionPoint"/> at the intersection (with the provided normal), or an invalid <see cref="CollisionPoint"/> if the lines are parallel.
+    /// A <see cref="IntersectionPoint"/> at the intersection (with the provided normal), or an invalid <see cref="IntersectionPoint"/> if the lines are parallel.
     /// </returns>
-    public static CollisionPoint IntersectLineLine(Vector2 line1Point, Vector2 line1Direction, Vector2 line2Point, Vector2 line2Direction, Vector2 line2Normal)
+    public static IntersectionPoint IntersectLineLine(Vector2 line1Point, Vector2 line1Direction, Vector2 line2Point, Vector2 line2Direction, Vector2 line2Normal)
     {
         var result = IntersectLineLine(line1Point, line1Direction, line2Point, line2Direction);
         if (result.Valid)
@@ -398,12 +398,12 @@ public readonly partial struct Line
     /// <param name="rayPoint">The origin point of the ray.</param>
     /// <param name="rayDirection">The direction vector of the ray.</param>
     /// <returns>
-    /// A <see cref="CollisionPoint"/> at the intersection, or an invalid <see cref="CollisionPoint"/> if the intersection does not lie in the direction of the ray.
+    /// A <see cref="IntersectionPoint"/> at the intersection, or an invalid <see cref="IntersectionPoint"/> if the intersection does not lie in the direction of the ray.
     /// </returns>
     /// <remarks>
     /// The intersection is valid only if it lies in the positive direction of the ray.
     /// </remarks>
-    public static CollisionPoint IntersectLineRay(Vector2 linePoint, Vector2 lineDirection, Vector2 rayPoint, Vector2 rayDirection)
+    public static IntersectionPoint IntersectLineRay(Vector2 linePoint, Vector2 lineDirection, Vector2 rayPoint, Vector2 rayDirection)
     {
         // Calculate the denominator of the intersection formula
         float denominator = lineDirection.X * rayDirection.Y - lineDirection.Y * rayDirection.X;
@@ -443,14 +443,14 @@ public readonly partial struct Line
     /// <param name="lineDirection">The direction vector of the infinite line.</param>
     /// <param name="rayPoint">The origin point of the ray.</param>
     /// <param name="rayDirection">The direction vector of the ray.</param>
-    /// <param name="rayNormal">The normal vector of the ray, used for the resulting <see cref="CollisionPoint"/>.</param>
+    /// <param name="rayNormal">The normal vector of the ray, used for the resulting <see cref="IntersectionPoint"/>.</param>
     /// <returns>
-    /// A <see cref="CollisionPoint"/> at the intersection (with the provided normal), or an invalid <see cref="CollisionPoint"/> if the intersection does not lie in the direction of the ray.
+    /// A <see cref="IntersectionPoint"/> at the intersection (with the provided normal), or an invalid <see cref="IntersectionPoint"/> if the intersection does not lie in the direction of the ray.
     /// </returns>
     /// <remarks>
     /// Use this overload when the ray's normal is already known.
     /// </remarks>
-    public static CollisionPoint IntersectLineRay(Vector2 linePoint, Vector2 lineDirection, Vector2 rayPoint, Vector2 rayDirection, Vector2 rayNormal)
+    public static IntersectionPoint IntersectLineRay(Vector2 linePoint, Vector2 lineDirection, Vector2 rayPoint, Vector2 rayDirection, Vector2 rayNormal)
     {
         var result = IntersectLineRay(linePoint, lineDirection, rayPoint, rayDirection);
         if (result.Valid)
@@ -469,13 +469,13 @@ public readonly partial struct Line
     /// <param name="circleCenter">The center of the circle.</param>
     /// <param name="circleRadius">The radius of the circle.</param>
     /// <returns>
-    /// A tuple containing two <see cref="CollisionPoint"/> objects representing the intersection points.
+    /// A tuple containing two <see cref="IntersectionPoint"/> objects representing the intersection points.
     /// If no intersection exists, both points are invalid.
     /// </returns>
     /// <remarks>
     /// The function calculates the closest approach of the line to the circle and determines if the line intersects the circle.
     /// </remarks>
-    public static (CollisionPoint a, CollisionPoint b) IntersectLineCircle(Vector2 linePoint, Vector2 lineDirection, Vector2 circleCenter, float circleRadius)
+    public static (IntersectionPoint a, IntersectionPoint b) IntersectLineCircle(Vector2 linePoint, Vector2 lineDirection, Vector2 circleCenter, float circleRadius)
     {
         // Normalize the direction vector
         lineDirection = lineDirection.Normalize();
@@ -506,14 +506,14 @@ public readonly partial struct Line
             var normal1 = (intersection1 - circleCenter).Normalize();
             var normal2 = (intersection2 - circleCenter).Normalize();
 
-            var p1 = new CollisionPoint(intersection1, normal1);
-            var p2 = new CollisionPoint(intersection2, normal2);
+            var p1 = new IntersectionPoint(intersection1, normal1);
+            var p2 = new IntersectionPoint(intersection2, normal2);
             return (p1, p2);
         }
 
         if (Math.Abs(distanceToCenter - circleRadius) < ShapeMath.EpsilonF)
         {
-            var p = new CollisionPoint(closestPoint, (closestPoint - circleCenter).Normalize());
+            var p = new IntersectionPoint(closestPoint, (closestPoint - circleCenter).Normalize());
             return (p, new());
         }
 
@@ -529,16 +529,16 @@ public readonly partial struct Line
     /// <param name="b">The second vertex of the triangle.</param>
     /// <param name="c">The third vertex of the triangle.</param>
     /// <returns>
-    /// A tuple containing up to two <see cref="CollisionPoint"/> objects representing the intersection points.
+    /// A tuple containing up to two <see cref="IntersectionPoint"/> objects representing the intersection points.
     /// If no intersection exists, both points are invalid.
     /// </returns>
     /// <remarks>
     /// The function checks each edge of the triangle for intersections with the line.
     /// </remarks>
-    public static (CollisionPoint a, CollisionPoint b) IntersectLineTriangle(Vector2 linePoint, Vector2 lineDirection, Vector2 a, Vector2 b, Vector2 c)
+    public static (IntersectionPoint a, IntersectionPoint b) IntersectLineTriangle(Vector2 linePoint, Vector2 lineDirection, Vector2 a, Vector2 b, Vector2 c)
     {
-        CollisionPoint resultA = new();
-        CollisionPoint resultB = new();
+        IntersectionPoint resultA = new();
+        IntersectionPoint resultB = new();
 
         var cp = IntersectLineSegment(linePoint, lineDirection, a, b);
         if (cp.Valid) resultA = cp;
@@ -572,16 +572,16 @@ public readonly partial struct Line
     /// <param name="c">The third vertex of the quadrilateral.</param>
     /// <param name="d">The fourth vertex of the quadrilateral.</param>
     /// <returns>
-    /// A tuple containing up to two <see cref="CollisionPoint"/> objects representing the intersection points.
+    /// A tuple containing up to two <see cref="IntersectionPoint"/> objects representing the intersection points.
     /// If no intersection exists, both points are invalid.
     /// </returns>
     /// <remarks>
     /// The function checks each edge of the quadrilateral for intersections with the line.
     /// </remarks>
-    public static (CollisionPoint a, CollisionPoint b) IntersectLineQuad(Vector2 linePoint, Vector2 lineDirection, Vector2 a, Vector2 b, Vector2 c, Vector2 d)
+    public static (IntersectionPoint a, IntersectionPoint b) IntersectLineQuad(Vector2 linePoint, Vector2 lineDirection, Vector2 a, Vector2 b, Vector2 c, Vector2 d)
     {
-        CollisionPoint resultA = new();
-        CollisionPoint resultB = new();
+        IntersectionPoint resultA = new();
+        IntersectionPoint resultB = new();
 
         var cp = IntersectLineSegment(linePoint, lineDirection, a, b);
         if (cp.Valid)
@@ -633,13 +633,13 @@ public readonly partial struct Line
     /// <param name="c">The third vertex of the rectangle.</param>
     /// <param name="d">The fourth vertex of the rectangle.</param>
     /// <returns>
-    /// A tuple containing up to two <see cref="CollisionPoint"/> objects representing the intersection points.
+    /// A tuple containing up to two <see cref="IntersectionPoint"/> objects representing the intersection points.
     /// If no intersection exists, both points are invalid.
     /// </returns>
     /// <remarks>
     /// This function is a specialized version of <see cref="IntersectLineQuad"/> for rectangles.
     /// </remarks>
-    public static (CollisionPoint a, CollisionPoint b) IntersectLineRect(Vector2 linePoint, Vector2 lineDirection, Vector2 a, Vector2 b, Vector2 c, Vector2 d)
+    public static (IntersectionPoint a, IntersectionPoint b) IntersectLineRect(Vector2 linePoint, Vector2 lineDirection, Vector2 a, Vector2 b, Vector2 c, Vector2 d)
     {
         return IntersectLineQuad(linePoint, lineDirection, a, b, c, d);
     }
@@ -652,16 +652,16 @@ public readonly partial struct Line
     /// <param name="points">A list of vertices defining the polygon.</param>
     /// <param name="maxCollisionPoints">The maximum number of collision points to return. Use -1 for no limit.</param>
     /// <returns>
-    /// A <see cref="CollisionPoints"/> object containing the intersection points, or null if no intersections exist.
+    /// A <see cref="IntersectionPoints"/> object containing the intersection points, or null if no intersections exist.
     /// </returns>
     /// <remarks>
     /// The function iterates through all edges of the polygon to find intersections with the line.
     /// </remarks>
-    public static CollisionPoints? IntersectLinePolygon(Vector2 linePoint, Vector2 lineDirection, List<Vector2> points, int maxCollisionPoints = -1)
+    public static IntersectionPoints? IntersectLinePolygon(Vector2 linePoint, Vector2 lineDirection, List<Vector2> points, int maxCollisionPoints = -1)
     {
         if (points.Count < 3) return null;
         if (maxCollisionPoints == 0) return null;
-        CollisionPoints? result = null;
+        IntersectionPoints? result = null;
         for (var i = 0; i < points.Count; i++)
         {
             var colPoint = IntersectLineSegment(linePoint, lineDirection, points[i], points[(i + 1) % points.Count]);
@@ -684,16 +684,16 @@ public readonly partial struct Line
     /// <param name="points">A list of vertices defining the polyline.</param>
     /// <param name="maxCollisionPoints">The maximum number of collision points to return. Use -1 for no limit.</param>
     /// <returns>
-    /// A <see cref="CollisionPoints"/> object containing the intersection points, or null if no intersections exist.
+    /// A <see cref="IntersectionPoints"/> object containing the intersection points, or null if no intersections exist.
     /// </returns>
     /// <remarks>
     /// The function iterates through all segments of the polyline to find intersections with the line.
     /// </remarks>
-    public static CollisionPoints? IntersectLinePolyline(Vector2 linePoint, Vector2 lineDirection, List<Vector2> points, int maxCollisionPoints = -1)
+    public static IntersectionPoints? IntersectLinePolyline(Vector2 linePoint, Vector2 lineDirection, List<Vector2> points, int maxCollisionPoints = -1)
     {
         if (points.Count < 3) return null;
         if (maxCollisionPoints == 0) return null;
-        CollisionPoints? result = null;
+        IntersectionPoints? result = null;
         for (var i = 0; i < points.Count - 1; i++)
         {
             var colPoint = IntersectLineSegment(linePoint, lineDirection, points[i], points[i + 1]);
@@ -716,16 +716,16 @@ public readonly partial struct Line
     /// <param name="segments">A list of segments to check for intersections.</param>
     /// <param name="maxCollisionPoints">The maximum number of collision points to return. Use -1 for no limit.</param>
     /// <returns>
-    /// A <see cref="CollisionPoints"/> object containing the intersection points, or null if no intersections exist.
+    /// A <see cref="IntersectionPoints"/> object containing the intersection points, or null if no intersections exist.
     /// </returns>
     /// <remarks>
     /// The function iterates through all segments in the collection to find intersections with the line.
     /// </remarks>
-    public static CollisionPoints? IntersectLineSegments(Vector2 linePoint, Vector2 lineDirection, List<Segment> segments, int maxCollisionPoints = -1)
+    public static IntersectionPoints? IntersectLineSegments(Vector2 linePoint, Vector2 lineDirection, List<Segment> segments, int maxCollisionPoints = -1)
     {
         if (segments.Count <= 0) return null;
         if (maxCollisionPoints == 0) return null;
-        CollisionPoints? result = null;
+        IntersectionPoints? result = null;
 
         foreach (var seg in segments)
         {
@@ -747,7 +747,7 @@ public readonly partial struct Line
     /// <param name="linePoint">A point through which the infinite line passes.</param>
     /// <param name="lineDirection">The direction vector of the infinite line.</param>
     /// <param name="points">A list of vertices defining the polygon. The polygon is assumed to be closed and non-self-intersecting.</param>
-    /// <param name="result">A reference to a <see cref="CollisionPoints"/> object that will be populated with intersection points, if any.</param>
+    /// <param name="result">A reference to a <see cref="IntersectionPoints"/> object that will be populated with intersection points, if any.</param>
     /// <param name="returnAfterFirstValid">
     /// If true, the function returns after finding the first valid intersection point. If false, all intersection points are found.
     /// </param>
@@ -755,7 +755,7 @@ public readonly partial struct Line
     /// <remarks>
     /// The function iterates through all edges of the polygon and checks for intersections with the line.
     /// </remarks>
-    public static int IntersectLinePolygon(Vector2 linePoint, Vector2 lineDirection, List<Vector2> points, ref CollisionPoints result,
+    public static int IntersectLinePolygon(Vector2 linePoint, Vector2 lineDirection, List<Vector2> points, ref IntersectionPoints result,
         bool returnAfterFirstValid = false)
     {
         if (points.Count < 3) return 0;

--- a/ShapeEngine/Geometry/PointsDef/PointsClosestPoint.cs
+++ b/ShapeEngine/Geometry/PointsDef/PointsClosestPoint.cs
@@ -263,7 +263,7 @@ public partial class Points
     {
         if (Count <= 0) return new();
 
-        var closestOther = new CollisionPoint();
+        var closestOther = new IntersectionPoint();
         int selfIndex = -1;
         int otherIndex = -1;
         float disSquared = -1f;
@@ -303,7 +303,7 @@ public partial class Points
     {
         if (Count <= 0) return new();
 
-        var closestOther = new CollisionPoint();
+        var closestOther = new IntersectionPoint();
         int selfIndex = -1;
         int otherIndex = -1;
         float disSquared = -1f;
@@ -343,7 +343,7 @@ public partial class Points
     {
         if (Count <= 0) return new();
 
-        var closestOther = new CollisionPoint();
+        var closestOther = new IntersectionPoint();
         int selfIndex = -1;
         int otherIndex = -1;
         float disSquared = -1f;
@@ -383,7 +383,7 @@ public partial class Points
     {
         if (Count <= 0) return new();
 
-        var closestOther = new CollisionPoint();
+        var closestOther = new IntersectionPoint();
         int selfIndex = -1;
         int otherIndex = -1;
         float disSquared = -1f;
@@ -423,7 +423,7 @@ public partial class Points
     {
         if (Count <= 0) return new();
 
-        var closestOther = new CollisionPoint();
+        var closestOther = new IntersectionPoint();
         int selfIndex = -1;
         int otherIndex = -1;
         float disSquared = -1f;
@@ -463,7 +463,7 @@ public partial class Points
     {
         if (Count <= 0) return new();
 
-        var closestOther = new CollisionPoint();
+        var closestOther = new IntersectionPoint();
         int selfIndex = -1;
         int otherIndex = -1;
         float disSquared = -1f;

--- a/ShapeEngine/Geometry/PolygonDef/Polygon.cs
+++ b/ShapeEngine/Geometry/PolygonDef/Polygon.cs
@@ -39,7 +39,7 @@ namespace ShapeEngine.Geometry.PolygonDef;
 /// </remarks>
 public partial class Polygon : Points, IEquatable<Polygon>
 {
-    private static CollisionPoints collisionPointsReference = new(4);
+    private static IntersectionPoints intersectionPointsReference = new(4);
     /// <summary>
     /// Creates a deep copy of the current polygon.
     /// </summary>

--- a/ShapeEngine/Geometry/PolygonDef/PolygonClosestPoint.cs
+++ b/ShapeEngine/Geometry/PolygonDef/PolygonClosestPoint.cs
@@ -52,8 +52,8 @@ public partial class Polygon
     /// </summary>
     /// <param name="p">The point to test.</param>
     /// <param name="disSquared">The squared distance to the closest point (output).</param>
-    /// <returns>The closest point and its normal as a <see cref="CollisionPoint"/>.</returns>
-    public new CollisionPoint GetClosestPoint(Vector2 p, out float disSquared)
+    /// <returns>The closest point and its normal as a <see cref="IntersectionPoint"/>.</returns>
+    public new IntersectionPoint GetClosestPoint(Vector2 p, out float disSquared)
     {
         disSquared = -1;
         if (Count <= 2) return new();
@@ -86,8 +86,8 @@ public partial class Polygon
     /// <param name="p">The point to test.</param>
     /// <param name="disSquared">The squared distance to the closest point (output).</param>
     /// <param name="index">The index of the closest edge (output).</param>
-    /// <returns>The closest point and its normal as a <see cref="CollisionPoint"/>.</returns>
-    public new CollisionPoint GetClosestPoint(Vector2 p, out float disSquared, out int index)
+    /// <returns>The closest point and its normal as a <see cref="IntersectionPoint"/>.</returns>
+    public new IntersectionPoint GetClosestPoint(Vector2 p, out float disSquared, out int index)
     {
         disSquared = -1;
         index = -1;
@@ -669,8 +669,8 @@ public partial class Polygon
     /// </summary>
     /// <param name="p">The point to test.</param>
     /// <param name="disSquared">The squared distance to the closest segment (output).</param>
-    /// <returns>The closest segment and its closest point as a <see cref="CollisionPoint"/>.</returns>
-    public (Segment segment, CollisionPoint segmentPoint) GetClosestSegment(Vector2 p, out float disSquared)
+    /// <returns>The closest segment and its closest point as a <see cref="IntersectionPoint"/>.</returns>
+    public (Segment segment, IntersectionPoint segmentPoint) GetClosestSegment(Vector2 p, out float disSquared)
     {
         disSquared = -1;
         if (Count <= 2) return (new(), new());

--- a/ShapeEngine/Geometry/PolygonDef/PolygonIntersectShape.cs
+++ b/ShapeEngine/Geometry/PolygonDef/PolygonIntersectShape.cs
@@ -21,11 +21,11 @@ public partial class Polygon
     /// <param name="polygon">The polygon as a list of points.</param>
     /// <param name="rayPoint">The origin of the ray.</param>
     /// <param name="rayDirection">The direction of the ray.</param>
-    /// <returns>A <see cref="CollisionPoints"/> collection of intersection points, or null if none.</returns>
-    public static CollisionPoints? IntersectPolygonRay(List<Vector2> polygon, Vector2 rayPoint, Vector2 rayDirection)
+    /// <returns>A <see cref="IntersectionPoints"/> collection of intersection points, or null if none.</returns>
+    public static IntersectionPoints? IntersectPolygonRay(List<Vector2> polygon, Vector2 rayPoint, Vector2 rayDirection)
     {
         if (polygon.Count < 3) return null;
-        CollisionPoints? points = null;
+        IntersectionPoints? points = null;
         for (var i = 0; i < polygon.Count; i++)
         {
             var result = Segment.IntersectSegmentRay(polygon[i], polygon[(i + 1) % polygon.Count], rayPoint, rayDirection);
@@ -42,8 +42,8 @@ public partial class Polygon
     /// Computes intersection points between this polygon and a collider.
     /// </summary>
     /// <param name="collider">The collider to test against.</param>
-    /// <returns>A <see cref="CollisionPoints"/> collection of intersection points, or null if none.</returns>
-    public CollisionPoints? Intersect(Collider collider)
+    /// <returns>A <see cref="IntersectionPoints"/> collection of intersection points, or null if none.</returns>
+    public IntersectionPoints? Intersect(Collider collider)
     {
         if (!collider.Enabled) return null;
 
@@ -84,11 +84,11 @@ public partial class Polygon
     /// Computes intersection points between this polygon and a ray.
     /// </summary>
     /// <param name="r">The ray to test against.</param>
-    /// <returns>A <see cref="CollisionPoints"/> collection of intersection points, or null if none.</returns>
-    public CollisionPoints? IntersectShape(Ray r)
+    /// <returns>A <see cref="IntersectionPoints"/> collection of intersection points, or null if none.</returns>
+    public IntersectionPoints? IntersectShape(Ray r)
     {
         if (Count < 3) return null;
-        CollisionPoints? points = null;
+        IntersectionPoints? points = null;
         for (var i = 0; i < Count; i++)
         {
             var result = Segment.IntersectSegmentRay(this[i], this[(i + 1) % Count], r.Point, r.Direction, r.Normal);
@@ -105,11 +105,11 @@ public partial class Polygon
     /// Computes intersection points between this polygon and a line.
     /// </summary>
     /// <param name="l">The line to test against.</param>
-    /// <returns>A <see cref="CollisionPoints"/> collection of intersection points, or null if none.</returns>
-    public CollisionPoints? IntersectShape(Line l)
+    /// <returns>A <see cref="IntersectionPoints"/> collection of intersection points, or null if none.</returns>
+    public IntersectionPoints? IntersectShape(Line l)
     {
         if (Count < 3) return null;
-        CollisionPoints? points = null;
+        IntersectionPoints? points = null;
         for (var i = 0; i < Count; i++)
         {
             var result = Segment.IntersectSegmentLine(this[i], this[(i + 1) % Count], l.Point, l.Direction, l.Normal);
@@ -126,11 +126,11 @@ public partial class Polygon
     /// Computes intersection points between this polygon and a segment.
     /// </summary>
     /// <param name="s">The segment to test against.</param>
-    /// <returns>A <see cref="CollisionPoints"/> collection of intersection points, or null if none.</returns>
-    public CollisionPoints? IntersectShape(Segment s)
+    /// <returns>A <see cref="IntersectionPoints"/> collection of intersection points, or null if none.</returns>
+    public IntersectionPoints? IntersectShape(Segment s)
     {
         if (Count < 3) return null;
-        CollisionPoints? points = null;
+        IntersectionPoints? points = null;
         for (var i = 0; i < Count; i++)
         {
             var result = Segment.IntersectSegmentSegment(this[i], this[(i + 1) % Count], s.Start, s.End);
@@ -147,12 +147,12 @@ public partial class Polygon
     /// Computes intersection points between this polygon and a circle.
     /// </summary>
     /// <param name="c">The circle to test against.</param>
-    /// <returns>A <see cref="CollisionPoints"/> collection of intersection points, or null if none.</returns>
-    public CollisionPoints? IntersectShape(Circle c)
+    /// <returns>A <see cref="IntersectionPoints"/> collection of intersection points, or null if none.</returns>
+    public IntersectionPoints? IntersectShape(Circle c)
     {
         if (Count < 3) return null;
 
-        CollisionPoints? points = null;
+        IntersectionPoints? points = null;
 
         for (var i = 0; i < Count; i++)
         {
@@ -171,12 +171,12 @@ public partial class Polygon
     /// Computes intersection points between this polygon and a triangle.
     /// </summary>
     /// <param name="t">The triangle to test against.</param>
-    /// <returns>A <see cref="CollisionPoints"/> collection of intersection points, or null if none.</returns>
-    public CollisionPoints? IntersectShape(Triangle t)
+    /// <returns>A <see cref="IntersectionPoints"/> collection of intersection points, or null if none.</returns>
+    public IntersectionPoints? IntersectShape(Triangle t)
     {
         if (Count < 3) return null;
 
-        CollisionPoints? points = null;
+        IntersectionPoints? points = null;
         for (var i = 0; i < Count; i++)
         {
             var result = Segment.IntersectSegmentSegment(this[i], this[(i + 1) % Count], t.A, t.B);
@@ -207,12 +207,12 @@ public partial class Polygon
     /// Computes intersection points between this polygon and a rectangle.
     /// </summary>
     /// <param name="r">The rectangle to test against.</param>
-    /// <returns>A <see cref="CollisionPoints"/> collection of intersection points, or null if none.</returns>
-    public CollisionPoints? IntersectShape(Rect r)
+    /// <returns>A <see cref="IntersectionPoints"/> collection of intersection points, or null if none.</returns>
+    public IntersectionPoints? IntersectShape(Rect r)
     {
         if (Count < 3) return null;
 
-        CollisionPoints? points = null;
+        IntersectionPoints? points = null;
 
         var a = r.TopLeft;
         var b = r.BottomLeft;
@@ -256,12 +256,12 @@ public partial class Polygon
     /// Computes intersection points between this polygon and a quad.
     /// </summary>
     /// <param name="q">The quad to test against.</param>
-    /// <returns>A <see cref="CollisionPoints"/> collection of intersection points, or null if none.</returns>
-    public CollisionPoints? IntersectShape(Quad q)
+    /// <returns>A <see cref="IntersectionPoints"/> collection of intersection points, or null if none.</returns>
+    public IntersectionPoints? IntersectShape(Quad q)
     {
         if (Count < 3) return null;
 
-        CollisionPoints? points = null;
+        IntersectionPoints? points = null;
         for (var i = 0; i < Count; i++)
         {
             var result = Segment.IntersectSegmentSegment(this[i], this[(i + 1) % Count], q.A, q.B);
@@ -299,11 +299,11 @@ public partial class Polygon
     /// Computes intersection points between this polygon and another polygon.
     /// </summary>
     /// <param name="p">The other polygon to test against.</param>
-    /// <returns>A <see cref="CollisionPoints"/> collection of intersection points, or null if none.</returns>
-    public CollisionPoints? IntersectShape(Polygon p)
+    /// <returns>A <see cref="IntersectionPoints"/> collection of intersection points, or null if none.</returns>
+    public IntersectionPoints? IntersectShape(Polygon p)
     {
         if (Count < 3 || p.Count < 3) return null;
-        CollisionPoints? points = null;
+        IntersectionPoints? points = null;
         for (var i = 0; i < Count; i++)
         {
             for (var j = 0; j < p.Count; j++)
@@ -323,11 +323,11 @@ public partial class Polygon
     /// Computes intersection points between this polygon and a polyline.
     /// </summary>
     /// <param name="pl">The polyline to test against.</param>
-    /// <returns>A <see cref="CollisionPoints"/> collection of intersection points, or null if none.</returns>
-    public CollisionPoints? IntersectShape(Polyline pl)
+    /// <returns>A <see cref="IntersectionPoints"/> collection of intersection points, or null if none.</returns>
+    public IntersectionPoints? IntersectShape(Polyline pl)
     {
         if (Count < 3 || pl.Count < 2) return null;
-        CollisionPoints? points = null;
+        IntersectionPoints? points = null;
         for (var i = 0; i < Count; i++)
         {
             for (var j = 0; j < pl.Count - 1; j++)
@@ -347,14 +347,14 @@ public partial class Polygon
     /// Computes intersection points between this polygon and a set of segments.
     /// </summary>
     /// <param name="segments">The segments to test against.</param>
-    /// <returns>A <see cref="CollisionPoints"/> collection of intersection points, or null if none.</returns>
+    /// <returns>A <see cref="IntersectionPoints"/> collection of intersection points, or null if none.</returns>
     /// <remarks>
     /// Each segment in the set is tested against all edges of the polygon. All valid intersection points are collected and returned.
     /// </remarks>
-    public CollisionPoints? IntersectShape(Segments segments)
+    public IntersectionPoints? IntersectShape(Segments segments)
     {
         if (Count < 3 || segments.Count <= 0) return null;
-        CollisionPoints? points = null;
+        IntersectionPoints? points = null;
         for (var i = 0; i < Count; i++)
         {
             foreach (var seg in segments)

--- a/ShapeEngine/Geometry/PolygonDef/PolygonIntersectShape2.cs
+++ b/ShapeEngine/Geometry/PolygonDef/PolygonIntersectShape2.cs
@@ -22,7 +22,7 @@ public partial class Polygon
     /// <param name="rayDirection">The direction of the ray.</param>
     /// <param name="result">The collection to which intersection points are added.</param>
     /// <returns>The number of new intersection points added.</returns>
-    public static int IntersectPolygonRay(List<Vector2> polygon, Vector2 rayPoint, Vector2 rayDirection, ref CollisionPoints result)
+    public static int IntersectPolygonRay(List<Vector2> polygon, Vector2 rayPoint, Vector2 rayDirection, ref IntersectionPoints result)
     {
         if (polygon.Count < 3) return 0;
         int count = result.Count;
@@ -44,7 +44,7 @@ public partial class Polygon
     /// <param name="points">The collection to which intersection points are added.</param>
     /// <param name="returnAfterFirstValid">If true, returns after the first valid intersection is found.</param>
     /// <returns>The number of new intersection points added.</returns>
-    public int Intersect(Collider collider, ref CollisionPoints points, bool returnAfterFirstValid = false)
+    public int Intersect(Collider collider, ref IntersectionPoints points, bool returnAfterFirstValid = false)
     {
         if (!collider.Enabled) return 0;
 
@@ -88,7 +88,7 @@ public partial class Polygon
     /// <param name="points">The collection to which intersection points are added.</param>
     /// <param name="returnAfterFirstValid">If true, returns after the first valid intersection is found.</param>
     /// <returns>The number of new intersection points added.</returns>
-    public int IntersectShape(Ray r, ref CollisionPoints points, bool returnAfterFirstValid = false)
+    public int IntersectShape(Ray r, ref IntersectionPoints points, bool returnAfterFirstValid = false)
     {
         if (Count < 3) return 0;
         var count = 0;
@@ -112,7 +112,7 @@ public partial class Polygon
     /// <param name="points">The collection to which intersection points are added.</param>
     /// <param name="returnAfterFirstValid">If true, returns after the first valid intersection is found.</param>
     /// <returns>The number of new intersection points added.</returns>
-    public int IntersectShape(Line l, ref CollisionPoints points, bool returnAfterFirstValid = false)
+    public int IntersectShape(Line l, ref IntersectionPoints points, bool returnAfterFirstValid = false)
     {
         if (Count < 3) return 0;
         var count = 0;
@@ -136,7 +136,7 @@ public partial class Polygon
     /// <param name="points">The collection to which intersection points are added.</param>
     /// <param name="returnAfterFirstValid">If true, returns after the first valid intersection is found.</param>
     /// <returns>The number of new intersection points added.</returns>
-    public int IntersectShape(Segment s, ref CollisionPoints points, bool returnAfterFirstValid = false)
+    public int IntersectShape(Segment s, ref IntersectionPoints points, bool returnAfterFirstValid = false)
     {
         if (Count < 3) return 0;
         var count = 0;
@@ -160,7 +160,7 @@ public partial class Polygon
     /// <param name="points">The collection to which intersection points are added.</param>
     /// <param name="returnAfterFirstValid">If true, returns after the first valid intersection is found.</param>
     /// <returns>The number of new intersection points added.</returns>
-    public int IntersectShape(Circle c, ref CollisionPoints points, bool returnAfterFirstValid = false)
+    public int IntersectShape(Circle c, ref IntersectionPoints points, bool returnAfterFirstValid = false)
     {
         if (Count < 3) return 0;
 
@@ -193,7 +193,7 @@ public partial class Polygon
     /// <param name="points">The collection to which intersection points are added.</param>
     /// <param name="returnAfterFirstValid">If true, returns after the first valid intersection is found.</param>
     /// <returns>The number of new intersection points added.</returns>
-    public int IntersectShape(Triangle t, ref CollisionPoints points, bool returnAfterFirstValid = false)
+    public int IntersectShape(Triangle t, ref IntersectionPoints points, bool returnAfterFirstValid = false)
     {
         if (Count < 3) return 0;
 
@@ -234,7 +234,7 @@ public partial class Polygon
     /// <param name="points">The collection to which intersection points are added.</param>
     /// <param name="returnAfterFirstValid">If true, returns after the first valid intersection is found.</param>
     /// <returns>The number of new intersection points added.</returns>
-    public int IntersectShape(Quad q, ref CollisionPoints points, bool returnAfterFirstValid = false)
+    public int IntersectShape(Quad q, ref IntersectionPoints points, bool returnAfterFirstValid = false)
     {
         if (Count < 3) return 0;
 
@@ -283,7 +283,7 @@ public partial class Polygon
     /// <param name="points">The collection to which intersection points are added.</param>
     /// <param name="returnAfterFirstValid">If true, returns after the first valid intersection is found.</param>
     /// <returns>The number of new intersection points added.</returns>
-    public int IntersectShape(Rect r, ref CollisionPoints points, bool returnAfterFirstValid = false)
+    public int IntersectShape(Rect r, ref IntersectionPoints points, bool returnAfterFirstValid = false)
     {
         if (Count < 3) return 0;
 
@@ -338,7 +338,7 @@ public partial class Polygon
     /// <param name="points">The collection to which intersection points are added.</param>
     /// <param name="returnAfterFirstValid">If true, returns after the first valid intersection is found.</param>
     /// <returns>The number of new intersection points added.</returns>
-    public int IntersectShape(Polygon p, ref CollisionPoints points, bool returnAfterFirstValid = false)
+    public int IntersectShape(Polygon p, ref IntersectionPoints points, bool returnAfterFirstValid = false)
     {
         if (Count < 3 || p.Count < 3) return 0;
         var count = 0;
@@ -365,7 +365,7 @@ public partial class Polygon
     /// <param name="points">The collection to which intersection points are added.</param>
     /// <param name="returnAfterFirstValid">If true, returns after the first valid intersection is found.</param>
     /// <returns>The number of new intersection points added.</returns>
-    public int IntersectShape(Polyline pl, ref CollisionPoints points, bool returnAfterFirstValid = false)
+    public int IntersectShape(Polyline pl, ref IntersectionPoints points, bool returnAfterFirstValid = false)
     {
         if (Count < 3 || pl.Count < 2) return 0;
         var count = 0;
@@ -395,7 +395,7 @@ public partial class Polygon
     /// <remarks>
     /// Each segment in the set is tested against all edges of the polygon. All valid intersection points are collected and returned unless <paramref name="returnAfterFirstValid"/> is true.
     /// </remarks>
-    public int IntersectShape(Segments shape, ref CollisionPoints points, bool returnAfterFirstValid = false)
+    public int IntersectShape(Segments shape, ref IntersectionPoints points, bool returnAfterFirstValid = false)
     {
         if (Count < 3 || shape.Count <= 0) return 0;
         var count = 0;

--- a/ShapeEngine/Geometry/PolygonDef/PolygonStatic.cs
+++ b/ShapeEngine/Geometry/PolygonDef/PolygonStatic.cs
@@ -57,21 +57,21 @@ public partial class Polygon
         if (rayDirection.X == 0 && rayDirection.Y == 0) return 0;
 
         rayDirection = rayDirection.Normalize();
-        var intersectionPoints = IntersectPolygonRay(this, rayPoint, rayDirection, ref collisionPointsReference);
+        var intersectionPoints = IntersectPolygonRay(this, rayPoint, rayDirection, ref intersectionPointsReference);
         if (intersectionPoints < 2) return 0;
 
         int count = result.Count;
-        collisionPointsReference.SortClosestFirst(rayPoint);
+        intersectionPointsReference.SortClosestFirst(rayPoint);
 
-        for (int i = 0; i < collisionPointsReference.Count - 1; i += 2)
+        for (int i = 0; i < intersectionPointsReference.Count - 1; i += 2)
         {
-            var segmentStart = collisionPointsReference[i].Point;
-            var segmentEnd = collisionPointsReference[i + 1].Point;
+            var segmentStart = intersectionPointsReference[i].Point;
+            var segmentEnd = intersectionPointsReference[i + 1].Point;
             var segment = new Segment(segmentStart, segmentEnd);
             result.Add(segment);
         }
 
-        collisionPointsReference.Clear();
+        intersectionPointsReference.Clear();
         return result.Count - count;
     }
 

--- a/ShapeEngine/Geometry/PolylineDef/PolylineClosestPoint.cs
+++ b/ShapeEngine/Geometry/PolylineDef/PolylineClosestPoint.cs
@@ -58,14 +58,14 @@ public partial class Polyline
     /// </summary>
     /// <param name="p">The point to which the closest point on the polyline is sought.</param>
     /// <param name="disSquared">Outputs the squared distance from <paramref name="p"/> to the closest point on the polyline.</param>
-    /// <returns>A <see cref="CollisionPoint"/> representing the closest point on the polyline.
+    /// <returns>A <see cref="IntersectionPoint"/> representing the closest point on the polyline.
     /// Returns a default value if the polyline has fewer than two points.</returns>
     /// <remarks>
     /// This method iterates through each segment of the polyline
     /// and finds the closest point on each segment to <paramref name="p"/>.
-    /// The closest of these is returned as a <see cref="CollisionPoint"/>.
+    /// The closest of these is returned as a <see cref="IntersectionPoint"/>.
     /// </remarks>
-    public new CollisionPoint GetClosestPoint(Vector2 p, out float disSquared)
+    public new IntersectionPoint GetClosestPoint(Vector2 p, out float disSquared)
     {
         disSquared = -1;
         if (Count < 2) return new();
@@ -99,14 +99,14 @@ public partial class Polyline
     /// <param name="p">The point to which the closest point on the polyline is sought.</param>
     /// <param name="disSquared">Outputs the squared distance from <paramref name="p"/> to the closest point on the polyline.</param>
     /// <param name="index">Outputs the index of the segment containing the closest point.</param>
-    /// <returns>A <see cref="CollisionPoint"/> representing the closest point on the polyline.
+    /// <returns>A <see cref="IntersectionPoint"/> representing the closest point on the polyline.
     /// Returns a default value if the polyline has fewer than two points.</returns>
     /// <remarks>
     /// This method iterates through each segment of the polyline
     /// and finds the closest point on each segment to <paramref name="p"/>.
-    /// The closest of these is returned as a <see cref="CollisionPoint"/>, and the segment index is provided.
+    /// The closest of these is returned as a <see cref="IntersectionPoint"/>, and the segment index is provided.
     /// </remarks>
-    public new CollisionPoint GetClosestPoint(Vector2 p, out float disSquared, out int index)
+    public new IntersectionPoint GetClosestPoint(Vector2 p, out float disSquared, out int index)
     {
         disSquared = -1;
         index = -1;
@@ -768,13 +768,13 @@ public partial class Polyline
     /// </summary>
     /// <param name="p">The point to which the closest segment is sought.</param>
     /// <param name="disSquared">Outputs the squared distance from <paramref name="p"/> to the closest point on the segment.</param>
-    /// <returns>A tuple containing the closest <see cref="Segment"/> and the closest point on that segment as a <see cref="CollisionPoint"/>.</returns>
+    /// <returns>A tuple containing the closest <see cref="Segment"/> and the closest point on that segment as a <see cref="IntersectionPoint"/>.</returns>
     /// <remarks>
     /// This method iterates through each segment of the polyline
     /// and finds the closest point on each segment to <paramref name="p"/>.
     /// The closest of these segments and points is returned.
     /// </remarks>
-    public (Segment segment, CollisionPoint segmentPoint) GetClosestSegment(Vector2 p, out float disSquared)
+    public (Segment segment, IntersectionPoint segmentPoint) GetClosestSegment(Vector2 p, out float disSquared)
     {
         disSquared = -1;
         if (Count < 2) return (new(), new());

--- a/ShapeEngine/Geometry/PolylineDef/PolylineIntersectShape.cs
+++ b/ShapeEngine/Geometry/PolylineDef/PolylineIntersectShape.cs
@@ -18,13 +18,13 @@ public partial class Polyline
     /// </summary>
     /// <param name="collider">The collider whose shape will be tested for intersection with this polyline.</param>
     /// <returns>
-    /// A <see cref="CollisionPoints"/> object containing intersection points,
+    /// A <see cref="IntersectionPoints"/> object containing intersection points,
     /// or <c>null</c> if there are no intersections or the collider is disabled.
     /// </returns>
     /// <remarks>
     /// The method dispatches to the appropriate intersection routine based on the collider's shape type.
     /// </remarks>
-    public CollisionPoints? Intersect(Collider collider)
+    public IntersectionPoints? Intersect(Collider collider)
     {
         if (!collider.Enabled) return null;
 
@@ -67,17 +67,17 @@ public partial class Polyline
     /// </summary>
     /// <param name="ray">The <see cref="Ray"/> to test for intersection.</param>
     /// <returns>
-    /// A <see cref="CollisionPoints"/> object containing intersection points,
+    /// A <see cref="IntersectionPoints"/> object containing intersection points,
     /// or <c>null</c> if there are no intersections.
     /// </returns>
     /// <remarks>
     /// Iterates through each segment of the polyline and checks for intersection with the ray.
     /// </remarks>
-    public CollisionPoints? IntersectShape(Ray ray)
+    public IntersectionPoints? IntersectShape(Ray ray)
     {
         if (Count < 2) return null;
 
-        CollisionPoints? points = null;
+        IntersectionPoints? points = null;
         for (var i = 0; i < Count - 1; i++)
         {
             var result = Segment.IntersectSegmentRay(this[i], this[i + 1], ray.Point, ray.Direction, ray.Normal);
@@ -96,17 +96,17 @@ public partial class Polyline
     /// </summary>
     /// <param name="l">The <see cref="Line"/> to test for intersection.</param>
     /// <returns>
-    /// A <see cref="CollisionPoints"/> object containing intersection points,
+    /// A <see cref="IntersectionPoints"/> object containing intersection points,
     /// or <c>null</c> if there are no intersections.
     /// </returns>
     /// <remarks>
     /// Iterates through each segment of the polyline and checks for intersection with the line.
     /// </remarks>
-    public CollisionPoints? IntersectShape(Line l)
+    public IntersectionPoints? IntersectShape(Line l)
     {
         if (Count < 2) return null;
 
-        CollisionPoints? points = null;
+        IntersectionPoints? points = null;
         for (var i = 0; i < Count - 1; i++)
         {
             var result = Segment.IntersectSegmentLine(this[i], this[i + 1], l.Point, l.Direction, l.Normal);
@@ -124,16 +124,16 @@ public partial class Polyline
     /// Computes the intersection points between this polyline and a <see cref="Segment"/>.
     /// </summary>
     /// <param name="s">The <see cref="Segment"/> to test for intersection.</param>
-    /// <returns>A <see cref="CollisionPoints"/> object containing intersection points,
+    /// <returns>A <see cref="IntersectionPoints"/> object containing intersection points,
     /// or <c>null</c> if there are no intersections.</returns>
     /// <remarks>
     /// Iterates through each segment of the polyline and checks for intersection with the segment.
     /// </remarks>
-    public CollisionPoints? IntersectShape(Segment s)
+    public IntersectionPoints? IntersectShape(Segment s)
     {
         if (Count < 2) return null;
 
-        CollisionPoints? points = null;
+        IntersectionPoints? points = null;
         for (var i = 0; i < Count - 1; i++)
         {
             var result = Segment.IntersectSegmentSegment(this[i], this[i + 1], s.Start, s.End);
@@ -151,16 +151,16 @@ public partial class Polyline
     /// Computes the intersection points between this polyline and a <see cref="Circle"/>.
     /// </summary>
     /// <param name="c">The <see cref="Circle"/> to test for intersection.</param>
-    /// <returns>A <see cref="CollisionPoints"/> object containing intersection points,
+    /// <returns>A <see cref="IntersectionPoints"/> object containing intersection points,
     /// or <c>null</c> if there are no intersections.</returns>
     /// <remarks>
     /// Iterates through each segment of the polyline and checks for intersection with the circle.
     /// </remarks>
-    public CollisionPoints? IntersectShape(Circle c)
+    public IntersectionPoints? IntersectShape(Circle c)
     {
         if (Count < 2) return null;
 
-        CollisionPoints? points = null;
+        IntersectionPoints? points = null;
 
         for (var i = 0; i < Count - 1; i++)
         {
@@ -180,16 +180,16 @@ public partial class Polyline
     /// Computes the intersection points between this polyline and a <see cref="Triangle"/>.
     /// </summary>
     /// <param name="t">The <see cref="Triangle"/> to test for intersection.</param>
-    /// <returns>A <see cref="CollisionPoints"/> object containing intersection points,
+    /// <returns>A <see cref="IntersectionPoints"/> object containing intersection points,
     /// or <c>null</c> if there are no intersections.</returns>
     /// <remarks>
     /// Iterates through each segment of the polyline and each edge of the triangle, checking for intersections.
     /// </remarks>
-    public CollisionPoints? IntersectShape(Triangle t)
+    public IntersectionPoints? IntersectShape(Triangle t)
     {
         if (Count < 2) return null;
 
-        CollisionPoints? points = null;
+        IntersectionPoints? points = null;
         for (var i = 0; i < Count - 1; i++)
         {
             var p1 = this[i];
@@ -223,16 +223,16 @@ public partial class Polyline
     /// Computes the intersection points between this polyline and a <see cref="Rect"/>.
     /// </summary>
     /// <param name="r">The <see cref="Rect"/> to test for intersection.</param>
-    /// <returns>A <see cref="CollisionPoints"/> object containing intersection points,
+    /// <returns>A <see cref="IntersectionPoints"/> object containing intersection points,
     /// or <c>null</c> if there are no intersections.</returns>
     /// <remarks>
     /// Iterates through each segment of the polyline and each edge of the rectangle, checking for intersections.
     /// </remarks>
-    public CollisionPoints? IntersectShape(Rect r)
+    public IntersectionPoints? IntersectShape(Rect r)
     {
         if (Count < 2) return null;
 
-        CollisionPoints? points = null;
+        IntersectionPoints? points = null;
         var a = r.TopLeft;
         var b = r.BottomLeft;
         var c = r.BottomRight;
@@ -277,16 +277,16 @@ public partial class Polyline
     /// Computes the intersection points between this polyline and a <see cref="Quad"/>.
     /// </summary>
     /// <param name="q">The <see cref="Quad"/> to test for intersection.</param>
-    /// <returns>A <see cref="CollisionPoints"/> object containing intersection points,
+    /// <returns>A <see cref="IntersectionPoints"/> object containing intersection points,
     /// or <c>null</c> if there are no intersections.</returns>
     /// <remarks>
     /// Iterates through each segment of the polyline and each edge of the quad, checking for intersections.
     /// </remarks>
-    public CollisionPoints? IntersectShape(Quad q)
+    public IntersectionPoints? IntersectShape(Quad q)
     {
         if (Count < 2) return null;
 
-        CollisionPoints? points = null;
+        IntersectionPoints? points = null;
         for (var i = 0; i < Count - 1; i++)
         {
             var p1 = this[i];
@@ -327,15 +327,15 @@ public partial class Polyline
     /// Computes the intersection points between this polyline and a <see cref="Polygon"/>.
     /// </summary>
     /// <param name="p">The <see cref="Polygon"/> to test for intersection.</param>
-    /// <returns>A <see cref="CollisionPoints"/> object containing intersection points,
+    /// <returns>A <see cref="IntersectionPoints"/> object containing intersection points,
     /// or <c>null</c> if there are no intersections.</returns>
     /// <remarks>
     /// Iterates through each segment of the polyline and each edge of the polygon, checking for intersections.
     /// </remarks>
-    public CollisionPoints? IntersectShape(Polygon p)
+    public IntersectionPoints? IntersectShape(Polygon p)
     {
         if (p.Count < 3 || Count < 2) return null;
-        CollisionPoints? points = null;
+        IntersectionPoints? points = null;
         for (var i = 0; i < Count - 1; i++)
         {
             for (var j = 0; j < p.Count; j++)
@@ -356,15 +356,15 @@ public partial class Polyline
     /// Computes the intersection points between this polyline and another <see cref="Polyline"/>.
     /// </summary>
     /// <param name="pl">The <see cref="Polyline"/> to test for intersection.</param>
-    /// <returns>A <see cref="CollisionPoints"/> object containing intersection points,
+    /// <returns>A <see cref="IntersectionPoints"/> object containing intersection points,
     /// or <c>null</c> if there are no intersections.</returns>
     /// <remarks>
     /// Iterates through each segment of both polylines, checking for intersections between all segment pairs.
     /// </remarks>
-    public CollisionPoints? IntersectShape(Polyline pl)
+    public IntersectionPoints? IntersectShape(Polyline pl)
     {
         if (pl.Count < 2 || Count < 2) return null;
-        CollisionPoints? points = null;
+        IntersectionPoints? points = null;
         for (var i = 0; i < Count - 1; i++)
         {
             for (var j = 0; j < pl.Count - 1; j++)
@@ -385,15 +385,15 @@ public partial class Polyline
     /// Computes the intersection points between this polyline and a <see cref="Segments"/> collection.
     /// </summary>
     /// <param name="segments">The <see cref="Segments"/> collection to test for intersection.</param>
-    /// <returns>A <see cref="CollisionPoints"/> object containing intersection points,
+    /// <returns>A <see cref="IntersectionPoints"/> object containing intersection points,
     /// or <c>null</c> if there are no intersections.</returns>
     /// <remarks>
     /// Iterates through each segment of the polyline and each segment in the collection, checking for intersections.
     /// </remarks>
-    public CollisionPoints? IntersectShape(Segments segments)
+    public IntersectionPoints? IntersectShape(Segments segments)
     {
         if (Count < 2 || segments.Count <= 0) return null;
-        CollisionPoints? points = null;
+        IntersectionPoints? points = null;
         for (var i = 0; i < Count - 1; i++)
         {
             foreach (var seg in segments)

--- a/ShapeEngine/Geometry/PolylineDef/PolylineIntersectShape2.cs
+++ b/ShapeEngine/Geometry/PolylineDef/PolylineIntersectShape2.cs
@@ -15,10 +15,10 @@ public partial class Polyline
 {
     /// <summary>
     /// Computes the intersection points between this polyline and another collider's shape,
-    /// storing results in a provided <see cref="CollisionPoints"/> collection.
+    /// storing results in a provided <see cref="IntersectionPoints"/> collection.
     /// </summary>
     /// <param name="collider">The collider whose shape will be tested for intersection with this polyline.</param>
-    /// <param name="points">A reference to a <see cref="CollisionPoints"/> collection
+    /// <param name="points">A reference to a <see cref="IntersectionPoints"/> collection
     /// where intersection points will be stored.</param>
     /// <param name="returnAfterFirstValid">If true, the method returns after finding the first valid intersection;
     /// otherwise, it finds all intersections.</param>
@@ -27,7 +27,7 @@ public partial class Polyline
     /// The method dispatches to the appropriate intersection routine based on the collider's shape type.
     /// This overload allows for efficient accumulation of results.
     /// </remarks>
-    public int Intersect(Collider collider, ref CollisionPoints points, bool returnAfterFirstValid = false)
+    public int Intersect(Collider collider, ref IntersectionPoints points, bool returnAfterFirstValid = false)
     {
         if (!collider.Enabled) return 0;
 
@@ -66,17 +66,17 @@ public partial class Polyline
     }
 
     /// <summary>
-    /// Computes the intersection points between this polyline and a <see cref="Ray"/>, storing results in a provided <see cref="CollisionPoints"/> collection.
+    /// Computes the intersection points between this polyline and a <see cref="Ray"/>, storing results in a provided <see cref="IntersectionPoints"/> collection.
     /// </summary>
     /// <param name="r">The <see cref="Ray"/> to test for intersection.</param>
-    /// <param name="points">A reference to a <see cref="CollisionPoints"/> collection where intersection points will be stored.</param>
+    /// <param name="points">A reference to a <see cref="IntersectionPoints"/> collection where intersection points will be stored.</param>
     /// <param name="returnAfterFirstValid">If true, the method returns after finding the first valid intersection; otherwise, it finds all intersections.</param>
     /// <returns>The number of intersection points found.</returns>
     /// <remarks>
     /// Iterates through each segment of the polyline and checks for intersection with the ray.
     /// This overload allows for efficient accumulation of results.
     /// </remarks>
-    public int IntersectShape(Ray r, ref CollisionPoints points, bool returnAfterFirstValid = false)
+    public int IntersectShape(Ray r, ref IntersectionPoints points, bool returnAfterFirstValid = false)
     {
         if (Count < 2) return 0;
 
@@ -97,10 +97,10 @@ public partial class Polyline
 
     /// <summary>
     /// Computes the intersection points between this polyline and a <see cref="Line"/>,
-    /// storing results in a provided <see cref="CollisionPoints"/> collection.
+    /// storing results in a provided <see cref="IntersectionPoints"/> collection.
     /// </summary>
     /// <param name="l">The <see cref="Line"/> to test for intersection.</param>
-    /// <param name="points">A reference to a <see cref="CollisionPoints"/> collection where intersection points will be stored.</param>
+    /// <param name="points">A reference to a <see cref="IntersectionPoints"/> collection where intersection points will be stored.</param>
     /// <param name="returnAfterFirstValid">If true, the method returns after finding the first valid intersection;
     /// otherwise, it finds all intersections.</param>
     /// <returns>The number of intersection points found.</returns>
@@ -108,7 +108,7 @@ public partial class Polyline
     /// Iterates through each segment of the polyline and checks for intersection with the line.
     /// This overload allows for efficient accumulation of results.
     /// </remarks>
-    public int IntersectShape(Line l, ref CollisionPoints points, bool returnAfterFirstValid = false)
+    public int IntersectShape(Line l, ref IntersectionPoints points, bool returnAfterFirstValid = false)
     {
         if (Count < 2) return 0;
 
@@ -129,10 +129,10 @@ public partial class Polyline
 
     /// <summary>
     /// Computes the intersection points between this polyline and a <see cref="Segment"/>,
-    /// storing results in a provided <see cref="CollisionPoints"/> collection.
+    /// storing results in a provided <see cref="IntersectionPoints"/> collection.
     /// </summary>
     /// <param name="s">The <see cref="Segment"/> to test for intersection.</param>
-    /// <param name="points">A reference to a <see cref="CollisionPoints"/> collection where intersection points will be stored.</param>
+    /// <param name="points">A reference to a <see cref="IntersectionPoints"/> collection where intersection points will be stored.</param>
     /// <param name="returnAfterFirstValid">If true, the method returns after finding the first valid intersection;
     /// otherwise, it finds all intersections.</param>
     /// <returns>The number of intersection points found.</returns>
@@ -140,7 +140,7 @@ public partial class Polyline
     /// Iterates through each segment of the polyline and checks for intersection with the segment.
     /// This overload allows for efficient accumulation of results.
     /// </remarks>
-    public int IntersectShape(Segment s, ref CollisionPoints points, bool returnAfterFirstValid = false)
+    public int IntersectShape(Segment s, ref IntersectionPoints points, bool returnAfterFirstValid = false)
     {
         if (Count < 2) return 0;
 
@@ -161,10 +161,10 @@ public partial class Polyline
 
     /// <summary>
     /// Computes the intersection points between this polyline and a <see cref="Circle"/>,
-    /// storing results in a provided <see cref="CollisionPoints"/> collection.
+    /// storing results in a provided <see cref="IntersectionPoints"/> collection.
     /// </summary>
     /// <param name="c">The <see cref="Circle"/> to test for intersection.</param>
-    /// <param name="points">A reference to a <see cref="CollisionPoints"/> collection where intersection points will be stored.</param>
+    /// <param name="points">A reference to a <see cref="IntersectionPoints"/> collection where intersection points will be stored.</param>
     /// <param name="returnAfterFirstValid">If true, the method returns after finding the first valid intersection;
     /// otherwise, it finds all intersections.</param>
     /// <returns>The number of intersection points found.</returns>
@@ -172,7 +172,7 @@ public partial class Polyline
     /// Iterates through each segment of the polyline and checks for intersection with the circle.
     /// This overload allows for efficient accumulation of results.
     /// </remarks>
-    public int IntersectShape(Circle c, ref CollisionPoints points, bool returnAfterFirstValid = false)
+    public int IntersectShape(Circle c, ref IntersectionPoints points, bool returnAfterFirstValid = false)
     {
         if (Count < 2) return 0;
 
@@ -201,10 +201,10 @@ public partial class Polyline
 
     /// <summary>
     /// Computes the intersection points between this polyline and a <see cref="Triangle"/>,
-    /// storing results in a provided <see cref="CollisionPoints"/> collection.
+    /// storing results in a provided <see cref="IntersectionPoints"/> collection.
     /// </summary>
     /// <param name="t">The <see cref="Triangle"/> to test for intersection.</param>
-    /// <param name="points">A reference to a <see cref="CollisionPoints"/> collection where intersection points will be stored.</param>
+    /// <param name="points">A reference to a <see cref="IntersectionPoints"/> collection where intersection points will be stored.</param>
     /// <param name="returnAfterFirstValid">If true, the method returns after finding the first valid intersection;
     /// otherwise, it finds all intersections.</param>
     /// <returns>The number of intersection points found.</returns>
@@ -212,7 +212,7 @@ public partial class Polyline
     /// Iterates through each segment of the polyline and each edge of the triangle, checking for intersections.
     /// This overload allows for efficient accumulation of results.
     /// </remarks>
-    public int IntersectShape(Triangle t, ref CollisionPoints points, bool returnAfterFirstValid = false)
+    public int IntersectShape(Triangle t, ref IntersectionPoints points, bool returnAfterFirstValid = false)
     {
         if (Count < 2) return 0;
 
@@ -249,10 +249,10 @@ public partial class Polyline
 
     /// <summary>
     /// Computes the intersection points between this polyline and a <see cref="Quad"/>,
-    /// storing results in a provided <see cref="CollisionPoints"/> collection.
+    /// storing results in a provided <see cref="IntersectionPoints"/> collection.
     /// </summary>
     /// <param name="q">The <see cref="Quad"/> to test for intersection.</param>
-    /// <param name="points">A reference to a <see cref="CollisionPoints"/> collection where intersection points will be stored.</param>
+    /// <param name="points">A reference to a <see cref="IntersectionPoints"/> collection where intersection points will be stored.</param>
     /// <param name="returnAfterFirstValid">If true, the method returns after finding the first valid intersection;
     /// otherwise, it finds all intersections.</param>
     /// <returns>The number of intersection points found.</returns>
@@ -260,7 +260,7 @@ public partial class Polyline
     /// Iterates through each segment of the polyline and each edge of the quad, checking for intersections.
     /// This overload allows for efficient accumulation of results.
     /// </remarks>
-    public int IntersectShape(Quad q, ref CollisionPoints points, bool returnAfterFirstValid = false)
+    public int IntersectShape(Quad q, ref IntersectionPoints points, bool returnAfterFirstValid = false)
     {
         if (Count < 2) return 0;
 
@@ -304,10 +304,10 @@ public partial class Polyline
     }
 
     /// <summary>
-    /// Computes the intersection points between this polyline and a <see cref="Rect"/>, storing results in a provided <see cref="CollisionPoints"/> collection.
+    /// Computes the intersection points between this polyline and a <see cref="Rect"/>, storing results in a provided <see cref="IntersectionPoints"/> collection.
     /// </summary>
     /// <param name="r">The <see cref="Rect"/> to test for intersection.</param>
-    /// <param name="points">A reference to a <see cref="CollisionPoints"/> collection
+    /// <param name="points">A reference to a <see cref="IntersectionPoints"/> collection
     /// where intersection points will be stored.</param>
     /// <param name="returnAfterFirstValid">If true, the method returns after finding the first valid intersection;
     /// otherwise, it finds all intersections.</param>
@@ -316,7 +316,7 @@ public partial class Polyline
     /// Iterates through each segment of the polyline and each edge of the rectangle, checking for intersections.
     /// This overload allows for efficient accumulation of results.
     /// </remarks>
-    public int IntersectShape(Rect r, ref CollisionPoints points, bool returnAfterFirstValid = false)
+    public int IntersectShape(Rect r, ref IntersectionPoints points, bool returnAfterFirstValid = false)
     {
         if (Count < 2) return 0;
 
@@ -365,10 +365,10 @@ public partial class Polyline
 
     /// <summary>
     /// Computes the intersection points between this polyline and a <see cref="Polygon"/>,
-    /// storing results in a provided <see cref="CollisionPoints"/> collection.
+    /// storing results in a provided <see cref="IntersectionPoints"/> collection.
     /// </summary>
     /// <param name="p">The <see cref="Polygon"/> to test for intersection.</param>
-    /// <param name="points">A reference to a <see cref="CollisionPoints"/> collection
+    /// <param name="points">A reference to a <see cref="IntersectionPoints"/> collection
     /// where intersection points will be stored.</param>
     /// <param name="returnAfterFirstValid">If true, the method returns after finding the first valid intersection;
     /// otherwise, it finds all intersections.</param>
@@ -377,7 +377,7 @@ public partial class Polyline
     /// Iterates through each segment of the polyline and each edge of the polygon, checking for intersections.
     /// This overload allows for efficient accumulation of results.
     /// </remarks>
-    public int IntersectShape(Polygon p, ref CollisionPoints points, bool returnAfterFirstValid = false)
+    public int IntersectShape(Polygon p, ref IntersectionPoints points, bool returnAfterFirstValid = false)
     {
         if (p.Count < 3 || Count < 2) return 0;
         var count = 0;
@@ -400,10 +400,10 @@ public partial class Polyline
 
     /// <summary>
     /// Computes the intersection points between this polyline and another <see cref="Polyline"/>,
-    /// storing results in a provided <see cref="CollisionPoints"/> collection.
+    /// storing results in a provided <see cref="IntersectionPoints"/> collection.
     /// </summary>
     /// <param name="pl">The <see cref="Polyline"/> to test for intersection.</param>
-    /// <param name="points">A reference to a <see cref="CollisionPoints"/> collection
+    /// <param name="points">A reference to a <see cref="IntersectionPoints"/> collection
     /// where intersection points will be stored.</param>
     /// <param name="returnAfterFirstValid">If true, the method returns after finding the first valid intersection;
     /// otherwise, it finds all intersections.</param>
@@ -412,7 +412,7 @@ public partial class Polyline
     /// Iterates through each segment of both polylines, checking for intersections between all segment pairs.
     /// This overload allows for efficient accumulation of results.
     /// </remarks>
-    public int IntersectShape(Polyline pl, ref CollisionPoints points, bool returnAfterFirstValid = false)
+    public int IntersectShape(Polyline pl, ref IntersectionPoints points, bool returnAfterFirstValid = false)
     {
         if (pl.Count < 2 || Count < 2) return 0;
         var count = 0;
@@ -435,10 +435,10 @@ public partial class Polyline
 
     /// <summary>
     /// Computes the intersection points between this polyline and a <see cref="Segments"/> collection,
-    /// storing results in a provided <see cref="CollisionPoints"/> collection.
+    /// storing results in a provided <see cref="IntersectionPoints"/> collection.
     /// </summary>
     /// <param name="shape">The <see cref="Segments"/> collection to test for intersection.</param>
-    /// <param name="points">A reference to a <see cref="CollisionPoints"/> collection
+    /// <param name="points">A reference to a <see cref="IntersectionPoints"/> collection
     /// where intersection points will be stored.</param>
     /// <param name="returnAfterFirstValid">If true, the method returns after finding the first valid intersection;
     /// otherwise, it finds all intersections.</param>
@@ -447,7 +447,7 @@ public partial class Polyline
     /// Iterates through each segment of the polyline and each segment in the collection, checking for intersections.
     /// This overload allows for efficient accumulation of results.
     /// </remarks>
-    public int IntersectShape(Segments shape, ref CollisionPoints points, bool returnAfterFirstValid = false)
+    public int IntersectShape(Segments shape, ref IntersectionPoints points, bool returnAfterFirstValid = false)
     {
         if (Count < 2 || shape.Count <= 0) return 0;
         var count = 0;

--- a/ShapeEngine/Geometry/QuadDef/QuadClosestPoint.cs
+++ b/ShapeEngine/Geometry/QuadDef/QuadClosestPoint.cs
@@ -60,9 +60,9 @@ public readonly partial struct Quad
     /// </summary>
     /// <param name="p">The point to find the closest point to.</param>
     /// <param name="disSquared">The squared distance from <paramref name="p"/> to the closest point.</param>
-    /// <returns>A <see cref="CollisionPoint"/> containing the closest point and the edge normal.</returns>
+    /// <returns>A <see cref="IntersectionPoint"/> containing the closest point and the edge normal.</returns>
     /// <remarks>Returns the closest point on any edge and the corresponding normal.</remarks>
-    public CollisionPoint GetClosestPoint(Vector2 p, out float disSquared)
+    public IntersectionPoint GetClosestPoint(Vector2 p, out float disSquared)
     {
         var min = Segment.GetClosestPointSegmentPoint(A, B, p, out disSquared);
         var normal = B - A;
@@ -101,9 +101,9 @@ public readonly partial struct Quad
     /// <param name="p">The point to find the closest point to.</param>
     /// <param name="disSquared">The squared distance from <paramref name="p"/> to the closest point.</param>
     /// <param name="index">The index of the edge (0-3) where the closest point was found.</param>
-    /// <returns>A <see cref="CollisionPoint"/> containing the closest point and the edge normal.</returns>
+    /// <returns>A <see cref="IntersectionPoint"/> containing the closest point and the edge normal.</returns>
     /// <remarks>Edge indices: 0=AB, 1=BC, 2=CD, 3=DA.</remarks>
-    public CollisionPoint GetClosestPoint(Vector2 p, out float disSquared, out int index)
+    public IntersectionPoint GetClosestPoint(Vector2 p, out float disSquared, out int index)
     {
         var min = Segment.GetClosestPointSegmentPoint(A, B, p, out disSquared);
         index = 0;
@@ -1011,9 +1011,9 @@ public readonly partial struct Quad
     /// </summary>
     /// <param name="p">The point to compare against.</param>
     /// <param name="disSquared">The squared distance from <paramref name="p"/> to the closest point on the segment.</param>
-    /// <returns>A tuple containing the closest <see cref="Segment"/> and its closest <see cref="CollisionPoint"/> to <paramref name="p"/>.</returns>
+    /// <returns>A tuple containing the closest <see cref="Segment"/> and its closest <see cref="IntersectionPoint"/> to <paramref name="p"/>.</returns>
     /// <remarks>Checks all four edges and returns the closest segment and point.</remarks>
-    public (Segment segment, CollisionPoint segmentPoint) GetClosestSegment(Vector2 p, out float disSquared)
+    public (Segment segment, IntersectionPoint segmentPoint) GetClosestSegment(Vector2 p, out float disSquared)
     {
         var closestSegment = SegmentAToB;
         var closestResult = closestSegment.GetClosestPoint(p, out float minDisSquared);

--- a/ShapeEngine/Geometry/QuadDef/QuadIntersectShape.cs
+++ b/ShapeEngine/Geometry/QuadDef/QuadIntersectShape.cs
@@ -17,9 +17,9 @@ public readonly partial struct Quad
     /// Computes intersection points between this quad and the specified collider.
     /// </summary>
     /// <param name="collider">The collider to test for intersection.</param>
-    /// <returns>A <see cref="CollisionPoints"/> collection of intersection points, or null if none.</returns>
+    /// <returns>A <see cref="IntersectionPoints"/> collection of intersection points, or null if none.</returns>
     /// <remarks>Returns null if the collider is disabled or no intersection occurs.</remarks>
-    public CollisionPoints? Intersect(Collider collider)
+    public IntersectionPoints? Intersect(Collider collider)
     {
         if (!collider.Enabled) return null;
 
@@ -60,12 +60,12 @@ public readonly partial struct Quad
     /// Computes intersection points between this quad and a set of segments.
     /// </summary>
     /// <param name="segments">The segments to test for intersection.</param>
-    /// <returns>A <see cref="CollisionPoints"/> collection of intersection points, or null if none.</returns>
-    public CollisionPoints? IntersectShape(Segments segments)
+    /// <returns>A <see cref="IntersectionPoints"/> collection of intersection points, or null if none.</returns>
+    public IntersectionPoints? IntersectShape(Segments segments)
     {
         if (segments.Count <= 0) return null;
 
-        CollisionPoints? points = null;
+        IntersectionPoints? points = null;
 
         foreach (var seg in segments)
         {
@@ -104,10 +104,10 @@ public readonly partial struct Quad
     /// Computes intersection points between this quad and a ray.
     /// </summary>
     /// <param name="r">The ray to test for intersection.</param>
-    /// <returns>A <see cref="CollisionPoints"/> collection of intersection points, or null if none.</returns>
-    public CollisionPoints? IntersectShape(Ray r)
+    /// <returns>A <see cref="IntersectionPoints"/> collection of intersection points, or null if none.</returns>
+    public IntersectionPoints? IntersectShape(Ray r)
     {
-        CollisionPoints? points = null;
+        IntersectionPoints? points = null;
         var result = Segment.IntersectSegmentRay(A, B, r.Point, r.Direction, r.Normal);
         if (result.Valid)
         {
@@ -142,10 +142,10 @@ public readonly partial struct Quad
     /// Computes intersection points between this quad and a line.
     /// </summary>
     /// <param name="l">The line to test for intersection.</param>
-    /// <returns>A <see cref="CollisionPoints"/> collection of intersection points, or null if none.</returns>
-    public CollisionPoints? IntersectShape(Line l)
+    /// <returns>A <see cref="IntersectionPoints"/> collection of intersection points, or null if none.</returns>
+    public IntersectionPoints? IntersectShape(Line l)
     {
-        CollisionPoints? points = null;
+        IntersectionPoints? points = null;
         var result = Segment.IntersectSegmentLine(A, B, l.Point, l.Direction, l.Normal);
         if (result.Valid)
         {
@@ -180,10 +180,10 @@ public readonly partial struct Quad
     /// Computes intersection points between this quad and a segment.
     /// </summary>
     /// <param name="s">The segment to test for intersection.</param>
-    /// <returns>A <see cref="CollisionPoints"/> collection of intersection points, or null if none.</returns>
-    public CollisionPoints? IntersectShape(Segment s)
+    /// <returns>A <see cref="IntersectionPoints"/> collection of intersection points, or null if none.</returns>
+    public IntersectionPoints? IntersectShape(Segment s)
     {
-        CollisionPoints? points = null;
+        IntersectionPoints? points = null;
         var result = Segment.IntersectSegmentSegment(A, B, s.Start, s.End);
         if (result.Valid)
         {
@@ -218,10 +218,10 @@ public readonly partial struct Quad
     /// Computes intersection points between this quad and a circle.
     /// </summary>
     /// <param name="c">The circle to test for intersection.</param>
-    /// <returns>A <see cref="CollisionPoints"/> collection of intersection points, or null if none.</returns>
-    public CollisionPoints? IntersectShape(Circle c)
+    /// <returns>A <see cref="IntersectionPoints"/> collection of intersection points, or null if none.</returns>
+    public IntersectionPoints? IntersectShape(Circle c)
     {
-        CollisionPoints? points = null;
+        IntersectionPoints? points = null;
         var result = Segment.IntersectSegmentCircle(A, B, c.Center, c.Radius);
         if (result.a.Valid || result.b.Valid)
         {
@@ -260,10 +260,10 @@ public readonly partial struct Quad
     /// Computes intersection points between this quad and a triangle.
     /// </summary>
     /// <param name="t">The triangle to test for intersection.</param>
-    /// <returns>A <see cref="CollisionPoints"/> collection of intersection points, or null if none.</returns>
-    public CollisionPoints? IntersectShape(Triangle t)
+    /// <returns>A <see cref="IntersectionPoints"/> collection of intersection points, or null if none.</returns>
+    public IntersectionPoints? IntersectShape(Triangle t)
     {
-        CollisionPoints? points = null;
+        IntersectionPoints? points = null;
         var result = Segment.IntersectSegmentSegment(A, B, t.A, t.B);
         if (result.Valid)
         {
@@ -355,10 +355,10 @@ public readonly partial struct Quad
     /// Computes intersection points between this quad and a rectangle.
     /// </summary>
     /// <param name="r">The rectangle to test for intersection.</param>
-    /// <returns>A <see cref="CollisionPoints"/> collection of intersection points, or null if none.</returns>
-    public CollisionPoints? IntersectShape(Rect r)
+    /// <returns>A <see cref="IntersectionPoints"/> collection of intersection points, or null if none.</returns>
+    public IntersectionPoints? IntersectShape(Rect r)
     {
-        CollisionPoints? points = null;
+        IntersectionPoints? points = null;
         var a = r.TopLeft;
         var b = r.BottomLeft;
         var result = Segment.IntersectSegmentSegment(A, B, a, b);
@@ -484,10 +484,10 @@ public readonly partial struct Quad
     /// Computes intersection points between this quad and another quad.
     /// </summary>
     /// <param name="q">The quad to test for intersection.</param>
-    /// <returns>A <see cref="CollisionPoints"/> collection of intersection points, or null if none.</returns>
-    public CollisionPoints? IntersectShape(Quad q)
+    /// <returns>A <see cref="IntersectionPoints"/> collection of intersection points, or null if none.</returns>
+    public IntersectionPoints? IntersectShape(Quad q)
     {
-        CollisionPoints? points = null;
+        IntersectionPoints? points = null;
         var result = Segment.IntersectSegmentSegment(A, B, q.A, q.B);
         if (result.Valid)
         {
@@ -608,12 +608,12 @@ public readonly partial struct Quad
     /// Computes intersection points between this quad and a polygon.
     /// </summary>
     /// <param name="p">The polygon to test for intersection.</param>
-    /// <returns>A <see cref="CollisionPoints"/> collection of intersection points, or null if none.</returns>
-    public CollisionPoints? IntersectShape(Polygon p)
+    /// <returns>A <see cref="IntersectionPoints"/> collection of intersection points, or null if none.</returns>
+    public IntersectionPoints? IntersectShape(Polygon p)
     {
         if (p.Count < 3) return null;
 
-        CollisionPoints? points = null;
+        IntersectionPoints? points = null;
         for (var i = 0; i < p.Count; i++)
         {
             var result = Segment.IntersectSegmentSegment(A, B, p[i], p[(i + 1) % p.Count]);
@@ -651,12 +651,12 @@ public readonly partial struct Quad
     /// Computes intersection points between this quad and a polyline.
     /// </summary>
     /// <param name="pl">The polyline to test for intersection.</param>
-    /// <returns>A <see cref="CollisionPoints"/> collection of intersection points, or null if none.</returns>
-    public CollisionPoints? IntersectShape(Polyline pl)
+    /// <returns>A <see cref="IntersectionPoints"/> collection of intersection points, or null if none.</returns>
+    public IntersectionPoints? IntersectShape(Polyline pl)
     {
         if (pl.Count < 2) return null;
 
-        CollisionPoints? points = null;
+        IntersectionPoints? points = null;
         for (var i = 0; i < pl.Count - 1; i++)
         {
             var result = Segment.IntersectSegmentSegment(A, B, pl[i], pl[(i + 1) % pl.Count]);
@@ -691,13 +691,13 @@ public readonly partial struct Quad
         return points;
     }
     /// <summary>
-    /// Computes intersection points between this quad and a collider, adding results to an existing <see cref="CollisionPoints"/> collection.
+    /// Computes intersection points between this quad and a collider, adding results to an existing <see cref="IntersectionPoints"/> collection.
     /// </summary>
     /// <param name="collider">The collider to test for intersection.</param>
     /// <param name="points">The collection to add intersection points to.</param>
     /// <param name="returnAfterFirstValid">If true, returns after the first intersection is found.</param>
     /// <returns>The number of intersection points found.</returns>
-    public int Intersect(Collider collider, ref CollisionPoints points, bool returnAfterFirstValid = false)
+    public int Intersect(Collider collider, ref IntersectionPoints points, bool returnAfterFirstValid = false)
     {
         if (!collider.Enabled) return 0;
 
@@ -736,13 +736,13 @@ public readonly partial struct Quad
     }
     /// <summary>
     /// Computes intersection points between this quad and a ray,
-    /// adding results to an existing <see cref="CollisionPoints"/> collection.
+    /// adding results to an existing <see cref="IntersectionPoints"/> collection.
     /// </summary>
     /// <param name="r">The ray to test for intersection.</param>
     /// <param name="points">The collection to add intersection points to.</param>
     /// <param name="returnAfterFirstValid">If true, returns after the first intersection is found.</param>
     /// <returns>The number of intersection points found.</returns>
-    public int IntersectShape(Ray r, ref CollisionPoints points, bool returnAfterFirstValid = false)
+    public int IntersectShape(Ray r, ref IntersectionPoints points, bool returnAfterFirstValid = false)
     {
         var count = 0;
         var result = Segment.IntersectSegmentRay(A, B, r.Point, r.Direction, r.Normal);
@@ -783,13 +783,13 @@ public readonly partial struct Quad
         return count;
     }
     /// <summary>
-    /// Computes intersection points between this quad and a line, adding results to an existing <see cref="CollisionPoints"/> collection.
+    /// Computes intersection points between this quad and a line, adding results to an existing <see cref="IntersectionPoints"/> collection.
     /// </summary>
     /// <param name="l">The line to test for intersection.</param>
     /// <param name="points">The collection to add intersection points to.</param>
     /// <param name="returnAfterFirstValid">If true, returns after the first intersection is found.</param>
     /// <returns>The number of intersection points found.</returns>
-    public int IntersectShape(Line l, ref CollisionPoints points, bool returnAfterFirstValid = false)
+    public int IntersectShape(Line l, ref IntersectionPoints points, bool returnAfterFirstValid = false)
     {
         var count = 0;
         var result = Segment.IntersectSegmentLine(A, B, l.Point, l.Direction, l.Normal);
@@ -830,13 +830,13 @@ public readonly partial struct Quad
         return count;
     }
     /// <summary>
-    /// Computes intersection points between this quad and a segment, adding results to an existing <see cref="CollisionPoints"/> collection.
+    /// Computes intersection points between this quad and a segment, adding results to an existing <see cref="IntersectionPoints"/> collection.
     /// </summary>
     /// <param name="s">The segment to test for intersection.</param>
     /// <param name="points">The collection to add intersection points to.</param>
     /// <param name="returnAfterFirstValid">If true, returns after the first intersection is found.</param>
     /// <returns>The number of intersection points found.</returns>
-    public int IntersectShape(Segment s, ref CollisionPoints points, bool returnAfterFirstValid = false)
+    public int IntersectShape(Segment s, ref IntersectionPoints points, bool returnAfterFirstValid = false)
     {
         var count = 0;
         var result = Segment.IntersectSegmentSegment(A, B, s.Start, s.End);
@@ -877,13 +877,13 @@ public readonly partial struct Quad
         return count;
     }
     /// <summary>
-    /// Computes intersection points between this quad and a circle, adding results to an existing <see cref="CollisionPoints"/> collection.
+    /// Computes intersection points between this quad and a circle, adding results to an existing <see cref="IntersectionPoints"/> collection.
     /// </summary>
     /// <param name="c">The circle to test for intersection.</param>
     /// <param name="points">The collection to add intersection points to.</param>
     /// <param name="returnAfterFirstValid">If true, returns after the first intersection is found.</param>
     /// <returns>The number of intersection points found.</returns>
-    public int IntersectShape(Circle c, ref CollisionPoints points, bool returnAfterFirstValid = false)
+    public int IntersectShape(Circle c, ref IntersectionPoints points, bool returnAfterFirstValid = false)
     {
         var count = 0;
         var result = Segment.IntersectSegmentCircle(A, B, c.Center, c.Radius);
@@ -948,13 +948,13 @@ public readonly partial struct Quad
         return count;
     }
     /// <summary>
-    /// Computes intersection points between this quad and a triangle, adding results to an existing <see cref="CollisionPoints"/> collection.
+    /// Computes intersection points between this quad and a triangle, adding results to an existing <see cref="IntersectionPoints"/> collection.
     /// </summary>
     /// <param name="t">The triangle to test for intersection.</param>
     /// <param name="points">The collection to add intersection points to.</param>
     /// <param name="returnAfterFirstValid">If true, returns after the first intersection is found.</param>
     /// <returns>The number of intersection points found.</returns>
-    public int IntersectShape(Triangle t, ref CollisionPoints points, bool returnAfterFirstValid = false)
+    public int IntersectShape(Triangle t, ref IntersectionPoints points, bool returnAfterFirstValid = false)
     {
         var count = 0;
         var result = Segment.IntersectSegmentSegment(A, B, t.A, t.B);
@@ -1056,13 +1056,13 @@ public readonly partial struct Quad
         return count;
     }
     /// <summary>
-    /// Computes intersection points between this quad and another quad, adding results to an existing <see cref="CollisionPoints"/> collection.
+    /// Computes intersection points between this quad and another quad, adding results to an existing <see cref="IntersectionPoints"/> collection.
     /// </summary>
     /// <param name="q">The quad to test for intersection.</param>
     /// <param name="points">The collection to add intersection points to.</param>
     /// <param name="returnAfterFirstValid">If true, returns after the first intersection is found.</param>
     /// <returns>The number of intersection points found.</returns>
-    public int IntersectShape(Quad q, ref CollisionPoints points, bool returnAfterFirstValid = false)
+    public int IntersectShape(Quad q, ref IntersectionPoints points, bool returnAfterFirstValid = false)
     {
         var count = 0;
         var result = Segment.IntersectSegmentSegment(A, B, q.A, q.B);
@@ -1198,13 +1198,13 @@ public readonly partial struct Quad
     }
     /// <summary>
     /// Computes intersection points between this quad and a rectangle,
-    /// adding results to an existing <see cref="CollisionPoints"/> collection.
+    /// adding results to an existing <see cref="IntersectionPoints"/> collection.
     /// </summary>
     /// <param name="r">The rectangle to test for intersection.</param>
     /// <param name="points">The collection to add intersection points to.</param>
     /// <param name="returnAfterFirstValid">If true, returns after the first intersection is found.</param>
     /// <returns>The number of intersection points found.</returns>
-    public int IntersectShape(Rect r, ref CollisionPoints points, bool returnAfterFirstValid = false)
+    public int IntersectShape(Rect r, ref IntersectionPoints points, bool returnAfterFirstValid = false)
     {
         var count = 0;
         var a = r.TopLeft;
@@ -1344,13 +1344,13 @@ public readonly partial struct Quad
         return count;
     }
     /// <summary>
-    /// Computes intersection points between this quad and a polygon, adding results to an existing <see cref="CollisionPoints"/> collection.
+    /// Computes intersection points between this quad and a polygon, adding results to an existing <see cref="IntersectionPoints"/> collection.
     /// </summary>
     /// <param name="p">The polygon to test for intersection.</param>
     /// <param name="points">The collection to add intersection points to.</param>
     /// <param name="returnAfterFirstValid">If true, returns after the first intersection is found.</param>
     /// <returns>The number of intersection points found.</returns>
-    public int IntersectShape(Polygon p, ref CollisionPoints points, bool returnAfterFirstValid = false)
+    public int IntersectShape(Polygon p, ref IntersectionPoints points, bool returnAfterFirstValid = false)
     {
         if (p.Count < 3) return 0;
 
@@ -1393,13 +1393,13 @@ public readonly partial struct Quad
         return count;
     }
     /// <summary>
-    /// Computes intersection points between this quad and a polyline, adding results to an existing <see cref="CollisionPoints"/> collection.
+    /// Computes intersection points between this quad and a polyline, adding results to an existing <see cref="IntersectionPoints"/> collection.
     /// </summary>
     /// <param name="pl">The polyline to test for intersection.</param>
     /// <param name="points">The collection to add intersection points to.</param>
     /// <param name="returnAfterFirstValid">If true, returns after the first intersection is found.</param>
     /// <returns>The number of intersection points found.</returns>
-    public int IntersectShape(Polyline pl, ref CollisionPoints points, bool returnAfterFirstValid = false)
+    public int IntersectShape(Polyline pl, ref IntersectionPoints points, bool returnAfterFirstValid = false)
     {
         if (pl.Count < 2) return 0;
 
@@ -1442,13 +1442,13 @@ public readonly partial struct Quad
         return count;
     }
     /// <summary>
-    /// Computes intersection points between this quad and a set of segments, adding results to an existing <see cref="CollisionPoints"/> collection.
+    /// Computes intersection points between this quad and a set of segments, adding results to an existing <see cref="IntersectionPoints"/> collection.
     /// </summary>
     /// <param name="shape">The segments to test for intersection.</param>
     /// <param name="points">The collection to add intersection points to.</param>
     /// <param name="returnAfterFirstValid">If true, returns after the first intersection is found.</param>
     /// <returns>The number of intersection points found.</returns>
-    public int IntersectShape(Segments shape, ref CollisionPoints points, bool returnAfterFirstValid = false)
+    public int IntersectShape(Segments shape, ref IntersectionPoints points, bool returnAfterFirstValid = false)
     {
         if (shape.Count <= 0) return 0;
 

--- a/ShapeEngine/Geometry/RayDef/RayClosestPoint.cs
+++ b/ShapeEngine/Geometry/RayDef/RayClosestPoint.cs
@@ -20,11 +20,11 @@ public readonly partial struct Ray
     /// </summary>
     /// <param name="point">The point to find the closest point to.</param>
     /// <param name="disSquared">The squared distance from the point to the closest point on the ray.</param>
-    /// <returns>A <see cref="CollisionPoint"/> representing the closest point and its normal.</returns>
+    /// <returns>A <see cref="IntersectionPoint"/> representing the closest point and its normal.</returns>
     /// <remarks>
     /// If the projection of the point onto the ray is behind the ray's origin, the origin is returned as the closest point.
     /// </remarks>
-    public CollisionPoint GetClosestPoint(Vector2 point, out float disSquared)
+    public IntersectionPoint GetClosestPoint(Vector2 point, out float disSquared)
     {
         var toPoint = point - Point;
 

--- a/ShapeEngine/Geometry/RayDef/RayIntersectShape.cs
+++ b/ShapeEngine/Geometry/RayDef/RayIntersectShape.cs
@@ -17,11 +17,11 @@ public readonly partial struct Ray
     /// Computes all intersection points between this ray and a generic collider shape.
     /// </summary>
     /// <param name="collider">The collider to test for intersection. Must be enabled.</param>
-    /// <returns>A <see cref="CollisionPoints"/> object containing all intersection points, or null if there are none or the collider is not enabled.</returns>
+    /// <returns>A <see cref="IntersectionPoints"/> object containing all intersection points, or null if there are none or the collider is not enabled.</returns>
     /// <remarks>
     /// The method dispatches to the appropriate shape-specific intersection method based on the collider's shape type.
     /// </remarks>
-    public CollisionPoints? Intersect(Collider collider)
+    public IntersectionPoints? Intersect(Collider collider)
     {
         if (!collider.Enabled) return null;
 
@@ -62,17 +62,17 @@ public readonly partial struct Ray
     /// Computes all intersection points between this ray and a segment.
     /// </summary>
     /// <param name="segment">The segment to test for intersection.</param>
-    /// <returns>A <see cref="CollisionPoints"/> object containing the intersection point, or null if there is no intersection.</returns>
+    /// <returns>A <see cref="IntersectionPoints"/> object containing the intersection point, or null if there is no intersection.</returns>
     /// <remarks>
     /// Only a single intersection point is possible for a ray and a segment.
     /// </remarks>
-    public CollisionPoints? IntersectShape(Segment segment)
+    public IntersectionPoints? IntersectShape(Segment segment)
     {
         var result = IntersectRaySegment(Point, Direction, segment.Start, segment.End, segment.Normal);
         Console.WriteLine($"Point of intersection: {result.Point} - Normal: {result.Normal} - Valid: {result.Valid}");
         if (result.Valid)
         {
-            var colPoints = new CollisionPoints();
+            var colPoints = new IntersectionPoints();
             colPoints.Add(result);
             return colPoints;
         }
@@ -83,16 +83,16 @@ public readonly partial struct Ray
     /// Computes all intersection points between this ray and a line.
     /// </summary>
     /// <param name="line">The line to test for intersection.</param>
-    /// <returns>A <see cref="CollisionPoints"/> object containing the intersection point, or null if there is no intersection.</returns>
+    /// <returns>A <see cref="IntersectionPoints"/> object containing the intersection point, or null if there is no intersection.</returns>
     /// <remarks>
     /// Only a single intersection point is possible for a ray and a line.
     /// </remarks>
-    public CollisionPoints? IntersectShape(Line line)
+    public IntersectionPoints? IntersectShape(Line line)
     {
         var result = IntersectRayLine(Point, Direction, line.Point, line.Direction, line.Normal);
         if (result.Valid)
         {
-            var colPoints = new CollisionPoints();
+            var colPoints = new IntersectionPoints();
             colPoints.Add(result);
             return colPoints;
         }
@@ -103,16 +103,16 @@ public readonly partial struct Ray
     /// Computes all intersection points between this ray and another ray.
     /// </summary>
     /// <param name="ray">The other ray to test for intersection.</param>
-    /// <returns>A <see cref="CollisionPoints"/> object containing the intersection point, or null if there is no intersection.</returns>
+    /// <returns>A <see cref="IntersectionPoints"/> object containing the intersection point, or null if there is no intersection.</returns>
     /// <remarks>
     /// Only a single intersection point is possible for two rays.
     /// </remarks>
-    public CollisionPoints? IntersectShape(Ray ray)
+    public IntersectionPoints? IntersectShape(Ray ray)
     {
         var result = IntersectRayRay(Point, Direction, ray.Point, ray.Direction, ray.Normal);
         if (result.Valid)
         {
-            var colPoints = new CollisionPoints();
+            var colPoints = new IntersectionPoints();
             colPoints.Add(result);
             return colPoints;
         }
@@ -123,16 +123,16 @@ public readonly partial struct Ray
     /// Computes all intersection points between this ray and a circle.
     /// </summary>
     /// <param name="circle">The circle to test for intersection.</param>
-    /// <returns>A <see cref="CollisionPoints"/> object containing all intersection points, or null if there are none.</returns>
+    /// <returns>A <see cref="IntersectionPoints"/> object containing all intersection points, or null if there are none.</returns>
     /// <remarks>
     /// There can be zero, one, or two intersection points for a ray and a circle.
     /// </remarks>
-    public CollisionPoints? IntersectShape(Circle circle)
+    public IntersectionPoints? IntersectShape(Circle circle)
     {
         var result = IntersectCircle(circle);
         if (result.a.Valid || result.b.Valid)
         {
-            var colPoints = new CollisionPoints();
+            var colPoints = new IntersectionPoints();
             if (result.a.Valid)
             {
                 colPoints.Add(result.a);
@@ -152,16 +152,16 @@ public readonly partial struct Ray
     /// Computes all intersection points between this ray and a triangle.
     /// </summary>
     /// <param name="t">The triangle to test for intersection.</param>
-    /// <returns>A <see cref="CollisionPoints"/> object containing all intersection points, or null if there are none.</returns>
+    /// <returns>A <see cref="IntersectionPoints"/> object containing all intersection points, or null if there are none.</returns>
     /// <remarks>
     /// There can be zero, one, or two intersection points for a ray and a triangle.
     /// </remarks>
-    public CollisionPoints? IntersectShape(Triangle t)
+    public IntersectionPoints? IntersectShape(Triangle t)
     {
         var result = IntersectRayTriangle(Point, Direction, t.A, t.B, t.C);
         if (result.a.Valid || result.b.Valid)
         {
-            var colPoints = new CollisionPoints();
+            var colPoints = new IntersectionPoints();
             if (result.a.Valid)
             {
                 colPoints.Add(result.a);
@@ -181,16 +181,16 @@ public readonly partial struct Ray
     /// Computes all intersection points between this ray and a quad.
     /// </summary>
     /// <param name="q">The quad to test for intersection.</param>
-    /// <returns>A <see cref="CollisionPoints"/> object containing all intersection points, or null if there are none.</returns>
+    /// <returns>A <see cref="IntersectionPoints"/> object containing all intersection points, or null if there are none.</returns>
     /// <remarks>
     /// There can be zero, one, or two intersection points for a ray and a quad.
     /// </remarks>
-    public CollisionPoints? IntersectShape(Quad q)
+    public IntersectionPoints? IntersectShape(Quad q)
     {
         var result = IntersectRayQuad(Point, Direction, q.A, q.B, q.C, q.D);
         if (result.a.Valid || result.b.Valid)
         {
-            var colPoints = new CollisionPoints();
+            var colPoints = new IntersectionPoints();
             if (result.a.Valid)
             {
                 colPoints.Add(result.a);
@@ -210,16 +210,16 @@ public readonly partial struct Ray
     /// Computes all intersection points between this ray and a rectangle.
     /// </summary>
     /// <param name="r">The rectangle to test for intersection.</param>
-    /// <returns>A <see cref="CollisionPoints"/> object containing all intersection points, or null if there are none.</returns>
+    /// <returns>A <see cref="IntersectionPoints"/> object containing all intersection points, or null if there are none.</returns>
     /// <remarks>
     /// There can be zero, one, or two intersection points for a ray and a rectangle.
     /// </remarks>
-    public CollisionPoints? IntersectShape(Rect r)
+    public IntersectionPoints? IntersectShape(Rect r)
     {
         var result = IntersectRayQuad(Point, Direction, r.A, r.B, r.C, r.D);
         if (result.a.Valid || result.b.Valid)
         {
-            var colPoints = new CollisionPoints();
+            var colPoints = new IntersectionPoints();
             if (result.a.Valid)
             {
                 colPoints.Add(result.a);
@@ -240,45 +240,45 @@ public readonly partial struct Ray
     /// </summary>
     /// <param name="p">The polygon to test for intersection.</param>
     /// <param name="maxCollisionPoints">The maximum number of collision points to compute. Default is -1, which means no limit.</param>
-    /// <returns>A <see cref="CollisionPoints"/> object containing all intersection points, or null if there are none.</returns>
+    /// <returns>A <see cref="IntersectionPoints"/> object containing all intersection points, or null if there are none.</returns>
     /// <remarks>
     /// The method uses the ray-polygon intersection algorithm, which may return multiple intersection points depending on the polygon's shape and the ray's direction.
     /// </remarks>
-    public CollisionPoints? IntersectShape(Polygon p, int maxCollisionPoints = -1) => IntersectRayPolygon(Point, Direction, p, maxCollisionPoints);
+    public IntersectionPoints? IntersectShape(Polygon p, int maxCollisionPoints = -1) => IntersectRayPolygon(Point, Direction, p, maxCollisionPoints);
     /// <summary>
     /// Computes all intersection points between this ray and a polyline.
     /// </summary>
     /// <param name="pl">The polyline to test for intersection.</param>
     /// <param name="maxCollisionPoints">The maximum number of collision points to compute. Default is -1, which means no limit.</param>
-    /// <returns>A <see cref="CollisionPoints"/> object containing all intersection points, or null if there are none.</returns>
+    /// <returns>A <see cref="IntersectionPoints"/> object containing all intersection points, or null if there are none.</returns>
     /// <remarks>
     /// The method uses the ray-polyline intersection algorithm, which may return multiple intersection points depending on the polyline's shape and the ray's direction.
     /// </remarks>
-    public CollisionPoints? IntersectShape(Polyline pl, int maxCollisionPoints = -1) => IntersectRayPolyline(Point, Direction, pl, maxCollisionPoints);
+    public IntersectionPoints? IntersectShape(Polyline pl, int maxCollisionPoints = -1) => IntersectRayPolyline(Point, Direction, pl, maxCollisionPoints);
 
     /// <summary>
     /// Computes all intersection points between this ray and a set of segments.
     /// </summary>
     /// <param name="segments">The set of segments to test for intersection.</param>
     /// <param name="maxCollisionPoints">The maximum number of collision points to compute. Default is -1, which means no limit.</param>
-    /// <returns>A <see cref="CollisionPoints"/> object containing all intersection points, or null if there are none.</returns>
+    /// <returns>A <see cref="IntersectionPoints"/> object containing all intersection points, or null if there are none.</returns>
     /// <remarks>
     /// The method uses the ray-segments intersection algorithm, which may return multiple intersection points depending on the segments' shapes and the ray's direction.
     /// </remarks>
-    public CollisionPoints? IntersectShape(Segments segments, int maxCollisionPoints = -1) =>
+    public IntersectionPoints? IntersectShape(Segments segments, int maxCollisionPoints = -1) =>
         IntersectRaySegments(Point, Direction, segments, maxCollisionPoints);
 
     /// <summary>
-    /// Computes all intersection points between this ray and a generic collider shape, and stores them in the provided <see cref="CollisionPoints"/> object.
+    /// Computes all intersection points between this ray and a generic collider shape, and stores them in the provided <see cref="IntersectionPoints"/> object.
     /// </summary>
     /// <param name="collider">The collider to test for intersection. Must be enabled.</param>
-    /// <param name="points">The <see cref="CollisionPoints"/> object to store the intersection points.</param>
+    /// <param name="points">The <see cref="IntersectionPoints"/> object to store the intersection points.</param>
     /// <param name="returnAfterFirstValid">If true, the method returns after finding the first valid intersection point. Default is false.</param>
     /// <returns>The number of valid intersection points found.</returns>
     /// <remarks>
     /// The method dispatches to the appropriate shape-specific intersection method based on the collider's shape type.
     /// </remarks>
-    public int Intersect(Collider collider, ref CollisionPoints points, bool returnAfterFirstValid = false)
+    public int Intersect(Collider collider, ref IntersectionPoints points, bool returnAfterFirstValid = false)
     {
         if (!collider.Enabled) return 0;
 
@@ -316,15 +316,15 @@ public readonly partial struct Ray
         return 0;
     }
     /// <summary>
-    /// Computes all intersection points between this ray and another ray, and stores the result in the provided <see cref="CollisionPoints"/> object.
+    /// Computes all intersection points between this ray and another ray, and stores the result in the provided <see cref="IntersectionPoints"/> object.
     /// </summary>
     /// <param name="r">The other ray to test for intersection.</param>
-    /// <param name="points">The <see cref="CollisionPoints"/> object to store the intersection points.</param>
+    /// <param name="points">The <see cref="IntersectionPoints"/> object to store the intersection points.</param>
     /// <returns>The number of valid intersection points found.</returns>
     /// <remarks>
     /// Only a single intersection point is possible for two rays.
     /// </remarks>
-    public int IntersectShape(Ray r, ref CollisionPoints points)
+    public int IntersectShape(Ray r, ref IntersectionPoints points)
     {
         var cp = IntersectRayRay(Point, Direction, r.Point, r.Direction, r.Normal);
         if (cp.Valid)
@@ -336,15 +336,15 @@ public readonly partial struct Ray
         return 0;
     }
     /// <summary>
-    /// Computes all intersection points between this ray and a line, and stores the result in the provided <see cref="CollisionPoints"/> object.
+    /// Computes all intersection points between this ray and a line, and stores the result in the provided <see cref="IntersectionPoints"/> object.
     /// </summary>
     /// <param name="l">The line to test for intersection.</param>
-    /// <param name="points">The <see cref="CollisionPoints"/> object to store the intersection points.</param>
+    /// <param name="points">The <see cref="IntersectionPoints"/> object to store the intersection points.</param>
     /// <returns>The number of valid intersection points found.</returns>
     /// <remarks>
     /// Only a single intersection point is possible for a ray and a line.
     /// </remarks>
-    public int IntersectShape(Line l, ref CollisionPoints points)
+    public int IntersectShape(Line l, ref IntersectionPoints points)
     {
         var cp = IntersectRayLine(Point, Direction, l.Point, l.Direction, l.Normal);
         if (cp.Valid)
@@ -356,15 +356,15 @@ public readonly partial struct Ray
         return 0;
     }
     /// <summary>
-    /// Computes all intersection points between this ray and a segment, and stores the result in the provided <see cref="CollisionPoints"/> object.
+    /// Computes all intersection points between this ray and a segment, and stores the result in the provided <see cref="IntersectionPoints"/> object.
     /// </summary>
     /// <param name="s">The segment to test for intersection.</param>
-    /// <param name="points">The <see cref="CollisionPoints"/> object to store the intersection points.</param>
+    /// <param name="points">The <see cref="IntersectionPoints"/> object to store the intersection points.</param>
     /// <returns>The number of valid intersection points found.</returns>
     /// <remarks>
     /// Only a single intersection point is possible for a ray and a segment.
     /// </remarks>
-    public int IntersectShape(Segment s, ref CollisionPoints points)
+    public int IntersectShape(Segment s, ref IntersectionPoints points)
     {
         var cp = IntersectRaySegment(Point, Direction, s.Start, s.End);
         if (cp.Valid)
@@ -376,16 +376,16 @@ public readonly partial struct Ray
         return 0;
     }
     /// <summary>
-    /// Computes all intersection points between this ray and a circle, and stores the result in the provided <see cref="CollisionPoints"/> object.
+    /// Computes all intersection points between this ray and a circle, and stores the result in the provided <see cref="IntersectionPoints"/> object.
     /// </summary>
     /// <param name="c">The circle to test for intersection.</param>
-    /// <param name="points">The <see cref="CollisionPoints"/> object to store the intersection points.</param>
+    /// <param name="points">The <see cref="IntersectionPoints"/> object to store the intersection points.</param>
     /// <param name="returnAfterFirstValid">If true, the method returns after finding the first valid intersection point. Default is false.</param>
     /// <returns>The number of valid intersection points found.</returns>
     /// <remarks>
     /// There can be zero, one, or two intersection points for a ray and a circle.
     /// </remarks>
-    public int IntersectShape(Circle c, ref CollisionPoints points, bool returnAfterFirstValid = false)
+    public int IntersectShape(Circle c, ref IntersectionPoints points, bool returnAfterFirstValid = false)
     {
         var result = IntersectRayCircle(Point, Direction, c.Center, c.Radius);
 
@@ -417,16 +417,16 @@ public readonly partial struct Ray
         return 0;
     }
     /// <summary>
-    /// Computes all intersection points between this ray and a triangle, and stores the result in the provided <see cref="CollisionPoints"/> object.
+    /// Computes all intersection points between this ray and a triangle, and stores the result in the provided <see cref="IntersectionPoints"/> object.
     /// </summary>
     /// <param name="t">The triangle to test for intersection.</param>
-    /// <param name="points">The <see cref="CollisionPoints"/> object to store the intersection points.</param>
+    /// <param name="points">The <see cref="IntersectionPoints"/> object to store the intersection points.</param>
     /// <param name="returnAfterFirstValid">If true, the method returns after finding the first valid intersection point. Default is false.</param>
     /// <returns>The number of valid intersection points found.</returns>
     /// <remarks>
     /// Intersecting a triangle with a ray can result in zero, one, or two intersection points.
     /// </remarks>
-    public int IntersectShape(Triangle t, ref CollisionPoints points, bool returnAfterFirstValid = false)
+    public int IntersectShape(Triangle t, ref IntersectionPoints points, bool returnAfterFirstValid = false)
     {
         var cp = IntersectRaySegment(Point, Direction, t.A, t.B);
         var count = 0;
@@ -458,16 +458,16 @@ public readonly partial struct Ray
         return count;
     }
     /// <summary>
-    /// Computes all intersection points between this ray and a quad, and stores the result in the provided <see cref="CollisionPoints"/> object.
+    /// Computes all intersection points between this ray and a quad, and stores the result in the provided <see cref="IntersectionPoints"/> object.
     /// </summary>
     /// <param name="q">The quad to test for intersection.</param>
-    /// <param name="points">The <see cref="CollisionPoints"/> object to store the intersection points.</param>
+    /// <param name="points">The <see cref="IntersectionPoints"/> object to store the intersection points.</param>
     /// <param name="returnAfterFirstValid">If true, the method returns after finding the first valid intersection point. Default is false.</param>
     /// <returns>The number of valid intersection points found.</returns>
     /// <remarks>
     /// Intersecting a quad with a ray can result in zero, one, or two intersection points.
     /// </remarks>
-    public int IntersectShape(Quad q, ref CollisionPoints points, bool returnAfterFirstValid = false)
+    public int IntersectShape(Quad q, ref IntersectionPoints points, bool returnAfterFirstValid = false)
     {
         var cp = IntersectRaySegment(Point, Direction, q.A, q.B);
         var count = 0;
@@ -510,16 +510,16 @@ public readonly partial struct Ray
         return count;
     }
     /// <summary>
-    /// Computes all intersection points between this ray and a rectangle, and stores the result in the provided <see cref="CollisionPoints"/> object.
+    /// Computes all intersection points between this ray and a rectangle, and stores the result in the provided <see cref="IntersectionPoints"/> object.
     /// </summary>
     /// <param name="r">The rectangle to test for intersection.</param>
-    /// <param name="points">The <see cref="CollisionPoints"/> object to store the intersection points.</param>
+    /// <param name="points">The <see cref="IntersectionPoints"/> object to store the intersection points.</param>
     /// <param name="returnAfterFirstValid">If true, the method returns after finding the first valid intersection point. Default is false.</param>
     /// <returns>The number of valid intersection points found.</returns>
     /// <remarks>
     /// Intersecting a rectangle with a ray can result in zero, one, or two intersection points.
     /// </remarks>
-    public int IntersectShape(Rect r, ref CollisionPoints points, bool returnAfterFirstValid = false)
+    public int IntersectShape(Rect r, ref IntersectionPoints points, bool returnAfterFirstValid = false)
     {
         var a = r.TopLeft;
         var b = r.BottomLeft;
@@ -567,16 +567,16 @@ public readonly partial struct Ray
         return count;
     }
     /// <summary>
-    /// Computes all intersection points between this ray and a polygon, and stores the result in the provided <see cref="CollisionPoints"/> object.
+    /// Computes all intersection points between this ray and a polygon, and stores the result in the provided <see cref="IntersectionPoints"/> object.
     /// </summary>
     /// <param name="p">The polygon to test for intersection.</param>
-    /// <param name="points">The <see cref="CollisionPoints"/> object to store the intersection points.</param>
+    /// <param name="points">The <see cref="IntersectionPoints"/> object to store the intersection points.</param>
     /// <param name="returnAfterFirstValid">If true, the method returns after finding the first valid intersection point. Default is false.</param>
     /// <returns>The number of valid intersection points found.</returns>
     /// <remarks>
     /// The method uses the ray-polygon intersection algorithm, which may return multiple intersection points depending on the polygon's shape and the ray's direction.
     /// </remarks>
-    public int IntersectShape(Polygon p, ref CollisionPoints points, bool returnAfterFirstValid = false)
+    public int IntersectShape(Polygon p, ref IntersectionPoints points, bool returnAfterFirstValid = false)
     {
         if (p.Count < 3) return 0;
         var count = 0;
@@ -594,16 +594,16 @@ public readonly partial struct Ray
         return count;
     }
     /// <summary>
-    /// Computes all intersection points between this ray and a polyline, and stores the result in the provided <see cref="CollisionPoints"/> object.
+    /// Computes all intersection points between this ray and a polyline, and stores the result in the provided <see cref="IntersectionPoints"/> object.
     /// </summary>
     /// <param name="pl">The polyline to test for intersection.</param>
-    /// <param name="points">The <see cref="CollisionPoints"/> object to store the intersection points.</param>
+    /// <param name="points">The <see cref="IntersectionPoints"/> object to store the intersection points.</param>
     /// <param name="returnAfterFirstValid">If true, the method returns after finding the first valid intersection point. Default is false.</param>
     /// <returns>The number of valid intersection points found.</returns>
     /// <remarks>
     /// The method uses the ray-polyline intersection algorithm, which may return multiple intersection points depending on the polyline's shape and the ray's direction.
     /// </remarks>
-    public int IntersectShape(Polyline pl, ref CollisionPoints points, bool returnAfterFirstValid = false)
+    public int IntersectShape(Polyline pl, ref IntersectionPoints points, bool returnAfterFirstValid = false)
     {
         if (pl.Count < 2) return 0;
         var count = 0;
@@ -621,16 +621,16 @@ public readonly partial struct Ray
         return count;
     }
     /// <summary>
-    /// Computes all intersection points between this ray and a set of segments, and stores the result in the provided <see cref="CollisionPoints"/> object.
+    /// Computes all intersection points between this ray and a set of segments, and stores the result in the provided <see cref="IntersectionPoints"/> object.
     /// </summary>
     /// <param name="shape">The set of segments to test for intersection.</param>
-    /// <param name="points">The <see cref="CollisionPoints"/> object to store the intersection points.</param>
+    /// <param name="points">The <see cref="IntersectionPoints"/> object to store the intersection points.</param>
     /// <param name="returnAfterFirstValid">If true, the method returns after finding the first valid intersection point. Default is false.</param>
     /// <returns>The number of valid intersection points found.</returns>
     /// <remarks>
     /// The method uses the ray-segments intersection algorithm, which may return multiple intersection points depending on the segments' shapes and the ray's direction.
     /// </remarks>
-    public int IntersectShape(Segments shape, ref CollisionPoints points, bool returnAfterFirstValid = false)
+    public int IntersectShape(Segments shape, ref IntersectionPoints points, bool returnAfterFirstValid = false)
     {
         if (shape.Count <= 0) return 0;
         var count = 0;

--- a/ShapeEngine/Geometry/RayDef/RayIntersection.cs
+++ b/ShapeEngine/Geometry/RayDef/RayIntersection.cs
@@ -19,71 +19,71 @@ public readonly partial struct Ray
     /// </summary>
     /// <param name="segmentStart">The start point of the segment.</param>
     /// <param name="segmentEnd">The end point of the segment.</param>
-    /// <returns>A <see cref="CollisionPoint"/> representing the intersection, or an invalid point if there is no intersection.</returns>
+    /// <returns>A <see cref="IntersectionPoint"/> representing the intersection, or an invalid point if there is no intersection.</returns>
     /// <remarks>
-    /// Returns an invalid <see cref="CollisionPoint"/> if there is no intersection.
+    /// Returns an invalid <see cref="IntersectionPoint"/> if there is no intersection.
     /// </remarks>
-    public CollisionPoint IntersectSegment(Vector2 segmentStart, Vector2 segmentEnd) => IntersectRaySegment(Point, Direction, segmentStart, segmentEnd);
+    public IntersectionPoint IntersectSegment(Vector2 segmentStart, Vector2 segmentEnd) => IntersectRaySegment(Point, Direction, segmentStart, segmentEnd);
     /// <summary>
     /// Computes the intersection point between this ray and a segment.
     /// </summary>
     /// <param name="segment">The segment to test for intersection.</param>
-    /// <returns>A <see cref="CollisionPoint"/> representing the intersection, or an invalid point if there is no intersection.</returns>
-    public CollisionPoint IntersectSegment(Segment segment) => IntersectRaySegment(Point, Direction, segment.Start, segment.End, segment.Normal);
+    /// <returns>A <see cref="IntersectionPoint"/> representing the intersection, or an invalid point if there is no intersection.</returns>
+    public IntersectionPoint IntersectSegment(Segment segment) => IntersectRaySegment(Point, Direction, segment.Start, segment.End, segment.Normal);
     /// <summary>
     /// Computes the intersection point between this ray and a line defined by a point and direction.
     /// </summary>
     /// <param name="linePoint">A point on the line.</param>
     /// <param name="lineDirection">The direction vector of the line.</param>
-    /// <returns>A <see cref="CollisionPoint"/> representing the intersection, or an invalid point if there is no intersection.</returns>
-    public CollisionPoint IntersectLine(Vector2 linePoint, Vector2 lineDirection) => IntersectRayLine(Point, Direction, linePoint, lineDirection);
+    /// <returns>A <see cref="IntersectionPoint"/> representing the intersection, or an invalid point if there is no intersection.</returns>
+    public IntersectionPoint IntersectLine(Vector2 linePoint, Vector2 lineDirection) => IntersectRayLine(Point, Direction, linePoint, lineDirection);
     /// <summary>
     /// Computes the intersection point between this ray and a line.
     /// </summary>
     /// <param name="line">The line to test for intersection.</param>
-    /// <returns>A <see cref="CollisionPoint"/> representing the intersection, or an invalid point if there is no intersection.</returns>
-    public CollisionPoint IntersectLine(Line line) => IntersectRayLine(Point, Direction, line.Point, line.Direction, line.Normal);
+    /// <returns>A <see cref="IntersectionPoint"/> representing the intersection, or an invalid point if there is no intersection.</returns>
+    public IntersectionPoint IntersectLine(Line line) => IntersectRayLine(Point, Direction, line.Point, line.Direction, line.Normal);
     /// <summary>
     /// Computes the intersection point between this ray and another ray defined by a point and direction.
     /// </summary>
     /// <param name="rayPoint">The origin point of the other ray.</param>
     /// <param name="rayDirection">The direction vector of the other ray.</param>
-    /// <returns>A <see cref="CollisionPoint"/> representing the intersection, or an invalid point if there is no intersection.</returns>
-    public CollisionPoint IntersectRay(Vector2 rayPoint, Vector2 rayDirection) => IntersectRayRay(Point, Direction, rayPoint, rayDirection);
+    /// <returns>A <see cref="IntersectionPoint"/> representing the intersection, or an invalid point if there is no intersection.</returns>
+    public IntersectionPoint IntersectRay(Vector2 rayPoint, Vector2 rayDirection) => IntersectRayRay(Point, Direction, rayPoint, rayDirection);
     /// <summary>
     /// Computes the intersection point between this ray and another ray.
     /// </summary>
     /// <param name="ray">The other ray to test for intersection.</param>
-    /// <returns>A <see cref="CollisionPoint"/> representing the intersection, or an invalid point if there is no intersection.</returns>
-    public CollisionPoint IntersectRay(Ray ray) => IntersectRayRay(Point, Direction, ray.Point, ray.Direction, ray.Normal);
+    /// <returns>A <see cref="IntersectionPoint"/> representing the intersection, or an invalid point if there is no intersection.</returns>
+    public IntersectionPoint IntersectRay(Ray ray) => IntersectRayRay(Point, Direction, ray.Point, ray.Direction, ray.Normal);
     /// <summary>
     /// Computes the intersection points between this ray and a circle defined by center and radius.
     /// </summary>
     /// <param name="circleCenter">The center of the circle.</param>
     /// <param name="circleRadius">The radius of the circle.</param>
-    /// <returns>A tuple of two <see cref="CollisionPoint"/>s representing the intersection points, or invalid points if there is no intersection.</returns>
-    public (CollisionPoint a, CollisionPoint b) IntersectCircle(Vector2 circleCenter, float circleRadius) =>
+    /// <returns>A tuple of two <see cref="IntersectionPoint"/>s representing the intersection points, or invalid points if there is no intersection.</returns>
+    public (IntersectionPoint a, IntersectionPoint b) IntersectCircle(Vector2 circleCenter, float circleRadius) =>
         IntersectRayCircle(Point, Direction, circleCenter, circleRadius);
     /// <summary>
     /// Computes the intersection points between this ray and a circle.
     /// </summary>
     /// <param name="circle">The circle to test for intersection.</param>
-    /// <returns>A tuple of two <see cref="CollisionPoint"/>s representing the intersection points, or invalid points if there is no intersection.</returns>
-    public (CollisionPoint a, CollisionPoint b) IntersectCircle(Circle circle) => IntersectRayCircle(Point, Direction, circle.Center, circle.Radius);
+    /// <returns>A tuple of two <see cref="IntersectionPoint"/>s representing the intersection points, or invalid points if there is no intersection.</returns>
+    public (IntersectionPoint a, IntersectionPoint b) IntersectCircle(Circle circle) => IntersectRayCircle(Point, Direction, circle.Center, circle.Radius);
     /// <summary>
     /// Computes the intersection points between this ray and a triangle defined by three points.
     /// </summary>
     /// <param name="a">The first vertex of the triangle.</param>
     /// <param name="b">The second vertex of the triangle.</param>
     /// <param name="c">The third vertex of the triangle.</param>
-    /// <returns>A tuple of two <see cref="CollisionPoint"/>s representing the intersection points, or invalid points if there is no intersection.</returns>
-    public (CollisionPoint a, CollisionPoint b) IntersectTriangle(Vector2 a, Vector2 b, Vector2 c) => IntersectRayTriangle(Point, Direction, a, b, c);
+    /// <returns>A tuple of two <see cref="IntersectionPoint"/>s representing the intersection points, or invalid points if there is no intersection.</returns>
+    public (IntersectionPoint a, IntersectionPoint b) IntersectTriangle(Vector2 a, Vector2 b, Vector2 c) => IntersectRayTriangle(Point, Direction, a, b, c);
     /// <summary>
     /// Computes the intersection points between this ray and a triangle.
     /// </summary>
     /// <param name="triangle">The triangle to test for intersection.</param>
-    /// <returns>A tuple of two <see cref="CollisionPoint"/>s representing the intersection points, or invalid points if there is no intersection.</returns>
-    public (CollisionPoint a, CollisionPoint b) IntersectTriangle(Triangle triangle) =>
+    /// <returns>A tuple of two <see cref="IntersectionPoint"/>s representing the intersection points, or invalid points if there is no intersection.</returns>
+    public (IntersectionPoint a, IntersectionPoint b) IntersectTriangle(Triangle triangle) =>
         IntersectRayTriangle(Point, Direction, triangle.A, triangle.B, triangle.C);
     /// <summary>
     /// Computes the intersection points between this ray and a quad defined by four points.
@@ -92,14 +92,14 @@ public readonly partial struct Ray
     /// <param name="b">The second vertex of the quad.</param>
     /// <param name="c">The third vertex of the quad.</param>
     /// <param name="d">The fourth vertex of the quad.</param>
-    /// <returns>A tuple of two <see cref="CollisionPoint"/>s representing the intersection points, or invalid points if there is no intersection.</returns>
-    public (CollisionPoint a, CollisionPoint b) IntersectQuad(Vector2 a, Vector2 b, Vector2 c, Vector2 d) => IntersectRayQuad(Point, Direction, a, b, c, d);
+    /// <returns>A tuple of two <see cref="IntersectionPoint"/>s representing the intersection points, or invalid points if there is no intersection.</returns>
+    public (IntersectionPoint a, IntersectionPoint b) IntersectQuad(Vector2 a, Vector2 b, Vector2 c, Vector2 d) => IntersectRayQuad(Point, Direction, a, b, c, d);
     /// <summary>
     /// Computes the intersection points between this ray and a quad.
     /// </summary>
     /// <param name="quad">The quad to test for intersection.</param>
-    /// <returns>A tuple of two <see cref="CollisionPoint"/>s representing the intersection points, or invalid points if there is no intersection.</returns>
-    public (CollisionPoint a, CollisionPoint b) IntersectQuad(Quad quad) => IntersectRayQuad(Point, Direction, quad.A, quad.B, quad.C, quad.D);
+    /// <returns>A tuple of two <see cref="IntersectionPoint"/>s representing the intersection points, or invalid points if there is no intersection.</returns>
+    public (IntersectionPoint a, IntersectionPoint b) IntersectQuad(Quad quad) => IntersectRayQuad(Point, Direction, quad.A, quad.B, quad.C, quad.D);
     /// <summary>
     /// Computes the intersection points between this ray and a rectangle defined by four points.
     /// </summary>
@@ -107,61 +107,61 @@ public readonly partial struct Ray
     /// <param name="b">The second vertex of the rectangle.</param>
     /// <param name="c">The third vertex of the rectangle.</param>
     /// <param name="d">The fourth vertex of the rectangle.</param>
-    /// <returns>A tuple of two <see cref="CollisionPoint"/>s representing the intersection points, or invalid points if there is no intersection.</returns>
-    public (CollisionPoint a, CollisionPoint b) IntersectRect(Vector2 a, Vector2 b, Vector2 c, Vector2 d) => IntersectRayQuad(Point, Direction, a, b, c, d);
+    /// <returns>A tuple of two <see cref="IntersectionPoint"/>s representing the intersection points, or invalid points if there is no intersection.</returns>
+    public (IntersectionPoint a, IntersectionPoint b) IntersectRect(Vector2 a, Vector2 b, Vector2 c, Vector2 d) => IntersectRayQuad(Point, Direction, a, b, c, d);
     /// <summary>
     /// Computes the intersection points between this ray and a rectangle.
     /// </summary>
     /// <param name="rect">The rectangle to test for intersection.</param>
-    /// <returns>A tuple of two <see cref="CollisionPoint"/>s representing the intersection points, or invalid points if there is no intersection.</returns>
-    public (CollisionPoint a, CollisionPoint b) IntersectRect(Rect rect) => IntersectRayQuad(Point, Direction, rect.A, rect.B, rect.C, rect.D);
+    /// <returns>A tuple of two <see cref="IntersectionPoint"/>s representing the intersection points, or invalid points if there is no intersection.</returns>
+    public (IntersectionPoint a, IntersectionPoint b) IntersectRect(Rect rect) => IntersectRayQuad(Point, Direction, rect.A, rect.B, rect.C, rect.D);
     /// <summary>
     /// Computes all intersection points between this ray and a polygon defined by a list of points.
     /// </summary>
     /// <param name="points">The list of points defining the polygon.</param>
     /// <param name="maxCollisionPoints">The maximum number of collision points to return. Use -1 for no limit.</param>
-    /// <returns>A <see cref="CollisionPoints"/> object containing all intersection points, or null if there are none.</returns>
-    public CollisionPoints? IntersectPolygon(List<Vector2> points, int maxCollisionPoints = -1) =>
+    /// <returns>A <see cref="IntersectionPoints"/> object containing all intersection points, or null if there are none.</returns>
+    public IntersectionPoints? IntersectPolygon(List<Vector2> points, int maxCollisionPoints = -1) =>
         IntersectRayPolygon(Point, Direction, points, maxCollisionPoints);
     /// <summary>
     /// Computes all intersection points between this ray and a polygon.
     /// </summary>
     /// <param name="polygon">The polygon to test for intersection.</param>
     /// <param name="maxCollisionPoints">The maximum number of collision points to return. Use -1 for no limit.</param>
-    /// <returns>A <see cref="CollisionPoints"/> object containing all intersection points, or null if there are none.</returns>
-    public CollisionPoints? IntersectPolygon(Polygon polygon, int maxCollisionPoints = -1) =>
+    /// <returns>A <see cref="IntersectionPoints"/> object containing all intersection points, or null if there are none.</returns>
+    public IntersectionPoints? IntersectPolygon(Polygon polygon, int maxCollisionPoints = -1) =>
         IntersectRayPolygon(Point, Direction, polygon, maxCollisionPoints);
     /// <summary>
     /// Computes all intersection points between this ray and a polyline defined by a list of points.
     /// </summary>
     /// <param name="points">The list of points defining the polyline.</param>
     /// <param name="maxCollisionPoints">The maximum number of collision points to return. Use -1 for no limit.</param>
-    /// <returns>A <see cref="CollisionPoints"/> object containing all intersection points, or null if there are none.</returns>
-    public CollisionPoints? IntersectPolyline(List<Vector2> points, int maxCollisionPoints = -1) =>
+    /// <returns>A <see cref="IntersectionPoints"/> object containing all intersection points, or null if there are none.</returns>
+    public IntersectionPoints? IntersectPolyline(List<Vector2> points, int maxCollisionPoints = -1) =>
         IntersectRayPolyline(Point, Direction, points, maxCollisionPoints);
     /// <summary>
     /// Computes all intersection points between this ray and a polyline.
     /// </summary>
     /// <param name="polyline">The polyline to test for intersection.</param>
     /// <param name="maxCollisionPoints">The maximum number of collision points to return. Use -1 for no limit.</param>
-    /// <returns>A <see cref="CollisionPoints"/> object containing all intersection points, or null if there are none.</returns>
-    public CollisionPoints? IntersectPolyline(Polyline polyline, int maxCollisionPoints = -1) =>
+    /// <returns>A <see cref="IntersectionPoints"/> object containing all intersection points, or null if there are none.</returns>
+    public IntersectionPoints? IntersectPolyline(Polyline polyline, int maxCollisionPoints = -1) =>
         IntersectRayPolyline(Point, Direction, polyline, maxCollisionPoints);
     /// <summary>
     /// Computes all intersection points between this ray and a list of segments.
     /// </summary>
     /// <param name="segments">The list of segments to test for intersection.</param>
     /// <param name="maxCollisionPoints">The maximum number of collision points to return. Use -1 for no limit.</param>
-    /// <returns>A <see cref="CollisionPoints"/> object containing all intersection points, or null if there are none.</returns>
-    public CollisionPoints? IntersectSegments(List<Segment> segments, int maxCollisionPoints = -1) =>
+    /// <returns>A <see cref="IntersectionPoints"/> object containing all intersection points, or null if there are none.</returns>
+    public IntersectionPoints? IntersectSegments(List<Segment> segments, int maxCollisionPoints = -1) =>
         IntersectRaySegments(Point, Direction, segments, maxCollisionPoints);
     /// <summary>
     /// Computes all intersection points between this ray and a set of segments.
     /// </summary>
     /// <param name="segments">The set of segments to test for intersection.</param>
     /// <param name="maxCollisionPoints">The maximum number of collision points to return. Use -1 for no limit.</param>
-    /// <returns>A <see cref="CollisionPoints"/> object containing all intersection points, or null if there are none.</returns>
-    public CollisionPoints? IntersectSegments(Segments segments, int maxCollisionPoints = -1) =>
+    /// <returns>A <see cref="IntersectionPoints"/> object containing all intersection points, or null if there are none.</returns>
+    public IntersectionPoints? IntersectSegments(Segments segments, int maxCollisionPoints = -1) =>
         IntersectRaySegments(Point, Direction, segments, maxCollisionPoints);
 
 }

--- a/ShapeEngine/Geometry/RayDef/RayIntersectionStatic.cs
+++ b/ShapeEngine/Geometry/RayDef/RayIntersectionStatic.cs
@@ -37,11 +37,11 @@ public readonly partial struct Ray
     /// <param name="rayDirection">The direction vector of the ray.</param>
     /// <param name="segmentStart">The start point of the segment.</param>
     /// <param name="segmentEnd">The end point of the segment.</param>
-    /// <returns>A tuple containing the <see cref="CollisionPoint"/> and the parameter t along the ray, or -1 if no intersection.</returns>
+    /// <returns>A tuple containing the <see cref="IntersectionPoint"/> and the parameter t along the ray, or -1 if no intersection.</returns>
     /// <remarks>
     /// The returned parameter t is the distance along the ray direction to the intersection point.
     /// </remarks>
-    public static (CollisionPoint p, float t) IntersectRaySegmentInfo(Vector2 rayPoint, Vector2 rayDirection, Vector2 segmentStart, Vector2 segmentEnd)
+    public static (IntersectionPoint p, float t) IntersectRaySegmentInfo(Vector2 rayPoint, Vector2 rayDirection, Vector2 segmentStart, Vector2 segmentEnd)
     {
         float denominator = rayDirection.X * (segmentEnd.Y - segmentStart.Y) - rayDirection.Y * (segmentEnd.X - segmentStart.X);
 
@@ -73,8 +73,8 @@ public readonly partial struct Ray
     /// <param name="segmentStart">The start point of the segment.</param>
     /// <param name="segmentEnd">The end point of the segment.</param>
     /// <param name="segmentNormal">The normal vector of the segment.</param>
-    /// <returns>A tuple containing the <see cref="CollisionPoint"/> (with the provided normal) and the parameter t along the ray, or -1 if no intersection.</returns>
-    public static (CollisionPoint p, float t) IntersectRaySegmentInfo(Vector2 rayPoint, Vector2 rayDirection, Vector2 segmentStart, Vector2 segmentEnd,
+    /// <returns>A tuple containing the <see cref="IntersectionPoint"/> (with the provided normal) and the parameter t along the ray, or -1 if no intersection.</returns>
+    public static (IntersectionPoint p, float t) IntersectRaySegmentInfo(Vector2 rayPoint, Vector2 rayDirection, Vector2 segmentStart, Vector2 segmentEnd,
         Vector2 segmentNormal)
     {
         var result = IntersectRaySegmentInfo(rayPoint, rayDirection, segmentStart, segmentEnd);
@@ -93,11 +93,11 @@ public readonly partial struct Ray
     /// <param name="rayDirection">The direction vector of the ray.</param>
     /// <param name="linePoint">A point on the line.</param>
     /// <param name="lineDirection">The direction vector of the line.</param>
-    /// <returns>A tuple containing the <see cref="CollisionPoint"/> and the parameter t along the ray, or -1 if no intersection.</returns>
+    /// <returns>A tuple containing the <see cref="IntersectionPoint"/> and the parameter t along the ray, or -1 if no intersection.</returns>
     /// <remarks>
     /// The returned parameter t is the distance along the ray direction to the intersection point.
     /// </remarks>
-    public static (CollisionPoint p, float t) IntersectRayLineInfo(Vector2 rayPoint, Vector2 rayDirection, Vector2 linePoint, Vector2 lineDirection)
+    public static (IntersectionPoint p, float t) IntersectRayLineInfo(Vector2 rayPoint, Vector2 rayDirection, Vector2 linePoint, Vector2 lineDirection)
     {
         float denominator = rayDirection.X * lineDirection.Y - rayDirection.Y * lineDirection.X;
 
@@ -127,8 +127,8 @@ public readonly partial struct Ray
     /// <param name="linePoint">A point on the line.</param>
     /// <param name="lineDirection">The direction vector of the line.</param>
     /// <param name="lineNormal">The normal vector of the line.</param>
-    /// <returns>A tuple containing the <see cref="CollisionPoint"/> (with the provided normal) and the parameter t along the ray, or -1 if no intersection.</returns>
-    public static (CollisionPoint p, float t) IntersectRayLineInfo(Vector2 rayPoint, Vector2 rayDirection, Vector2 linePoint, Vector2 lineDirection,
+    /// <returns>A tuple containing the <see cref="IntersectionPoint"/> (with the provided normal) and the parameter t along the ray, or -1 if no intersection.</returns>
+    public static (IntersectionPoint p, float t) IntersectRayLineInfo(Vector2 rayPoint, Vector2 rayDirection, Vector2 linePoint, Vector2 lineDirection,
         Vector2 lineNormal)
     {
         var result = IntersectRayLineInfo(rayPoint, rayDirection, linePoint, lineDirection);
@@ -147,11 +147,11 @@ public readonly partial struct Ray
     /// <param name="ray1Direction">The direction vector of the first ray.</param>
     /// <param name="ray2Point">The origin point of the second ray.</param>
     /// <param name="ray2Direction">The direction vector of the second ray.</param>
-    /// <returns>A tuple containing the <see cref="CollisionPoint"/> and the parameter t along the first ray, or -1 if no intersection.</returns>
+    /// <returns>A tuple containing the <see cref="IntersectionPoint"/> and the parameter t along the first ray, or -1 if no intersection.</returns>
     /// <remarks>
     /// The returned parameter t is the distance along the first ray direction to the intersection point.
     /// </remarks>
-    public static (CollisionPoint p, float t) IntersectRayRayInfo(Vector2 ray1Point, Vector2 ray1Direction, Vector2 ray2Point, Vector2 ray2Direction)
+    public static (IntersectionPoint p, float t) IntersectRayRayInfo(Vector2 ray1Point, Vector2 ray1Direction, Vector2 ray2Point, Vector2 ray2Direction)
     {
         float denominator = ray1Direction.X * ray2Direction.Y - ray1Direction.Y * ray2Direction.X;
 
@@ -182,8 +182,8 @@ public readonly partial struct Ray
     /// <param name="ray2Point">The origin point of the second ray.</param>
     /// <param name="ray2Direction">The direction vector of the second ray.</param>
     /// <param name="ray2Normal">The normal vector of the second ray.</param>
-    /// <returns>A tuple containing the <see cref="CollisionPoint"/> (with the provided normal) and the parameter t along the first ray, or -1 if no intersection.</returns>
-    public static (CollisionPoint p, float t) IntersectRayRayInfo(Vector2 ray1Point, Vector2 ray1Direction, Vector2 ray2Point, Vector2 ray2Direction,
+    /// <returns>A tuple containing the <see cref="IntersectionPoint"/> (with the provided normal) and the parameter t along the first ray, or -1 if no intersection.</returns>
+    public static (IntersectionPoint p, float t) IntersectRayRayInfo(Vector2 ray1Point, Vector2 ray1Direction, Vector2 ray2Point, Vector2 ray2Direction,
         Vector2 ray2Normal)
     {
         var result = IntersectRayRayInfo(ray1Point, ray1Direction, ray2Point, ray2Direction);
@@ -202,8 +202,8 @@ public readonly partial struct Ray
     /// <param name="rayDirection">The direction vector of the ray.</param>
     /// <param name="segmentStart">The start point of the segment.</param>
     /// <param name="segmentEnd">The end point of the segment.</param>
-    /// <returns>The <see cref="CollisionPoint"/> representing the intersection point, or an invalid <see cref="CollisionPoint"/> if no intersection occurs.</returns>
-    public static CollisionPoint IntersectRaySegment(Vector2 rayPoint, Vector2 rayDirection, Vector2 segmentStart, Vector2 segmentEnd)
+    /// <returns>The <see cref="IntersectionPoint"/> representing the intersection point, or an invalid <see cref="IntersectionPoint"/> if no intersection occurs.</returns>
+    public static IntersectionPoint IntersectRaySegment(Vector2 rayPoint, Vector2 rayDirection, Vector2 segmentStart, Vector2 segmentEnd)
     {
         float denominator = rayDirection.X * (segmentEnd.Y - segmentStart.Y) - rayDirection.Y * (segmentEnd.X - segmentStart.X);
 
@@ -235,8 +235,8 @@ public readonly partial struct Ray
     /// <param name="segmentStart">The start point of the segment.</param>
     /// <param name="segmentEnd">The end point of the segment.</param>
     /// <param name="segmentNormal">The normal vector of the segment.</param>
-    /// <returns>The <see cref="CollisionPoint"/> representing the intersection point (with the provided normal), or an invalid <see cref="CollisionPoint"/> if no intersection occurs.</returns>
-    public static CollisionPoint IntersectRaySegment(Vector2 rayPoint, Vector2 rayDirection, Vector2 segmentStart, Vector2 segmentEnd, Vector2 segmentNormal)
+    /// <returns>The <see cref="IntersectionPoint"/> representing the intersection point (with the provided normal), or an invalid <see cref="IntersectionPoint"/> if no intersection occurs.</returns>
+    public static IntersectionPoint IntersectRaySegment(Vector2 rayPoint, Vector2 rayDirection, Vector2 segmentStart, Vector2 segmentEnd, Vector2 segmentNormal)
     {
         var result = IntersectRaySegment(rayPoint, rayDirection, segmentStart, segmentEnd);
         if (result.Valid)
@@ -254,8 +254,8 @@ public readonly partial struct Ray
     /// <param name="rayDirection">The direction vector of the ray.</param>
     /// <param name="linePoint">A point on the line.</param>
     /// <param name="lineDirection">The direction vector of the line.</param>
-    /// <returns>The <see cref="CollisionPoint"/> representing the intersection point, or an invalid <see cref="CollisionPoint"/> if no intersection occurs.</returns>
-    public static CollisionPoint IntersectRayLine(Vector2 rayPoint, Vector2 rayDirection, Vector2 linePoint, Vector2 lineDirection)
+    /// <returns>The <see cref="IntersectionPoint"/> representing the intersection point, or an invalid <see cref="IntersectionPoint"/> if no intersection occurs.</returns>
+    public static IntersectionPoint IntersectRayLine(Vector2 rayPoint, Vector2 rayDirection, Vector2 linePoint, Vector2 lineDirection)
     {
         float denominator = rayDirection.X * lineDirection.Y - rayDirection.Y * lineDirection.X;
 
@@ -285,8 +285,8 @@ public readonly partial struct Ray
     /// <param name="linePoint">A point on the line.</param>
     /// <param name="lineDirection">The direction vector of the line.</param>
     /// <param name="lineNormal">The normal vector of the line.</param>
-    /// <returns>The <see cref="CollisionPoint"/> representing the intersection point (with the provided normal), or an invalid <see cref="CollisionPoint"/> if no intersection occurs.</returns>
-    public static CollisionPoint IntersectRayLine(Vector2 rayPoint, Vector2 rayDirection, Vector2 linePoint, Vector2 lineDirection, Vector2 lineNormal)
+    /// <returns>The <see cref="IntersectionPoint"/> representing the intersection point (with the provided normal), or an invalid <see cref="IntersectionPoint"/> if no intersection occurs.</returns>
+    public static IntersectionPoint IntersectRayLine(Vector2 rayPoint, Vector2 rayDirection, Vector2 linePoint, Vector2 lineDirection, Vector2 lineNormal)
     {
         var result = IntersectRayLine(rayPoint, rayDirection, linePoint, lineDirection);
         if (result.Valid)
@@ -304,8 +304,8 @@ public readonly partial struct Ray
     /// <param name="ray1Direction">The direction vector of the first ray.</param>
     /// <param name="ray2Point">The origin point of the second ray.</param>
     /// <param name="ray2Direction">The direction vector of the second ray.</param>
-    /// <returns>The <see cref="CollisionPoint"/> representing the intersection point, or an invalid <see cref="CollisionPoint"/> if no intersection occurs.</returns>
-    public static CollisionPoint IntersectRayRay(Vector2 ray1Point, Vector2 ray1Direction, Vector2 ray2Point, Vector2 ray2Direction)
+    /// <returns>The <see cref="IntersectionPoint"/> representing the intersection point, or an invalid <see cref="IntersectionPoint"/> if no intersection occurs.</returns>
+    public static IntersectionPoint IntersectRayRay(Vector2 ray1Point, Vector2 ray1Direction, Vector2 ray2Point, Vector2 ray2Direction)
     {
         float denominator = ray1Direction.X * ray2Direction.Y - ray1Direction.Y * ray2Direction.X;
 
@@ -336,8 +336,8 @@ public readonly partial struct Ray
     /// <param name="ray2Point">The origin point of the second ray.</param>
     /// <param name="ray2Direction">The direction vector of the second ray.</param>
     /// <param name="ray2Normal">The normal vector of the second ray.</param>
-    /// <returns>The <see cref="CollisionPoint"/> representing the intersection point (with the provided normal), or an invalid <see cref="CollisionPoint"/> if no intersection occurs.</returns>
-    public static CollisionPoint IntersectRayRay(Vector2 ray1Point, Vector2 ray1Direction, Vector2 ray2Point, Vector2 ray2Direction, Vector2 ray2Normal)
+    /// <returns>The <see cref="IntersectionPoint"/> representing the intersection point (with the provided normal), or an invalid <see cref="IntersectionPoint"/> if no intersection occurs.</returns>
+    public static IntersectionPoint IntersectRayRay(Vector2 ray1Point, Vector2 ray1Direction, Vector2 ray2Point, Vector2 ray2Direction, Vector2 ray2Normal)
     {
         var result = IntersectRayRay(ray1Point, ray1Direction, ray2Point, ray2Direction);
         if (result.Valid)
@@ -355,11 +355,11 @@ public readonly partial struct Ray
     /// <param name="rayDirection">The direction vector of the ray.</param>
     /// <param name="circleCenter">The center point of the circle.</param>
     /// <param name="radius">The radius of the circle.</param>
-    /// <returns>A tuple containing two <see cref="CollisionPoint"/>s representing the intersection points, or two invalid <see cref="CollisionPoint"/>s if no intersection occurs.</returns>
+    /// <returns>A tuple containing two <see cref="IntersectionPoint"/>s representing the intersection points, or two invalid <see cref="IntersectionPoint"/>s if no intersection occurs.</returns>
     /// <remarks>
-    /// If the ray is tangent to the circle, one valid <see cref="CollisionPoint"/> and one invalid <see cref="CollisionPoint"/> will be returned.
+    /// If the ray is tangent to the circle, one valid <see cref="IntersectionPoint"/> and one invalid <see cref="IntersectionPoint"/> will be returned.
     /// </remarks>
-    public static (CollisionPoint a, CollisionPoint b) IntersectRayCircle(Vector2 rayPoint, Vector2 rayDirection, Vector2 circleCenter, float radius)
+    public static (IntersectionPoint a, IntersectionPoint b) IntersectRayCircle(Vector2 rayPoint, Vector2 rayDirection, Vector2 circleCenter, float radius)
     {
         var toCircle = circleCenter - rayPoint;
         float projectionLength = Vector2.Dot(toCircle, rayDirection);
@@ -372,8 +372,8 @@ public readonly partial struct Ray
             var intersection1 = closestPoint - offset * rayDirection;
             var intersection2 = closestPoint + offset * rayDirection;
 
-            CollisionPoint a = new();
-            CollisionPoint b = new();
+            IntersectionPoint a = new();
+            IntersectionPoint b = new();
             if (Vector2.Dot(intersection1 - rayPoint, rayDirection) >= 0)
             {
                 var normal1 = (intersection1 - circleCenter).Normalize();
@@ -392,7 +392,7 @@ public readonly partial struct Ray
         {
             if (Vector2.Dot(closestPoint - rayPoint, rayDirection) >= 0)
             {
-                var cp = new CollisionPoint(closestPoint, (closestPoint - circleCenter).Normalize());
+                var cp = new IntersectionPoint(closestPoint, (closestPoint - circleCenter).Normalize());
                 return (cp, new());
             }
         }
@@ -408,11 +408,11 @@ public readonly partial struct Ray
     /// <param name="a">The first vertex of the triangle.</param>
     /// <param name="b">The second vertex of the triangle.</param>
     /// <param name="c">The third vertex of the triangle.</param>
-    /// <returns>A tuple containing two <see cref="CollisionPoint"/>s representing the intersection points, or two invalid <see cref="CollisionPoint"/>s if no intersection occurs.</returns>
-    public static (CollisionPoint a, CollisionPoint b) IntersectRayTriangle(Vector2 rayPoint, Vector2 rayDirection, Vector2 a, Vector2 b, Vector2 c)
+    /// <returns>A tuple containing two <see cref="IntersectionPoint"/>s representing the intersection points, or two invalid <see cref="IntersectionPoint"/>s if no intersection occurs.</returns>
+    public static (IntersectionPoint a, IntersectionPoint b) IntersectRayTriangle(Vector2 rayPoint, Vector2 rayDirection, Vector2 a, Vector2 b, Vector2 c)
     {
-        CollisionPoint resultA = new();
-        CollisionPoint resultB = new();
+        IntersectionPoint resultA = new();
+        IntersectionPoint resultB = new();
 
         var cp = IntersectRaySegment(rayPoint, rayDirection, a, b);
         if (cp.Valid) resultA = cp;
@@ -445,11 +445,11 @@ public readonly partial struct Ray
     /// <param name="b">The second vertex of the quadrilateral.</param>
     /// <param name="c">The third vertex of the quadrilateral.</param>
     /// <param name="d">The fourth vertex of the quadrilateral.</param>
-    /// <returns>A tuple containing two <see cref="CollisionPoint"/>s representing the intersection points, or two invalid <see cref="CollisionPoint"/>s if no intersection occurs.</returns>
-    public static (CollisionPoint a, CollisionPoint b) IntersectRayQuad(Vector2 rayPoint, Vector2 rayDirection, Vector2 a, Vector2 b, Vector2 c, Vector2 d)
+    /// <returns>A tuple containing two <see cref="IntersectionPoint"/>s representing the intersection points, or two invalid <see cref="IntersectionPoint"/>s if no intersection occurs.</returns>
+    public static (IntersectionPoint a, IntersectionPoint b) IntersectRayQuad(Vector2 rayPoint, Vector2 rayDirection, Vector2 a, Vector2 b, Vector2 c, Vector2 d)
     {
-        CollisionPoint resultA = new();
-        CollisionPoint resultB = new();
+        IntersectionPoint resultA = new();
+        IntersectionPoint resultB = new();
 
         var cp = IntersectRaySegment(rayPoint, rayDirection, a, b);
         if (cp.Valid) resultA = cp;
@@ -491,8 +491,8 @@ public readonly partial struct Ray
     /// <param name="b">The second vertex of the rectangle.</param>
     /// <param name="c">The third vertex of the rectangle.</param>
     /// <param name="d">The fourth vertex of the rectangle.</param>
-    /// <returns>A tuple containing two <see cref="CollisionPoint"/>s representing the intersection points, or two invalid <see cref="CollisionPoint"/>s if no intersection occurs.</returns>
-    public static (CollisionPoint a, CollisionPoint b) IntersectRayRect(Vector2 rayPoint, Vector2 rayDirection, Vector2 a, Vector2 b, Vector2 c, Vector2 d)
+    /// <returns>A tuple containing two <see cref="IntersectionPoint"/>s representing the intersection points, or two invalid <see cref="IntersectionPoint"/>s if no intersection occurs.</returns>
+    public static (IntersectionPoint a, IntersectionPoint b) IntersectRayRect(Vector2 rayPoint, Vector2 rayDirection, Vector2 a, Vector2 b, Vector2 c, Vector2 d)
     {
         return IntersectRayQuad(rayPoint, rayDirection, a, b, c, d);
     }
@@ -504,15 +504,15 @@ public readonly partial struct Ray
     /// <param name="rayDirection">The direction vector of the ray.</param>
     /// <param name="points">The list of points defining the polygon.</param>
     /// <param name="maxCollisionPoints">The maximum number of collision points to return, or -1 for no limit.</param>
-    /// <returns>A list of <see cref="CollisionPoint"/>s representing the intersection points, or null if the polygon has fewer than 3 points.</returns>
+    /// <returns>A list of <see cref="IntersectionPoint"/>s representing the intersection points, or null if the polygon has fewer than 3 points.</returns>
     /// <remarks>
     /// If <paramref name="maxCollisionPoints"/> is greater than 0, the method will return at most that many collision points.
     /// </remarks>
-    public static CollisionPoints? IntersectRayPolygon(Vector2 rayPoint, Vector2 rayDirection, List<Vector2> points, int maxCollisionPoints = -1)
+    public static IntersectionPoints? IntersectRayPolygon(Vector2 rayPoint, Vector2 rayDirection, List<Vector2> points, int maxCollisionPoints = -1)
     {
         if (points.Count < 3) return null;
         if (maxCollisionPoints == 0) return null;
-        CollisionPoints? result = null;
+        IntersectionPoints? result = null;
         for (var i = 0; i < points.Count; i++)
         {
             var colPoint = IntersectRaySegment(rayPoint, rayDirection, points[i], points[(i + 1) % points.Count]);
@@ -534,15 +534,15 @@ public readonly partial struct Ray
     /// <param name="rayDirection">The direction vector of the ray.</param>
     /// <param name="points">The list of points defining the polyline.</param>
     /// <param name="maxCollisionPoints">The maximum number of collision points to return, or -1 for no limit.</param>
-    /// <returns>A list of <see cref="CollisionPoint"/>s representing the intersection points, or null if the polyline has fewer than 2 points.</returns>
+    /// <returns>A list of <see cref="IntersectionPoint"/>s representing the intersection points, or null if the polyline has fewer than 2 points.</returns>
     /// <remarks>
     /// If <paramref name="maxCollisionPoints"/> is greater than 0, the method will return at most that many collision points.
     /// </remarks>
-    public static CollisionPoints? IntersectRayPolyline(Vector2 rayPoint, Vector2 rayDirection, List<Vector2> points, int maxCollisionPoints = -1)
+    public static IntersectionPoints? IntersectRayPolyline(Vector2 rayPoint, Vector2 rayDirection, List<Vector2> points, int maxCollisionPoints = -1)
     {
         if (points.Count < 2) return null;
         if (maxCollisionPoints == 0) return null;
-        CollisionPoints? result = null;
+        IntersectionPoints? result = null;
         for (var i = 0; i < points.Count - 1; i++)
         {
             var colPoint = IntersectRaySegment(rayPoint, rayDirection, points[i], points[i + 1]);
@@ -564,15 +564,15 @@ public readonly partial struct Ray
     /// <param name="rayDirection">The direction vector of the ray.</param>
     /// <param name="segments">The list of segments to test for intersection.</param>
     /// <param name="maxCollisionPoints">The maximum number of collision points to return, or -1 for no limit.</param>
-    /// <returns>A list of <see cref="CollisionPoint"/>s representing the intersection points, or null if the list of segments is empty.</returns>
+    /// <returns>A list of <see cref="IntersectionPoint"/>s representing the intersection points, or null if the list of segments is empty.</returns>
     /// <remarks>
     /// If <paramref name="maxCollisionPoints"/> is greater than 0, the method will return at most that many collision points.
     /// </remarks>
-    public static CollisionPoints? IntersectRaySegments(Vector2 rayPoint, Vector2 rayDirection, List<Segment> segments, int maxCollisionPoints = -1)
+    public static IntersectionPoints? IntersectRaySegments(Vector2 rayPoint, Vector2 rayDirection, List<Segment> segments, int maxCollisionPoints = -1)
     {
         if (segments.Count <= 0) return null;
         if (maxCollisionPoints == 0) return null;
-        CollisionPoints? result = null;
+        IntersectionPoints? result = null;
 
         foreach (var seg in segments)
         {
@@ -600,7 +600,7 @@ public readonly partial struct Ray
     /// <remarks>
     /// The method will add valid collision points to the <paramref name="result"/> list.
     /// </remarks>
-    public static int IntersectRayPolygon(Vector2 rayPoint, Vector2 rayDirection, List<Vector2> points, ref CollisionPoints result,
+    public static int IntersectRayPolygon(Vector2 rayPoint, Vector2 rayDirection, List<Vector2> points, ref IntersectionPoints result,
         bool returnAfterFirstValid = false)
     {
         if (points.Count < 3) return 0;

--- a/ShapeEngine/Geometry/RectDef/RectClosestPoint.cs
+++ b/ShapeEngine/Geometry/RectDef/RectClosestPoint.cs
@@ -62,11 +62,11 @@ public readonly partial struct Rect
     /// </summary>
     /// <param name="p">The point to find the closest point to.</param>
     /// <param name="disSquared">The squared distance from <paramref name="p"/> to the closest point on the rectangle.</param>
-    /// <returns>A <see cref="CollisionPoint"/> containing the closest point and the outward normal.</returns>
+    /// <returns>A <see cref="IntersectionPoint"/> containing the closest point and the outward normal.</returns>
     /// <remarks>
     /// The normal is perpendicular to the edge where the closest point lies, pointing outward from the rectangle.
     /// </remarks>
-    public CollisionPoint GetClosestPoint(Vector2 p, out float disSquared)
+    public IntersectionPoint GetClosestPoint(Vector2 p, out float disSquared)
     {
         var min = Segment.GetClosestPointSegmentPoint(A, B, p, out disSquared);
         var normal = B - A;
@@ -104,11 +104,11 @@ public readonly partial struct Rect
     /// <param name="p">The point to find the closest point to.</param>
     /// <param name="disSquared">The squared distance from <paramref name="p"/> to the closest point on the rectangle.</param>
     /// <param name="index">The index of the edge (0 = AB, 1 = BC, 2 = CD, 3 = DA) where the closest point lies.</param>
-    /// <returns>A <see cref="CollisionPoint"/> containing the closest point and the outward normal.</returns>
+    /// <returns>A <see cref="IntersectionPoint"/> containing the closest point and the outward normal.</returns>
     /// <remarks>
     /// The normal is perpendicular to the edge where the closest point lies, pointing outward from the rectangle.
     /// </remarks>
-    public CollisionPoint GetClosestPoint(Vector2 p, out float disSquared, out int index)
+    public IntersectionPoint GetClosestPoint(Vector2 p, out float disSquared, out int index)
     {
         var min = Segment.GetClosestPointSegmentPoint(A, B, p, out disSquared);
         index = 0;
@@ -996,8 +996,8 @@ public readonly partial struct Rect
     /// </summary>
     /// <param name="p">The point to compare against.</param>
     /// <param name="disSquared">The squared distance from <paramref name="p"/> to the closest segment.</param>
-    /// <returns>A tuple containing the closest <see cref="Segment"/> and its closest <see cref="CollisionPoint"/>.</returns>
-    public (Segment segment, CollisionPoint segmentPoint) GetClosestSegment(Vector2 p, out float disSquared)
+    /// <returns>A tuple containing the closest <see cref="Segment"/> and its closest <see cref="IntersectionPoint"/>.</returns>
+    public (Segment segment, IntersectionPoint segmentPoint) GetClosestSegment(Vector2 p, out float disSquared)
     {
         var closestSegment = TopSegment;
         var closestResult = closestSegment.GetClosestPoint(p, out float minDisSquared);

--- a/ShapeEngine/Geometry/RectDef/RectCollision.cs
+++ b/ShapeEngine/Geometry/RectDef/RectCollision.cs
@@ -104,8 +104,8 @@ public readonly partial struct Rect
     {
         var pos = boundingCircle.Center;
         var radius = boundingCircle.Radius;
-        CollisionPoint horizontal;
-        CollisionPoint vertical;
+        IntersectionPoint horizontal;
+        IntersectionPoint vertical;
         if (pos.X + radius > Right)
         {
             pos.X = Right - radius;
@@ -157,8 +157,8 @@ public readonly partial struct Rect
         var halfSize = boundingBox.Size * 0.5f;
 
         var newPos = pos;
-        CollisionPoint horizontal;
-        CollisionPoint vertical;
+        IntersectionPoint horizontal;
+        IntersectionPoint vertical;
         if (pos.X + halfSize.Width > Right)
         {
             newPos.X = Right - halfSize.Width;

--- a/ShapeEngine/Geometry/RectDef/RectIntersectShape.cs
+++ b/ShapeEngine/Geometry/RectDef/RectIntersectShape.cs
@@ -18,12 +18,12 @@ public readonly partial struct Rect
     /// </summary>
     /// <param name="collider">The collider to test for intersection.</param>
     /// <returns>
-    /// A <see cref="CollisionPoints"/> object containing intersection points, or null if there are no intersections or the collider is disabled.
+    /// A <see cref="IntersectionPoints"/> object containing intersection points, or null if there are no intersections or the collider is disabled.
     /// </returns>
     /// <remarks>
     /// Dispatches to the appropriate shape-specific intersection method based on the collider's shape type.
     /// </remarks>
-    public CollisionPoints? Intersect(Collider collider)
+    public IntersectionPoints? Intersect(Collider collider)
     {
         if (!collider.Enabled) return null;
 
@@ -66,16 +66,16 @@ public readonly partial struct Rect
     /// </summary>
     /// <param name="segments">The segments to test for intersection.</param>
     /// <returns>
-    /// A <see cref="CollisionPoints"/> object containing intersection points, or null if there are no intersections.
+    /// A <see cref="IntersectionPoints"/> object containing intersection points, or null if there are no intersections.
     /// </returns>
     /// <remarks>
     /// Each segment is tested against all four sides of the rectangle.
     /// </remarks>
-    public CollisionPoints? IntersectShape(Segments segments)
+    public IntersectionPoints? IntersectShape(Segments segments)
     {
         if (segments.Count <= 0) return null;
 
-        CollisionPoints? points = null;
+        IntersectionPoints? points = null;
 
         var a = TopLeft;
         var b = BottomLeft;
@@ -121,14 +121,14 @@ public readonly partial struct Rect
     /// </summary>
     /// <param name="r">The ray to test for intersection.</param>
     /// <returns>
-    /// A <see cref="CollisionPoints"/> object containing intersection points, or null if there are no intersections.
+    /// A <see cref="IntersectionPoints"/> object containing intersection points, or null if there are no intersections.
     /// </returns>
     /// <remarks>
     /// Each side of the rectangle is tested against the ray.
     /// </remarks>
-    public CollisionPoints? IntersectShape(Ray r)
+    public IntersectionPoints? IntersectShape(Ray r)
     {
-        CollisionPoints? points = null;
+        IntersectionPoints? points = null;
         var a = TopLeft;
         var b = BottomLeft;
         var c = BottomRight;
@@ -170,14 +170,14 @@ public readonly partial struct Rect
     /// </summary>
     /// <param name="l">The line to test for intersection.</param>
     /// <returns>
-    /// A <see cref="CollisionPoints"/> object containing intersection points, or null if there are no intersections.
+    /// A <see cref="IntersectionPoints"/> object containing intersection points, or null if there are no intersections.
     /// </returns>
     /// <remarks>
     /// Each side of the rectangle is tested against the line.
     /// </remarks>
-    public CollisionPoints? IntersectShape(Line l)
+    public IntersectionPoints? IntersectShape(Line l)
     {
-        CollisionPoints? points = null;
+        IntersectionPoints? points = null;
         var a = TopLeft;
         var b = BottomLeft;
         var c = BottomRight;
@@ -219,14 +219,14 @@ public readonly partial struct Rect
     /// </summary>
     /// <param name="s">The segment to test for intersection.</param>
     /// <returns>
-    /// A <see cref="CollisionPoints"/> object containing intersection points, or null if there are no intersections.
+    /// A <see cref="IntersectionPoints"/> object containing intersection points, or null if there are no intersections.
     /// </returns>
     /// <remarks>
     /// Each side of the rectangle is tested against the segment.
     /// </remarks>
-    public CollisionPoints? IntersectShape(Segment s)
+    public IntersectionPoints? IntersectShape(Segment s)
     {
-        CollisionPoints? points = null;
+        IntersectionPoints? points = null;
         var a = TopLeft;
         var b = BottomLeft;
         var c = BottomRight;
@@ -268,14 +268,14 @@ public readonly partial struct Rect
     /// </summary>
     /// <param name="circle">The circle to test for intersection.</param>
     /// <returns>
-    /// A <see cref="CollisionPoints"/> object containing intersection points, or null if there are no intersections.
+    /// A <see cref="IntersectionPoints"/> object containing intersection points, or null if there are no intersections.
     /// </returns>
     /// <remarks>
     /// Each side of the rectangle is tested against the circle.
     /// </remarks>
-    public CollisionPoints? IntersectShape(Circle circle)
+    public IntersectionPoints? IntersectShape(Circle circle)
     {
-        CollisionPoints? points = null;
+        IntersectionPoints? points = null;
 
         var a = TopLeft;
         var b = BottomLeft;
@@ -322,14 +322,14 @@ public readonly partial struct Rect
     /// </summary>
     /// <param name="t">The triangle to test for intersection.</param>
     /// <returns>
-    /// A <see cref="CollisionPoints"/> object containing intersection points, or null if there are no intersections.
+    /// A <see cref="IntersectionPoints"/> object containing intersection points, or null if there are no intersections.
     /// </returns>
     /// <remarks>
     /// Each side of the rectangle is tested against the triangle's edges.
     /// </remarks>
-    public CollisionPoints? IntersectShape(Triangle t)
+    public IntersectionPoints? IntersectShape(Triangle t)
     {
-        CollisionPoints? points = null;
+        IntersectionPoints? points = null;
 
         var a = TopLeft;
         var b = BottomLeft;
@@ -430,14 +430,14 @@ public readonly partial struct Rect
     /// </summary>
     /// <param name="r">The rectangle to test for intersection.</param>
     /// <returns>
-    /// A <see cref="CollisionPoints"/> object containing intersection points, or null if there are no intersections.
+    /// A <see cref="IntersectionPoints"/> object containing intersection points, or null if there are no intersections.
     /// </returns>
     /// <remarks>
     /// Each side of the rectangle is tested against all four sides of the other rectangle.
     /// </remarks>
-    public CollisionPoints? IntersectShape(Rect r)
+    public IntersectionPoints? IntersectShape(Rect r)
     {
-        CollisionPoints? points = null;
+        IntersectionPoints? points = null;
         var a = TopLeft;
         var b = BottomLeft;
         var c = BottomRight;
@@ -573,14 +573,14 @@ public readonly partial struct Rect
     /// </summary>
     /// <param name="q">The quadrilateral to test for intersection.</param>
     /// <returns>
-    /// A <see cref="CollisionPoints"/> object containing intersection points, or null if there are no intersections.
+    /// A <see cref="IntersectionPoints"/> object containing intersection points, or null if there are no intersections.
     /// </returns>
     /// <remarks>
     /// Each side of the rectangle is tested against all four sides of the quadrilateral.
     /// </remarks>
-    public CollisionPoints? IntersectShape(Quad q)
+    public IntersectionPoints? IntersectShape(Quad q)
     {
-        CollisionPoints? points = null;
+        IntersectionPoints? points = null;
         var a = TopLeft;
         var b = BottomLeft;
         var c = BottomRight;
@@ -707,16 +707,16 @@ public readonly partial struct Rect
     /// </summary>
     /// <param name="p">The polygon to test for intersection.</param>
     /// <returns>
-    /// A <see cref="CollisionPoints"/> object containing intersection points, or null if there are no intersections.
+    /// A <see cref="IntersectionPoints"/> object containing intersection points, or null if there are no intersections.
     /// </returns>
     /// <remarks>
     /// Each side of the rectangle is tested against each edge of the polygon.
     /// </remarks>
-    public CollisionPoints? IntersectShape(Polygon p)
+    public IntersectionPoints? IntersectShape(Polygon p)
     {
         if (p.Count < 3) return null;
 
-        CollisionPoints? points = null;
+        IntersectionPoints? points = null;
 
         var a = TopLeft;
         var b = BottomLeft;
@@ -762,16 +762,16 @@ public readonly partial struct Rect
     /// </summary>
     /// <param name="pl">The polyline to test for intersection.</param>
     /// <returns>
-    /// A <see cref="CollisionPoints"/> object containing intersection points, or null if there are no intersections.
+    /// A <see cref="IntersectionPoints"/> object containing intersection points, or null if there are no intersections.
     /// </returns>
     /// <remarks>
     /// Each side of the rectangle is tested against each segment of the polyline.
     /// </remarks>
-    public CollisionPoints? IntersectShape(Polyline pl)
+    public IntersectionPoints? IntersectShape(Polyline pl)
     {
         if (pl.Count < 2) return null;
 
-        CollisionPoints? points = null;
+        IntersectionPoints? points = null;
 
         var a = TopLeft;
         var b = BottomLeft;

--- a/ShapeEngine/Geometry/RectDef/RectIntersectShape2.cs
+++ b/ShapeEngine/Geometry/RectDef/RectIntersectShape2.cs
@@ -14,16 +14,16 @@ namespace ShapeEngine.Geometry.RectDef;
 public readonly partial struct Rect
 {
     /// <summary>
-    /// Computes the number of intersection points between this rectangle and the specified collider, adding them to the provided <see cref="CollisionPoints"/> collection.
+    /// Computes the number of intersection points between this rectangle and the specified collider, adding them to the provided <see cref="IntersectionPoints"/> collection.
     /// </summary>
     /// <param name="collider">The collider to test for intersection.</param>
-    /// <param name="points">A reference to the <see cref="CollisionPoints"/> collection to which intersection points will be added.</param>
+    /// <param name="points">A reference to the <see cref="IntersectionPoints"/> collection to which intersection points will be added.</param>
     /// <param name="returnAfterFirstValid">If true, returns after the first valid intersection is found; otherwise, finds all intersections.</param>
     /// <returns>The number of intersection points found.</returns>
     /// <remarks>
     /// Dispatches to the appropriate shape-specific intersection method based on the collider's shape type.
     /// </remarks>
-    public int Intersect(Collider collider, ref CollisionPoints points, bool returnAfterFirstValid = false)
+    public int Intersect(Collider collider, ref IntersectionPoints points, bool returnAfterFirstValid = false)
     {
         if (!collider.Enabled) return 0;
 
@@ -62,16 +62,16 @@ public readonly partial struct Rect
     }
 
     /// <summary>
-    /// Computes the number of intersection points between this rectangle and a ray, adding them to the provided <see cref="CollisionPoints"/> collection.
+    /// Computes the number of intersection points between this rectangle and a ray, adding them to the provided <see cref="IntersectionPoints"/> collection.
     /// </summary>
     /// <param name="r">The ray to test for intersection.</param>
-    /// <param name="points">A reference to the <see cref="CollisionPoints"/> collection to which intersection points will be added.</param>
+    /// <param name="points">A reference to the <see cref="IntersectionPoints"/> collection to which intersection points will be added.</param>
     /// <param name="returnAfterFirstValid">If true, returns after the first valid intersection is found; otherwise, finds all intersections.</param>
     /// <returns>The number of intersection points found.</returns>
     /// <remarks>
     /// Each side of the rectangle is tested against the ray.
     /// </remarks>
-    public int IntersectShape(Ray r, ref CollisionPoints points, bool returnAfterFirstValid = false)
+    public int IntersectShape(Ray r, ref IntersectionPoints points, bool returnAfterFirstValid = false)
     {
         var count = 0;
         var a = TopLeft;
@@ -118,16 +118,16 @@ public readonly partial struct Rect
     }
 
     /// <summary>
-    /// Computes the number of intersection points between this rectangle and a line, adding them to the provided <see cref="CollisionPoints"/> collection.
+    /// Computes the number of intersection points between this rectangle and a line, adding them to the provided <see cref="IntersectionPoints"/> collection.
     /// </summary>
     /// <param name="l">The line to test for intersection.</param>
-    /// <param name="points">A reference to the <see cref="CollisionPoints"/> collection to which intersection points will be added.</param>
+    /// <param name="points">A reference to the <see cref="IntersectionPoints"/> collection to which intersection points will be added.</param>
     /// <param name="returnAfterFirstValid">If true, returns after the first valid intersection is found; otherwise, finds all intersections.</param>
     /// <returns>The number of intersection points found.</returns>
     /// <remarks>
     /// Each side of the rectangle is tested against the line.
     /// </remarks>
-    public int IntersectShape(Line l, ref CollisionPoints points, bool returnAfterFirstValid = false)
+    public int IntersectShape(Line l, ref IntersectionPoints points, bool returnAfterFirstValid = false)
     {
         var count = 0;
         var a = TopLeft;
@@ -174,16 +174,16 @@ public readonly partial struct Rect
     }
 
     /// <summary>
-    /// Computes the number of intersection points between this rectangle and a segment, adding them to the provided <see cref="CollisionPoints"/> collection.
+    /// Computes the number of intersection points between this rectangle and a segment, adding them to the provided <see cref="IntersectionPoints"/> collection.
     /// </summary>
     /// <param name="s">The segment to test for intersection.</param>
-    /// <param name="points">A reference to the <see cref="CollisionPoints"/> collection to which intersection points will be added.</param>
+    /// <param name="points">A reference to the <see cref="IntersectionPoints"/> collection to which intersection points will be added.</param>
     /// <param name="returnAfterFirstValid">If true, returns after the first valid intersection is found; otherwise, finds all intersections.</param>
     /// <returns>The number of intersection points found.</returns>
     /// <remarks>
     /// Each side of the rectangle is tested against the segment.
     /// </remarks>
-    public int IntersectShape(Segment s, ref CollisionPoints points, bool returnAfterFirstValid = false)
+    public int IntersectShape(Segment s, ref IntersectionPoints points, bool returnAfterFirstValid = false)
     {
         var count = 0;
         var a = TopLeft;
@@ -230,16 +230,16 @@ public readonly partial struct Rect
     }
 
     /// <summary>
-    /// Computes the number of intersection points between this rectangle and a circle, adding them to the provided <see cref="CollisionPoints"/> collection.
+    /// Computes the number of intersection points between this rectangle and a circle, adding them to the provided <see cref="IntersectionPoints"/> collection.
     /// </summary>
     /// <param name="circle">The circle to test for intersection.</param>
-    /// <param name="points">A reference to the <see cref="CollisionPoints"/> collection to which intersection points will be added.</param>
+    /// <param name="points">A reference to the <see cref="IntersectionPoints"/> collection to which intersection points will be added.</param>
     /// <param name="returnAfterFirstValid">If true, returns after the first valid intersection is found; otherwise, finds all intersections.</param>
     /// <returns>The number of intersection points found.</returns>
     /// <remarks>
     /// Each side of the rectangle is tested against the circle.
     /// </remarks>
-    public int IntersectShape(Circle circle, ref CollisionPoints points, bool returnAfterFirstValid = false)
+    public int IntersectShape(Circle circle, ref IntersectionPoints points, bool returnAfterFirstValid = false)
     {
         var count = 0;
 
@@ -311,16 +311,16 @@ public readonly partial struct Rect
     }
 
     /// <summary>
-    /// Computes the number of intersection points between this rectangle and a triangle, adding them to the provided <see cref="CollisionPoints"/> collection.
+    /// Computes the number of intersection points between this rectangle and a triangle, adding them to the provided <see cref="IntersectionPoints"/> collection.
     /// </summary>
     /// <param name="t">The triangle to test for intersection.</param>
-    /// <param name="points">A reference to the <see cref="CollisionPoints"/> collection to which intersection points will be added.</param>
+    /// <param name="points">A reference to the <see cref="IntersectionPoints"/> collection to which intersection points will be added.</param>
     /// <param name="returnAfterFirstValid">If true, returns after the first valid intersection is found; otherwise, finds all intersections.</param>
     /// <returns>The number of intersection points found.</returns>
     /// <remarks>
     /// Each side of the rectangle is tested against the triangle's edges.
     /// </remarks>
-    public int IntersectShape(Triangle t, ref CollisionPoints points, bool returnAfterFirstValid = false)
+    public int IntersectShape(Triangle t, ref IntersectionPoints points, bool returnAfterFirstValid = false)
     {
         var count = 0;
 
@@ -430,16 +430,16 @@ public readonly partial struct Rect
     }
 
     /// <summary>
-    /// Computes the number of intersection points between this rectangle and a quad, adding them to the provided <see cref="CollisionPoints"/> collection.
+    /// Computes the number of intersection points between this rectangle and a quad, adding them to the provided <see cref="IntersectionPoints"/> collection.
     /// </summary>
     /// <param name="q">The quad to test for intersection.</param>
-    /// <param name="points">A reference to the <see cref="CollisionPoints"/> collection to which intersection points will be added.</param>
+    /// <param name="points">A reference to the <see cref="IntersectionPoints"/> collection to which intersection points will be added.</param>
     /// <param name="returnAfterFirstValid">If true, returns after the first valid intersection is found; otherwise, finds all intersections.</param>
     /// <returns>The number of intersection points found.</returns>
     /// <remarks>
     /// Each side of the rectangle is tested against the quad's edges.
     /// </remarks>
-    public int IntersectShape(Quad q, ref CollisionPoints points, bool returnAfterFirstValid = false)
+    public int IntersectShape(Quad q, ref IntersectionPoints points, bool returnAfterFirstValid = false)
     {
         var count = 0;
         var a = TopLeft;
@@ -579,16 +579,16 @@ public readonly partial struct Rect
     }
 
     /// <summary>
-    /// Computes the number of intersection points between this rectangle and another rectangle, adding them to the provided <see cref="CollisionPoints"/> collection.
+    /// Computes the number of intersection points between this rectangle and another rectangle, adding them to the provided <see cref="IntersectionPoints"/> collection.
     /// </summary>
     /// <param name="r">The rectangle to test for intersection.</param>
-    /// <param name="points">A reference to the <see cref="CollisionPoints"/> collection to which intersection points will be added.</param>
+    /// <param name="points">A reference to the <see cref="IntersectionPoints"/> collection to which intersection points will be added.</param>
     /// <param name="returnAfterFirstValid">If true, returns after the first valid intersection is found; otherwise, finds all intersections.</param>
     /// <returns>The number of intersection points found.</returns>
     /// <remarks>
     /// Each side of the rectangle is tested against the other rectangle's sides.
     /// </remarks>
-    public int IntersectShape(Rect r, ref CollisionPoints points, bool returnAfterFirstValid = false)
+    public int IntersectShape(Rect r, ref IntersectionPoints points, bool returnAfterFirstValid = false)
     {
         var count = 0;
         var a = TopLeft;
@@ -737,16 +737,16 @@ public readonly partial struct Rect
     }
 
     /// <summary>
-    /// Computes the number of intersection points between this rectangle and a polygon, adding them to the provided <see cref="CollisionPoints"/> collection.
+    /// Computes the number of intersection points between this rectangle and a polygon, adding them to the provided <see cref="IntersectionPoints"/> collection.
     /// </summary>
     /// <param name="p">The polygon to test for intersection.</param>
-    /// <param name="points">A reference to the <see cref="CollisionPoints"/> collection to which intersection points will be added.</param>
+    /// <param name="points">A reference to the <see cref="IntersectionPoints"/> collection to which intersection points will be added.</param>
     /// <param name="returnAfterFirstValid">If true, returns after the first valid intersection is found; otherwise, finds all intersections.</param>
     /// <returns>The number of intersection points found.</returns>
     /// <remarks>
     /// Each side of the rectangle is tested against the polygon's edges.
     /// </remarks>
-    public int IntersectShape(Polygon p, ref CollisionPoints points, bool returnAfterFirstValid = false)
+    public int IntersectShape(Polygon p, ref IntersectionPoints points, bool returnAfterFirstValid = false)
     {
         if (p.Count < 3) return 0;
 
@@ -796,16 +796,16 @@ public readonly partial struct Rect
     }
 
     /// <summary>
-    /// Computes the number of intersection points between this rectangle and a polyline, adding them to the provided <see cref="CollisionPoints"/> collection.
+    /// Computes the number of intersection points between this rectangle and a polyline, adding them to the provided <see cref="IntersectionPoints"/> collection.
     /// </summary>
     /// <param name="pl">The polyline to test for intersection.</param>
-    /// <param name="points">A reference to the <see cref="CollisionPoints"/> collection to which intersection points will be added.</param>
+    /// <param name="points">A reference to the <see cref="IntersectionPoints"/> collection to which intersection points will be added.</param>
     /// <param name="returnAfterFirstValid">If true, returns after the first valid intersection is found; otherwise, finds all intersections.</param>
     /// <returns>The number of intersection points found.</returns>
     /// <remarks>
     /// Each side of the rectangle is tested against the polyline's segments.
     /// </remarks>
-    public int IntersectShape(Polyline pl, ref CollisionPoints points, bool returnAfterFirstValid = false)
+    public int IntersectShape(Polyline pl, ref IntersectionPoints points, bool returnAfterFirstValid = false)
     {
         if (pl.Count < 2) return 0;
 
@@ -854,16 +854,16 @@ public readonly partial struct Rect
     }
 
     /// <summary>
-    /// Computes the number of intersection points between this rectangle and a collection of segments, adding them to the provided <see cref="CollisionPoints"/> collection.
+    /// Computes the number of intersection points between this rectangle and a collection of segments, adding them to the provided <see cref="IntersectionPoints"/> collection.
     /// </summary>
     /// <param name="shape">The collection of segments to test for intersection.</param>
-    /// <param name="points">A reference to the <see cref="CollisionPoints"/> collection to which intersection points will be added.</param>
+    /// <param name="points">A reference to the <see cref="IntersectionPoints"/> collection to which intersection points will be added.</param>
     /// <param name="returnAfterFirstValid">If true, returns after the first valid intersection is found; otherwise, finds all intersections.</param>
     /// <returns>The number of intersection points found.</returns>
     /// <remarks>
     /// Each side of the rectangle is tested against each segment in the collection.
     /// </remarks>
-    public int IntersectShape(Segments shape, ref CollisionPoints points, bool returnAfterFirstValid = false)
+    public int IntersectShape(Segments shape, ref IntersectionPoints points, bool returnAfterFirstValid = false)
     {
         if (shape.Count <= 0) return 0;
 

--- a/ShapeEngine/Geometry/SegmentDef/SegmentClosestPoint.cs
+++ b/ShapeEngine/Geometry/SegmentDef/SegmentClosestPoint.cs
@@ -20,11 +20,11 @@ public readonly partial struct Segment
     /// </summary>
     /// <param name="p">The point to find the closest point to.</param>
     /// <param name="disSquared">The squared distance from the point to the closest point on the segment.</param>
-    /// <returns>A <see cref="CollisionPoint"/> representing the closest point and its normal.</returns>
+    /// <returns>A <see cref="IntersectionPoint"/> representing the closest point and its normal.</returns>
     /// <remarks>
     /// If the closest point is at the segment's endpoint, the normal is chosen based on the direction to the point.
     /// </remarks>
-    public CollisionPoint GetClosestPoint(Vector2 p, out float disSquared)
+    public IntersectionPoint GetClosestPoint(Vector2 p, out float disSquared)
     {
         Vector2 c;
         var w = Displacement;

--- a/ShapeEngine/Geometry/SegmentDef/SegmentIntersectShape.cs
+++ b/ShapeEngine/Geometry/SegmentDef/SegmentIntersectShape.cs
@@ -17,11 +17,11 @@ public readonly partial struct Segment
     /// Computes all intersection points between this segment and a collider shape.
     /// </summary>
     /// <param name="collider">The collider whose shape will be tested for intersection. Must be enabled.</param>
-    /// <returns>A <see cref="CollisionPoints"/> collection containing intersection points, or null if there are no intersections or the collider is disabled.</returns>
+    /// <returns>A <see cref="IntersectionPoints"/> collection containing intersection points, or null if there are no intersections or the collider is disabled.</returns>
     /// <remarks>
     /// The method dispatches to the appropriate shape-specific intersection method based on the collider's shape type.
     /// </remarks>
-    public CollisionPoints? Intersect(Collider collider)
+    public IntersectionPoints? Intersect(Collider collider)
     {
         if (!collider.Enabled) return null;
 
@@ -63,11 +63,11 @@ public readonly partial struct Segment
     /// Computes all intersection points between this segment and another segment.
     /// </summary>
     /// <param name="s">The segment to test against.</param>
-    /// <returns>A <see cref="CollisionPoints"/> collection containing intersection points, or null if there are no intersections.</returns>
+    /// <returns>A <see cref="IntersectionPoints"/> collection containing intersection points, or null if there are no intersections.</returns>
     /// <remarks>
     /// Returns a single intersection point if the segments intersect, otherwise null.
     /// </remarks>
-    public CollisionPoints? IntersectShape(Segment s)
+    public IntersectionPoints? IntersectShape(Segment s)
     {
         var cp = IntersectSegmentSegment(Start, End, s.Start, s.End, s.Normal);
         if (cp.Valid) return [cp];
@@ -79,11 +79,11 @@ public readonly partial struct Segment
     /// Computes all intersection points between this segment and a line.
     /// </summary>
     /// <param name="l">The line to test against.</param>
-    /// <returns>A <see cref="CollisionPoints"/> collection containing intersection points, or null if there are no intersections.</returns>
+    /// <returns>A <see cref="IntersectionPoints"/> collection containing intersection points, or null if there are no intersections.</returns>
     /// <remarks>
     /// Returns a single intersection point if the segment and line intersect, otherwise null.
     /// </remarks>
-    public CollisionPoints? IntersectShape(Line l)
+    public IntersectionPoints? IntersectShape(Line l)
     {
         var cp = IntersectSegmentLine(Start, End, l.Point, l.Direction, l.Normal);
         if (cp.Valid) return [cp];
@@ -95,11 +95,11 @@ public readonly partial struct Segment
     /// Computes all intersection points between this segment and a ray.
     /// </summary>
     /// <param name="r">The ray to test against.</param>
-    /// <returns>A <see cref="CollisionPoints"/> collection containing intersection points, or null if there are no intersections.</returns>
+    /// <returns>A <see cref="IntersectionPoints"/> collection containing intersection points, or null if there are no intersections.</returns>
     /// <remarks>
     /// Returns a single intersection point if the segment and ray intersect, otherwise null.
     /// </remarks>
-    public CollisionPoints? IntersectShape(Ray r)
+    public IntersectionPoints? IntersectShape(Ray r)
     {
         var cp = IntersectSegmentRay(Start, End, r.Point, r.Direction, r.Normal);
         if (cp.Valid) return [cp];
@@ -111,17 +111,17 @@ public readonly partial struct Segment
     /// Computes all intersection points between this segment and a circle.
     /// </summary>
     /// <param name="c">The circle to test against.</param>
-    /// <returns>A <see cref="CollisionPoints"/> collection containing intersection points, or null if there are no intersections.</returns>
+    /// <returns>A <see cref="IntersectionPoints"/> collection containing intersection points, or null if there are no intersections.</returns>
     /// <remarks>
     /// May return up to two intersection points depending on the segment's position relative to the circle.
     /// </remarks>
-    public CollisionPoints? IntersectShape(Circle c)
+    public IntersectionPoints? IntersectShape(Circle c)
     {
         var result = IntersectSegmentCircle(Start, End, c.Center, c.Radius);
 
         if (result.a.Valid && result.b.Valid)
         {
-            var points = new CollisionPoints
+            var points = new IntersectionPoints
             {
                 result.a,
                 result.b
@@ -131,13 +131,13 @@ public readonly partial struct Segment
 
         if (result.a.Valid)
         {
-            var points = new CollisionPoints { result.a };
+            var points = new IntersectionPoints { result.a };
             return points;
         }
 
         if (result.b.Valid)
         {
-            var points = new CollisionPoints { result.b };
+            var points = new IntersectionPoints { result.b };
             return points;
         }
 
@@ -148,13 +148,13 @@ public readonly partial struct Segment
     /// Computes all intersection points between this segment and a triangle.
     /// </summary>
     /// <param name="t">The triangle to test against.</param>
-    /// <returns>A <see cref="CollisionPoints"/> collection containing intersection points, or null if there are no intersections.</returns>
+    /// <returns>A <see cref="IntersectionPoints"/> collection containing intersection points, or null if there are no intersections.</returns>
     /// <remarks>
     /// May return up to two intersection points, as a segment can intersect a triangle at most twice.
     /// </remarks>
-    public CollisionPoints? IntersectShape(Triangle t)
+    public IntersectionPoints? IntersectShape(Triangle t)
     {
-        CollisionPoints? points = null;
+        IntersectionPoints? points = null;
         var cp = IntersectSegmentSegment(Start, End, t.A, t.B);
         if (cp.Valid)
         {
@@ -186,13 +186,13 @@ public readonly partial struct Segment
     /// Computes all intersection points between this segment and a quadrilateral.
     /// </summary>
     /// <param name="q">The quadrilateral to test against.</param>
-    /// <returns>A <see cref="CollisionPoints"/> collection containing intersection points, or null if there are no intersections.</returns>
+    /// <returns>A <see cref="IntersectionPoints"/> collection containing intersection points, or null if there are no intersections.</returns>
     /// <remarks>
     /// May return up to two intersection points, as a segment can intersect a quad at most twice.
     /// </remarks>
-    public CollisionPoints? IntersectShape(Quad q)
+    public IntersectionPoints? IntersectShape(Quad q)
     {
-        CollisionPoints? points = null;
+        IntersectionPoints? points = null;
         var cp = IntersectSegmentSegment(Start, End, q.A, q.B);
         if (cp.Valid)
         {
@@ -234,13 +234,13 @@ public readonly partial struct Segment
     /// Computes all intersection points between this segment and a rectangle.
     /// </summary>
     /// <param name="r">The rectangle to test against.</param>
-    /// <returns>A <see cref="CollisionPoints"/> collection containing intersection points, or null if there are no intersections.</returns>
+    /// <returns>A <see cref="IntersectionPoints"/> collection containing intersection points, or null if there are no intersections.</returns>
     /// <remarks>
     /// May return up to two intersection points, as a segment can intersect a rectangle at most twice.
     /// </remarks>
-    public CollisionPoints? IntersectShape(Rect r)
+    public IntersectionPoints? IntersectShape(Rect r)
     {
-        CollisionPoints? points = null;
+        IntersectionPoints? points = null;
         var a = r.TopLeft;
         var b = r.BottomLeft;
 
@@ -287,14 +287,14 @@ public readonly partial struct Segment
     /// Computes all intersection points between this segment and a polygon.
     /// </summary>
     /// <param name="p">The polygon to test against. Must have at least 3 vertices.</param>
-    /// <returns>A <see cref="CollisionPoints"/> collection containing intersection points, or null if there are no intersections.</returns>
+    /// <returns>A <see cref="IntersectionPoints"/> collection containing intersection points, or null if there are no intersections.</returns>
     /// <remarks>
     /// Iterates over all polygon edges and collects intersection points with the segment.
     /// </remarks>
-    public CollisionPoints? IntersectShape(Polygon p)
+    public IntersectionPoints? IntersectShape(Polygon p)
     {
         if (p.Count < 3) return null;
-        CollisionPoints? points = null;
+        IntersectionPoints? points = null;
         for (var i = 0; i < p.Count; i++)
         {
             var colPoint = IntersectSegmentSegment(Start, End, p[i], p[(i + 1) % p.Count]);
@@ -312,14 +312,14 @@ public readonly partial struct Segment
     /// Computes all intersection points between this segment and a polyline.
     /// </summary>
     /// <param name="pl">The polyline to test against. Must have at least 2 vertices.</param>
-    /// <returns>A <see cref="CollisionPoints"/> collection containing intersection points, or null if there are no intersections.</returns>
+    /// <returns>A <see cref="IntersectionPoints"/> collection containing intersection points, or null if there are no intersections.</returns>
     /// <remarks>
     /// Iterates over all polyline segments and collects intersection points with the segment.
     /// </remarks>
-    public CollisionPoints? IntersectShape(Polyline pl)
+    public IntersectionPoints? IntersectShape(Polyline pl)
     {
         if (pl.Count < 2) return null;
-        CollisionPoints? points = null;
+        IntersectionPoints? points = null;
         for (var i = 0; i < pl.Count - 1; i++)
         {
             var colPoint = IntersectSegmentSegment(Start, End, pl[i], pl[i + 1]);
@@ -337,14 +337,14 @@ public readonly partial struct Segment
     /// Computes all intersection points between this segment and a set of segments.
     /// </summary>
     /// <param name="shape">The set of segments to test against.</param>
-    /// <returns>A <see cref="CollisionPoints"/> collection containing intersection points, or null if there are no intersections.</returns>
+    /// <returns>A <see cref="IntersectionPoints"/> collection containing intersection points, or null if there are no intersections.</returns>
     /// <remarks>
     /// Iterates over all segments in the set and collects intersection points with the segment.
     /// </remarks>
-    public CollisionPoints? IntersectShape(Segments shape)
+    public IntersectionPoints? IntersectShape(Segments shape)
     {
         if (shape.Count <= 0) return null;
-        CollisionPoints? points = null;
+        IntersectionPoints? points = null;
 
         foreach (var seg in shape)
         {
@@ -363,13 +363,13 @@ public readonly partial struct Segment
     /// Computes all intersection points between this segment and a collider shape, storing results in a provided collection.
     /// </summary>
     /// <param name="collider">The collider whose shape will be tested for intersection. Must be enabled.</param>
-    /// <param name="points">A reference to a <see cref="CollisionPoints"/> collection to store intersection points.</param>
+    /// <param name="points">A reference to a <see cref="IntersectionPoints"/> collection to store intersection points.</param>
     /// <param name="returnAfterFirstValid">If true, the method returns after the first valid intersection is found.</param>
     /// <returns>The number of intersection points found.</returns>
     /// <remarks>
     /// The method dispatches to the appropriate shape-specific intersection method based on the collider's shape type.
     /// </remarks>
-    public int Intersect(Collider collider, ref CollisionPoints points, bool returnAfterFirstValid = false)
+    public int Intersect(Collider collider, ref IntersectionPoints points, bool returnAfterFirstValid = false)
     {
         if (!collider.Enabled) return 0;
 
@@ -411,12 +411,12 @@ public readonly partial struct Segment
     /// Computes all intersection points between this segment and a ray, storing results in a provided collection.
     /// </summary>
     /// <param name="r">The ray to test against.</param>
-    /// <param name="points">A reference to a <see cref="CollisionPoints"/> collection to store intersection points.</param>
+    /// <param name="points">A reference to a <see cref="IntersectionPoints"/> collection to store intersection points.</param>
     /// <returns>The number of intersection points found (0 or 1).</returns>
     /// <remarks>
     /// Returns 1 if the segment and ray intersect, otherwise 0.
     /// </remarks>
-    public int IntersectShape(Ray r, ref CollisionPoints points)
+    public int IntersectShape(Ray r, ref IntersectionPoints points)
     {
         var cp = IntersectSegmentRay(Start, End, r.Point, r.Direction, r.Normal);
         if (cp.Valid)
@@ -432,12 +432,12 @@ public readonly partial struct Segment
     /// Computes all intersection points between this segment and a line, storing results in a provided collection.
     /// </summary>
     /// <param name="l">The line to test against.</param>
-    /// <param name="points">A reference to a <see cref="CollisionPoints"/> collection to store intersection points.</param>
+    /// <param name="points">A reference to a <see cref="IntersectionPoints"/> collection to store intersection points.</param>
     /// <returns>The number of intersection points found (0 or 1).</returns>
     /// <remarks>
     /// Returns 1 if the segment and line intersect, otherwise 0.
     /// </remarks>
-    public int IntersectShape(Line l, ref CollisionPoints points)
+    public int IntersectShape(Line l, ref IntersectionPoints points)
     {
         var cp = IntersectSegmentLine(Start, End, l.Point, l.Direction, l.Normal);
         if (cp.Valid)
@@ -453,12 +453,12 @@ public readonly partial struct Segment
     /// Computes all intersection points between this segment and another segment, storing results in a provided collection.
     /// </summary>
     /// <param name="s">The segment to test against.</param>
-    /// <param name="points">A reference to a <see cref="CollisionPoints"/> collection to store intersection points.</param>
+    /// <param name="points">A reference to a <see cref="IntersectionPoints"/> collection to store intersection points.</param>
     /// <returns>The number of intersection points found (0 or 1).</returns>
     /// <remarks>
     /// Returns 1 if the segments intersect, otherwise 0.
     /// </remarks>
-    public int IntersectShape(Segment s, ref CollisionPoints points)
+    public int IntersectShape(Segment s, ref IntersectionPoints points)
     {
         var cp = IntersectSegmentSegment(Start, End, s.Start, s.End);
         if (cp.Valid)
@@ -474,13 +474,13 @@ public readonly partial struct Segment
     /// Computes all intersection points between this segment and a circle, storing results in a provided collection.
     /// </summary>
     /// <param name="c">The circle to test against.</param>
-    /// <param name="points">A reference to a <see cref="CollisionPoints"/> collection to store intersection points.</param>
+    /// <param name="points">A reference to a <see cref="IntersectionPoints"/> collection to store intersection points.</param>
     /// <param name="returnAfterFirstValid">If true, the method returns after the first valid intersection is found.</param>
     /// <returns>The number of intersection points found (0, 1, or 2).</returns>
     /// <remarks>
     /// May return up to two intersection points depending on the segment's position relative to the circle.
     /// </remarks>
-    public int IntersectShape(Circle c, ref CollisionPoints points, bool returnAfterFirstValid = false)
+    public int IntersectShape(Circle c, ref IntersectionPoints points, bool returnAfterFirstValid = false)
     {
         var result = IntersectSegmentCircle(Start, End, c.Center, c.Radius);
 
@@ -516,13 +516,13 @@ public readonly partial struct Segment
     /// Computes all intersection points between this segment and a triangle, storing results in a provided collection.
     /// </summary>
     /// <param name="t">The triangle to test against.</param>
-    /// <param name="points">A reference to a <see cref="CollisionPoints"/> collection to store intersection points.</param>
+    /// <param name="points">A reference to a <see cref="IntersectionPoints"/> collection to store intersection points.</param>
     /// <param name="returnAfterFirstValid">If true, the method returns after the first valid intersection is found.</param>
     /// <returns>The number of intersection points found (0, 1, or 2).</returns>
     /// <remarks>
     /// May return up to two intersection points, as a segment can intersect a triangle at most twice.
     /// </remarks>
-    public int IntersectShape(Triangle t, ref CollisionPoints points, bool returnAfterFirstValid = false)
+    public int IntersectShape(Triangle t, ref IntersectionPoints points, bool returnAfterFirstValid = false)
     {
         var cp = IntersectSegmentSegment(Start, End, t.A, t.B);
         var count = 0;
@@ -558,13 +558,13 @@ public readonly partial struct Segment
     /// Computes all intersection points between this segment and a quadrilateral, storing results in a provided collection.
     /// </summary>
     /// <param name="q">The quadrilateral to test against.</param>
-    /// <param name="points">A reference to a <see cref="CollisionPoints"/> collection to store intersection points.</param>
+    /// <param name="points">A reference to a <see cref="IntersectionPoints"/> collection to store intersection points.</param>
     /// <param name="returnAfterFirstValid">If true, the method returns after the first valid intersection is found.</param>
     /// <returns>The number of intersection points found (0, 1, or 2).</returns>
     /// <remarks>
     /// May return up to two intersection points, as a segment can intersect a quad at most twice.
     /// </remarks>
-    public int IntersectShape(Quad q, ref CollisionPoints points, bool returnAfterFirstValid = false)
+    public int IntersectShape(Quad q, ref IntersectionPoints points, bool returnAfterFirstValid = false)
     {
         var cp = IntersectSegmentSegment(Start, End, q.A, q.B);
         var count = 0;
@@ -611,13 +611,13 @@ public readonly partial struct Segment
     /// Computes all intersection points between this segment and a rectangle, storing results in a provided collection.
     /// </summary>
     /// <param name="r">The rectangle to test against.</param>
-    /// <param name="points">A reference to a <see cref="CollisionPoints"/> collection to store intersection points.</param>
+    /// <param name="points">A reference to a <see cref="IntersectionPoints"/> collection to store intersection points.</param>
     /// <param name="returnAfterFirstValid">If true, the method returns after the first valid intersection is found.</param>
     /// <returns>The number of intersection points found (0, 1, or 2).</returns>
     /// <remarks>
     /// May return up to two intersection points, as a segment can intersect a rectangle at most twice.
     /// </remarks>
-    public int IntersectShape(Rect r, ref CollisionPoints points, bool returnAfterFirstValid = false)
+    public int IntersectShape(Rect r, ref IntersectionPoints points, bool returnAfterFirstValid = false)
     {
         var a = r.TopLeft;
         var b = r.BottomLeft;
@@ -669,13 +669,13 @@ public readonly partial struct Segment
     /// Computes all intersection points between this segment and a polygon, storing results in a provided collection.
     /// </summary>
     /// <param name="p">The polygon to test against. Must have at least 3 vertices.</param>
-    /// <param name="points">A reference to a <see cref="CollisionPoints"/> collection to store intersection points.</param>
+    /// <param name="points">A reference to a <see cref="IntersectionPoints"/> collection to store intersection points.</param>
     /// <param name="returnAfterFirstValid">If true, the method returns after the first valid intersection is found.</param>
     /// <returns>The number of intersection points found.</returns>
     /// <remarks>
     /// Iterates over all polygon edges and collects intersection points with the segment.
     /// </remarks>
-    public int IntersectShape(Polygon p, ref CollisionPoints points, bool returnAfterFirstValid = false)
+    public int IntersectShape(Polygon p, ref IntersectionPoints points, bool returnAfterFirstValid = false)
     {
         if (p.Count < 3) return 0;
         var count = 0;
@@ -697,13 +697,13 @@ public readonly partial struct Segment
     /// Computes all intersection points between this segment and a polyline, storing results in a provided collection.
     /// </summary>
     /// <param name="pl">The polyline to test against. Must have at least 2 vertices.</param>
-    /// <param name="points">A reference to a <see cref="CollisionPoints"/> collection to store intersection points.</param>
+    /// <param name="points">A reference to a <see cref="IntersectionPoints"/> collection to store intersection points.</param>
     /// <param name="returnAfterFirstValid">If true, the method returns after the first valid intersection is found.</param>
     /// <returns>The number of intersection points found.</returns>
     /// <remarks>
     /// Iterates over all polyline segments and collects intersection points with the segment.
     /// </remarks>
-    public int IntersectShape(Polyline pl, ref CollisionPoints points, bool returnAfterFirstValid = false)
+    public int IntersectShape(Polyline pl, ref IntersectionPoints points, bool returnAfterFirstValid = false)
     {
         if (pl.Count < 2) return 0;
         var count = 0;
@@ -725,13 +725,13 @@ public readonly partial struct Segment
     /// Computes all intersection points between this segment and a set of segments, storing results in a provided collection.
     /// </summary>
     /// <param name="shape">The set of segments to test against.</param>
-    /// <param name="points">A reference to a <see cref="CollisionPoints"/> collection to store intersection points.</param>
+    /// <param name="points">A reference to a <see cref="IntersectionPoints"/> collection to store intersection points.</param>
     /// <param name="returnAfterFirstValid">If true, the method returns after the first valid intersection is found.</param>
     /// <returns>The number of intersection points found.</returns>
     /// <remarks>
     /// Iterates over all segments in the set and collects intersection points with the segment.
     /// </remarks>
-    public int IntersectShape(Segments shape, ref CollisionPoints points, bool returnAfterFirstValid = false)
+    public int IntersectShape(Segments shape, ref IntersectionPoints points, bool returnAfterFirstValid = false)
     {
         if (shape.Count <= 0) return 0;
         var count = 0;

--- a/ShapeEngine/Geometry/SegmentDef/SegmentIntersection.cs
+++ b/ShapeEngine/Geometry/SegmentDef/SegmentIntersection.cs
@@ -19,29 +19,29 @@ public readonly partial struct Segment
     /// </summary>
     /// <param name="linePos">A point on the line.</param>
     /// <param name="lineDir">The direction vector of the line.</param>
-    /// <returns>A <see cref="CollisionPoint"/> representing the intersection, or an invalid point if there is no intersection.</returns>
-    public CollisionPoint IntersectLine(Vector2 linePos, Vector2 lineDir) => IntersectSegmentLine(Start, End, linePos, lineDir);
+    /// <returns>A <see cref="IntersectionPoint"/> representing the intersection, or an invalid point if there is no intersection.</returns>
+    public IntersectionPoint IntersectLine(Vector2 linePos, Vector2 lineDir) => IntersectSegmentLine(Start, End, linePos, lineDir);
     /// <summary>
     /// Computes the intersection point between this segment and a ray.
     /// </summary>
     /// <param name="rayPos">The origin of the ray.</param>
     /// <param name="rayDir">The direction vector of the ray.</param>
-    /// <returns>A <see cref="CollisionPoint"/> representing the intersection, or an invalid point if there is no intersection.</returns>
-    public CollisionPoint IntersectRay(Vector2 rayPos, Vector2 rayDir) => IntersectSegmentRay(Start, End, rayPos, rayDir);
+    /// <returns>A <see cref="IntersectionPoint"/> representing the intersection, or an invalid point if there is no intersection.</returns>
+    public IntersectionPoint IntersectRay(Vector2 rayPos, Vector2 rayDir) => IntersectSegmentRay(Start, End, rayPos, rayDir);
     /// <summary>
     /// Computes the intersection point between this segment and another segment.
     /// </summary>
     /// <param name="segStart">The start point of the other segment.</param>
     /// <param name="segEnd">The end point of the other segment.</param>
-    /// <returns>A <see cref="CollisionPoint"/> representing the intersection, or an invalid point if there is no intersection.</returns>
-    public CollisionPoint IntersectSegment(Vector2 segStart, Vector2 segEnd) => IntersectSegmentSegment(Start, End, segStart, segEnd);
+    /// <returns>A <see cref="IntersectionPoint"/> representing the intersection, or an invalid point if there is no intersection.</returns>
+    public IntersectionPoint IntersectSegment(Vector2 segStart, Vector2 segEnd) => IntersectSegmentSegment(Start, End, segStart, segEnd);
     /// <summary>
     /// Computes the intersection points between this segment and a circle.
     /// </summary>
     /// <param name="circlePos">The center of the circle.</param>
     /// <param name="circleRadius">The radius of the circle.</param>
-    /// <returns>A tuple of <see cref="CollisionPoint"/> representing the intersection points (a, b). If there is no intersection, both are invalid.</returns>
-    public (CollisionPoint a, CollisionPoint b) IntersectCircle(Vector2 circlePos, float circleRadius) =>
+    /// <returns>A tuple of <see cref="IntersectionPoint"/> representing the intersection points (a, b). If there is no intersection, both are invalid.</returns>
+    public (IntersectionPoint a, IntersectionPoint b) IntersectCircle(Vector2 circlePos, float circleRadius) =>
         IntersectSegmentCircle(Start, End, circlePos, circleRadius);
     /// <summary>
     /// Computes the intersection points between this segment and a triangle.
@@ -49,8 +49,8 @@ public readonly partial struct Segment
     /// <param name="a">First vertex of the triangle.</param>
     /// <param name="b">Second vertex of the triangle.</param>
     /// <param name="c">Third vertex of the triangle.</param>
-    /// <returns>A tuple of <see cref="CollisionPoint"/> representing the intersection points (a, b).</returns>
-    public (CollisionPoint a, CollisionPoint b) IntersectTriangle(Vector2 a, Vector2 b, Vector2 c) => IntersectSegmentTriangle(Start, End, a, b, c);
+    /// <returns>A tuple of <see cref="IntersectionPoint"/> representing the intersection points (a, b).</returns>
+    public (IntersectionPoint a, IntersectionPoint b) IntersectTriangle(Vector2 a, Vector2 b, Vector2 c) => IntersectSegmentTriangle(Start, End, a, b, c);
     /// <summary>
     /// Computes the intersection points between this segment and a quadrilateral.
     /// </summary>
@@ -58,8 +58,8 @@ public readonly partial struct Segment
     /// <param name="b">Second vertex of the quad.</param>
     /// <param name="c">Third vertex of the quad.</param>
     /// <param name="d">Fourth vertex of the quad.</param>
-    /// <returns>A tuple of <see cref="CollisionPoint"/> representing the intersection points (a, b).</returns>
-    public (CollisionPoint a, CollisionPoint b) IntersectQuad(Vector2 a, Vector2 b, Vector2 c, Vector2 d) => IntersectSegmentQuad(Start, End, a, b, c, d);
+    /// <returns>A tuple of <see cref="IntersectionPoint"/> representing the intersection points (a, b).</returns>
+    public (IntersectionPoint a, IntersectionPoint b) IntersectQuad(Vector2 a, Vector2 b, Vector2 c, Vector2 d) => IntersectSegmentQuad(Start, End, a, b, c, d);
     /// <summary>
     /// Computes the intersection points between this segment and a rectangle.
     /// </summary>
@@ -67,98 +67,98 @@ public readonly partial struct Segment
     /// <param name="b">Second vertex of the rectangle.</param>
     /// <param name="c">Third vertex of the rectangle.</param>
     /// <param name="d">Fourth vertex of the rectangle.</param>
-    /// <returns>A tuple of <see cref="CollisionPoint"/> representing the intersection points (a, b).</returns>
-    public (CollisionPoint a, CollisionPoint b) IntersectRect(Vector2 a, Vector2 b, Vector2 c, Vector2 d) => IntersectSegmentQuad(Start, End, a, b, c, d);
+    /// <returns>A tuple of <see cref="IntersectionPoint"/> representing the intersection points (a, b).</returns>
+    public (IntersectionPoint a, IntersectionPoint b) IntersectRect(Vector2 a, Vector2 b, Vector2 c, Vector2 d) => IntersectSegmentQuad(Start, End, a, b, c, d);
     /// <summary>
     /// Computes all intersection points between this segment and a polygon.
     /// </summary>
     /// <param name="points">The list of polygon vertices.</param>
     /// <param name="maxCollisionPoints">The maximum number of collision points to return. -1 for unlimited.</param>
-    /// <returns>A <see cref="CollisionPoints"/> collection, or null if there are no intersections.</returns>
-    public CollisionPoints? IntersectPolygon(List<Vector2> points, int maxCollisionPoints = -1) =>
+    /// <returns>A <see cref="IntersectionPoints"/> collection, or null if there are no intersections.</returns>
+    public IntersectionPoints? IntersectPolygon(List<Vector2> points, int maxCollisionPoints = -1) =>
         IntersectSegmentPolygon(Start, End, points, maxCollisionPoints);
     /// <summary>
     /// Computes all intersection points between this segment and a polyline.
     /// </summary>
     /// <param name="points">The list of polyline vertices.</param>
     /// <param name="maxCollisionPoints">The maximum number of collision points to return. -1 for unlimited.</param>
-    /// <returns>A <see cref="CollisionPoints"/> collection, or null if there are no intersections.</returns>
-    public CollisionPoints? IntersectPolyline(List<Vector2> points, int maxCollisionPoints = -1) =>
+    /// <returns>A <see cref="IntersectionPoints"/> collection, or null if there are no intersections.</returns>
+    public IntersectionPoints? IntersectPolyline(List<Vector2> points, int maxCollisionPoints = -1) =>
         IntersectSegmentPolyline(Start, End, points, maxCollisionPoints);
     /// <summary>
     /// Computes all intersection points between this segment and a list of segments.
     /// </summary>
     /// <param name="segments">The list of segments to test against.</param>
     /// <param name="maxCollisionPoints">The maximum number of collision points to return. -1 for unlimited.</param>
-    /// <returns>A <see cref="CollisionPoints"/> collection, or null if there are no intersections.</returns>
-    public CollisionPoints? IntersectSegments(List<Segment> segments, int maxCollisionPoints = -1) =>
+    /// <returns>A <see cref="IntersectionPoints"/> collection, or null if there are no intersections.</returns>
+    public IntersectionPoints? IntersectSegments(List<Segment> segments, int maxCollisionPoints = -1) =>
         IntersectSegmentSegments(Start, End, segments, maxCollisionPoints);
     /// <summary>
     /// Computes the intersection point between this segment and a line.
     /// </summary>
     /// <param name="line">The line to test against.</param>
-    /// <returns>A <see cref="CollisionPoint"/> representing the intersection, or an invalid point if there is no intersection.</returns>
-    public CollisionPoint IntersectLine(Line line) => IntersectSegmentLine(Start, End, line.Point, line.Direction);
+    /// <returns>A <see cref="IntersectionPoint"/> representing the intersection, or an invalid point if there is no intersection.</returns>
+    public IntersectionPoint IntersectLine(Line line) => IntersectSegmentLine(Start, End, line.Point, line.Direction);
     /// <summary>
     /// Computes the intersection point between this segment and a ray.
     /// </summary>
     /// <param name="ray">The ray to test against.</param>
-    /// <returns>A <see cref="CollisionPoint"/> representing the intersection, or an invalid point if there is no intersection.</returns>
-    public CollisionPoint IntersectRay(Ray ray) => IntersectSegmentRay(Start, End, ray.Point, ray.Direction);
+    /// <returns>A <see cref="IntersectionPoint"/> representing the intersection, or an invalid point if there is no intersection.</returns>
+    public IntersectionPoint IntersectRay(Ray ray) => IntersectSegmentRay(Start, End, ray.Point, ray.Direction);
     /// <summary>
     /// Computes the intersection point between this segment and another segment.
     /// </summary>
     /// <param name="segment">The segment to test against.</param>
-    /// <returns>A <see cref="CollisionPoint"/> representing the intersection, or an invalid point if there is no intersection.</returns>
-    public CollisionPoint IntersectSegment(Segment segment) => IntersectSegmentSegment(Start, End, segment.Start, segment.End);
+    /// <returns>A <see cref="IntersectionPoint"/> representing the intersection, or an invalid point if there is no intersection.</returns>
+    public IntersectionPoint IntersectSegment(Segment segment) => IntersectSegmentSegment(Start, End, segment.Start, segment.End);
     /// <summary>
     /// Computes the intersection points between this segment and a circle.
     /// </summary>
     /// <param name="circle">The circle to test against.</param>
-    /// <returns>A tuple of <see cref="CollisionPoint"/> representing the intersection points (a, b).</returns>
-    public (CollisionPoint a, CollisionPoint b) IntersectCircle(Circle circle) => IntersectSegmentCircle(Start, End, circle.Center, circle.Radius);
+    /// <returns>A tuple of <see cref="IntersectionPoint"/> representing the intersection points (a, b).</returns>
+    public (IntersectionPoint a, IntersectionPoint b) IntersectCircle(Circle circle) => IntersectSegmentCircle(Start, End, circle.Center, circle.Radius);
     /// <summary>
     /// Computes the intersection points between this segment and a triangle.
     /// </summary>
     /// <param name="triangle">The triangle to test against.</param>
-    /// <returns>A tuple of <see cref="CollisionPoint"/> representing the intersection points (a, b).</returns>
-    public (CollisionPoint a, CollisionPoint b) IntersectTriangle(Triangle triangle) =>
+    /// <returns>A tuple of <see cref="IntersectionPoint"/> representing the intersection points (a, b).</returns>
+    public (IntersectionPoint a, IntersectionPoint b) IntersectTriangle(Triangle triangle) =>
         IntersectSegmentTriangle(Start, End, triangle.A, triangle.B, triangle.C);
     /// <summary>
     /// Computes the intersection points between this segment and a quadrilateral.
     /// </summary>
     /// <param name="quad">The quadrilateral to test against.</param>
-    /// <returns>A tuple of <see cref="CollisionPoint"/> representing the intersection points (a, b).</returns>
-    public (CollisionPoint a, CollisionPoint b) IntersectQuad(Quad quad) => IntersectSegmentQuad(Start, End, quad.A, quad.B, quad.C, quad.D);
+    /// <returns>A tuple of <see cref="IntersectionPoint"/> representing the intersection points (a, b).</returns>
+    public (IntersectionPoint a, IntersectionPoint b) IntersectQuad(Quad quad) => IntersectSegmentQuad(Start, End, quad.A, quad.B, quad.C, quad.D);
     /// <summary>
     /// Computes the intersection points between this segment and a rectangle.
     /// </summary>
     /// <param name="rect">The rectangle to test against.</param>
-    /// <returns>A tuple of <see cref="CollisionPoint"/> representing the intersection points (a, b).</returns>
-    public (CollisionPoint a, CollisionPoint b) IntersectRect(Rect rect) => IntersectSegmentQuad(Start, End, rect.A, rect.B, rect.C, rect.D);
+    /// <returns>A tuple of <see cref="IntersectionPoint"/> representing the intersection points (a, b).</returns>
+    public (IntersectionPoint a, IntersectionPoint b) IntersectRect(Rect rect) => IntersectSegmentQuad(Start, End, rect.A, rect.B, rect.C, rect.D);
     /// <summary>
     /// Computes all intersection points between this segment and a polygon.
     /// </summary>
     /// <param name="polygon">The polygon to test against.</param>
     /// <param name="maxCollisionPoints">The maximum number of collision points to return. -1 for unlimited.</param>
-    /// <returns>A <see cref="CollisionPoints"/> collection, or null if there are no intersections.</returns>
-    public CollisionPoints? IntersectPolygon(Polygon polygon, int maxCollisionPoints = -1) =>
+    /// <returns>A <see cref="IntersectionPoints"/> collection, or null if there are no intersections.</returns>
+    public IntersectionPoints? IntersectPolygon(Polygon polygon, int maxCollisionPoints = -1) =>
         IntersectSegmentPolygon(Start, End, polygon, maxCollisionPoints);
     /// <summary>
     /// Computes all intersection points between this segment and a polyline.
     /// </summary>
     /// <param name="polyline">The polyline to test against.</param>
     /// <param name="maxCollisionPoints">The maximum number of collision points to return. -1 for unlimited.</param>
-    /// <returns>A <see cref="CollisionPoints"/> collection, or null if there are no intersections.</returns>
-    public CollisionPoints? IntersectPolyline(Polyline polyline, int maxCollisionPoints = -1) =>
+    /// <returns>A <see cref="IntersectionPoints"/> collection, or null if there are no intersections.</returns>
+    public IntersectionPoints? IntersectPolyline(Polyline polyline, int maxCollisionPoints = -1) =>
         IntersectSegmentPolyline(Start, End, polyline, maxCollisionPoints);
     /// <summary>
     /// Computes all intersection points between this segment and a set of segments.
     /// </summary>
     /// <param name="segments">The set of segments to test against.</param>
     /// <param name="maxCollisionPoints">The maximum number of collision points to return. -1 for unlimited.</param>
-    /// <returns>A <see cref="CollisionPoints"/> collection, or null if there are no intersections.</returns>
-    public CollisionPoints? IntersectSegments(Segments segments, int maxCollisionPoints = -1) =>
+    /// <returns>A <see cref="IntersectionPoints"/> collection, or null if there are no intersections.</returns>
+    public IntersectionPoints? IntersectSegments(Segments segments, int maxCollisionPoints = -1) =>
         IntersectSegmentSegments(Start, End, segments, maxCollisionPoints);
 
 }

--- a/ShapeEngine/Geometry/SegmentDef/SegmentIntersectionStatic.cs
+++ b/ShapeEngine/Geometry/SegmentDef/SegmentIntersectionStatic.cs
@@ -13,7 +13,7 @@ public readonly partial struct Segment
     /// <param name="segment1End">The end point of the first segment.</param>
     /// <param name="segment2Start">The start point of the second segment.</param>
     /// <param name="segment2End">The end point of the second segment.</param>
-    /// <returns>A tuple containing the <see cref="IntersectionPoint"/> and the intersection time along the first segment. If there is no intersection, the collision point is invalid and the time is -1.</returns>
+    /// <returns>A tuple containing the <see cref="IntersectionPoint"/> and the intersection time along the first segment. If there is no intersection, the intersection point is invalid and the time is -1.</returns>
     public static (IntersectionPoint point, float time) IntersectSegmentSegmentInfo(Vector2 segment1Start, Vector2 segment1End, Vector2 segment2Start,
         Vector2 segment2End)
     {
@@ -55,7 +55,7 @@ public readonly partial struct Segment
     /// <param name="segment2Start">The start point of the second segment.</param>
     /// <param name="segment2End">The end point of the second segment.</param>
     /// <param name="segment2Normal">The normal vector to use for the second segment.</param>
-    /// <returns>A tuple containing the <see cref="IntersectionPoint"/> and the intersection time along the first segment. If there is no intersection, the collision point is invalid and the time is -1.</returns>
+    /// <returns>A tuple containing the <see cref="IntersectionPoint"/> and the intersection time along the first segment. If there is no intersection, the intersection point is invalid and the time is -1.</returns>
     public static (IntersectionPoint point, float time) IntersectSegmentSegmentInfo(Vector2 segment1Start, Vector2 segment1End, Vector2 segment2Start,
         Vector2 segment2End, Vector2 segment2Normal)
     {
@@ -93,7 +93,7 @@ public readonly partial struct Segment
     /// <param name="segmentEnd">The end point of the segment.</param>
     /// <param name="linePoint">A point on the line.</param>
     /// <param name="lineDirection">The direction vector of the line.</param>
-    /// <returns>A tuple containing the <see cref="IntersectionPoint"/> and the intersection time along the segment. If there is no intersection, the collision point is invalid and the time is -1.</returns>
+    /// <returns>A tuple containing the <see cref="IntersectionPoint"/> and the intersection time along the segment. If there is no intersection, the intersection point is invalid and the time is -1.</returns>
     public static (IntersectionPoint point, float time) IntersectSegmentLineInfo(Vector2 segmentStart, Vector2 segmentEnd, Vector2 linePoint,
         Vector2 lineDirection)
     {
@@ -125,7 +125,7 @@ public readonly partial struct Segment
     /// <param name="segmentEnd">The end point of the segment.</param>
     /// <param name="rayPoint">The origin of the ray.</param>
     /// <param name="rayDirection">The direction vector of the ray.</param>
-    /// <returns>A tuple containing the <see cref="IntersectionPoint"/> and the intersection time along the segment. If there is no intersection, the collision point is invalid and the time is -1.</returns>
+    /// <returns>A tuple containing the <see cref="IntersectionPoint"/> and the intersection time along the segment. If there is no intersection, the intersection point is invalid and the time is -1.</returns>
     public static (IntersectionPoint point, float time) IntersectSegmentRayInfo(Vector2 segmentStart, Vector2 segmentEnd, Vector2 rayPoint, Vector2 rayDirection)
     {
         float denominator = (segmentEnd.X - segmentStart.X) * rayDirection.Y - (segmentEnd.Y - segmentStart.Y) * rayDirection.X;
@@ -158,7 +158,7 @@ public readonly partial struct Segment
     /// <param name="linePoint">A point on the line.</param>
     /// <param name="lineDirection">The direction vector of the line.</param>
     /// <param name="lineNormal">The normal vector to use for the line.</param>
-    /// <returns>A tuple containing the <see cref="IntersectionPoint"/> and the intersection time along the segment. If there is no intersection, the collision point is invalid and the time is -1.</returns>
+    /// <returns>A tuple containing the <see cref="IntersectionPoint"/> and the intersection time along the segment. If there is no intersection, the intersection point is invalid and the time is -1.</returns>
     public static (IntersectionPoint point, float time) IntersectSegmentLineInfo(Vector2 segmentStart, Vector2 segmentEnd, Vector2 linePoint,
         Vector2 lineDirection, Vector2 lineNormal)
     {
@@ -190,7 +190,7 @@ public readonly partial struct Segment
     /// <param name="rayPoint">The origin of the ray.</param>
     /// <param name="rayDirection">The direction vector of the ray.</param>
     /// <param name="rayNormal">The normal vector to use for the ray.</param>
-    /// <returns>A tuple containing the <see cref="IntersectionPoint"/> and the intersection time along the segment. If there is no intersection, the collision point is invalid and the time is -1.</returns>
+    /// <returns>A tuple containing the <see cref="IntersectionPoint"/> and the intersection time along the segment. If there is no intersection, the intersection point is invalid and the time is -1.</returns>
     public static (IntersectionPoint point, float time) IntersectSegmentRayInfo(Vector2 segmentStart, Vector2 segmentEnd, Vector2 rayPoint, Vector2 rayDirection,
         Vector2 rayNormal)
     {

--- a/ShapeEngine/Geometry/SegmentDef/SegmentIntersectionStatic.cs
+++ b/ShapeEngine/Geometry/SegmentDef/SegmentIntersectionStatic.cs
@@ -13,8 +13,8 @@ public readonly partial struct Segment
     /// <param name="segment1End">The end point of the first segment.</param>
     /// <param name="segment2Start">The start point of the second segment.</param>
     /// <param name="segment2End">The end point of the second segment.</param>
-    /// <returns>A tuple containing the <see cref="CollisionPoint"/> and the intersection time along the first segment. If there is no intersection, the collision point is invalid and the time is -1.</returns>
-    public static (CollisionPoint point, float time) IntersectSegmentSegmentInfo(Vector2 segment1Start, Vector2 segment1End, Vector2 segment2Start,
+    /// <returns>A tuple containing the <see cref="IntersectionPoint"/> and the intersection time along the first segment. If there is no intersection, the collision point is invalid and the time is -1.</returns>
+    public static (IntersectionPoint point, float time) IntersectSegmentSegmentInfo(Vector2 segment1Start, Vector2 segment1End, Vector2 segment2Start,
         Vector2 segment2End)
     {
         // Calculate the direction vectors of the segments
@@ -41,7 +41,7 @@ public readonly partial struct Segment
             // Calculate the normal vector as perpendicular to the direction of the first segment
             var normal = new Vector2(-dir1.Y, dir1.X).Normalize();
 
-            return (new CollisionPoint(intersection, normal), t);
+            return (new IntersectionPoint(intersection, normal), t);
         }
 
         return (new(), -1);
@@ -55,8 +55,8 @@ public readonly partial struct Segment
     /// <param name="segment2Start">The start point of the second segment.</param>
     /// <param name="segment2End">The end point of the second segment.</param>
     /// <param name="segment2Normal">The normal vector to use for the second segment.</param>
-    /// <returns>A tuple containing the <see cref="CollisionPoint"/> and the intersection time along the first segment. If there is no intersection, the collision point is invalid and the time is -1.</returns>
-    public static (CollisionPoint point, float time) IntersectSegmentSegmentInfo(Vector2 segment1Start, Vector2 segment1End, Vector2 segment2Start,
+    /// <returns>A tuple containing the <see cref="IntersectionPoint"/> and the intersection time along the first segment. If there is no intersection, the collision point is invalid and the time is -1.</returns>
+    public static (IntersectionPoint point, float time) IntersectSegmentSegmentInfo(Vector2 segment1Start, Vector2 segment1End, Vector2 segment2Start,
         Vector2 segment2End, Vector2 segment2Normal)
     {
         // Calculate the direction vectors of the segments
@@ -80,7 +80,7 @@ public readonly partial struct Segment
         {
             var intersection = segment1Start + t * dir1;
 
-            return (new CollisionPoint(intersection, segment2Normal), t);
+            return (new IntersectionPoint(intersection, segment2Normal), t);
         }
 
         return (new(), -1);
@@ -93,8 +93,8 @@ public readonly partial struct Segment
     /// <param name="segmentEnd">The end point of the segment.</param>
     /// <param name="linePoint">A point on the line.</param>
     /// <param name="lineDirection">The direction vector of the line.</param>
-    /// <returns>A tuple containing the <see cref="CollisionPoint"/> and the intersection time along the segment. If there is no intersection, the collision point is invalid and the time is -1.</returns>
-    public static (CollisionPoint point, float time) IntersectSegmentLineInfo(Vector2 segmentStart, Vector2 segmentEnd, Vector2 linePoint,
+    /// <returns>A tuple containing the <see cref="IntersectionPoint"/> and the intersection time along the segment. If there is no intersection, the collision point is invalid and the time is -1.</returns>
+    public static (IntersectionPoint point, float time) IntersectSegmentLineInfo(Vector2 segmentStart, Vector2 segmentEnd, Vector2 linePoint,
         Vector2 lineDirection)
     {
         float denominator = (segmentEnd.X - segmentStart.X) * lineDirection.Y - (segmentEnd.Y - segmentStart.Y) * lineDirection.X;
@@ -125,8 +125,8 @@ public readonly partial struct Segment
     /// <param name="segmentEnd">The end point of the segment.</param>
     /// <param name="rayPoint">The origin of the ray.</param>
     /// <param name="rayDirection">The direction vector of the ray.</param>
-    /// <returns>A tuple containing the <see cref="CollisionPoint"/> and the intersection time along the segment. If there is no intersection, the collision point is invalid and the time is -1.</returns>
-    public static (CollisionPoint point, float time) IntersectSegmentRayInfo(Vector2 segmentStart, Vector2 segmentEnd, Vector2 rayPoint, Vector2 rayDirection)
+    /// <returns>A tuple containing the <see cref="IntersectionPoint"/> and the intersection time along the segment. If there is no intersection, the collision point is invalid and the time is -1.</returns>
+    public static (IntersectionPoint point, float time) IntersectSegmentRayInfo(Vector2 segmentStart, Vector2 segmentEnd, Vector2 rayPoint, Vector2 rayDirection)
     {
         float denominator = (segmentEnd.X - segmentStart.X) * rayDirection.Y - (segmentEnd.Y - segmentStart.Y) * rayDirection.X;
 
@@ -158,8 +158,8 @@ public readonly partial struct Segment
     /// <param name="linePoint">A point on the line.</param>
     /// <param name="lineDirection">The direction vector of the line.</param>
     /// <param name="lineNormal">The normal vector to use for the line.</param>
-    /// <returns>A tuple containing the <see cref="CollisionPoint"/> and the intersection time along the segment. If there is no intersection, the collision point is invalid and the time is -1.</returns>
-    public static (CollisionPoint point, float time) IntersectSegmentLineInfo(Vector2 segmentStart, Vector2 segmentEnd, Vector2 linePoint,
+    /// <returns>A tuple containing the <see cref="IntersectionPoint"/> and the intersection time along the segment. If there is no intersection, the collision point is invalid and the time is -1.</returns>
+    public static (IntersectionPoint point, float time) IntersectSegmentLineInfo(Vector2 segmentStart, Vector2 segmentEnd, Vector2 linePoint,
         Vector2 lineDirection, Vector2 lineNormal)
     {
         float denominator = (segmentEnd.X - segmentStart.X) * lineDirection.Y - (segmentEnd.Y - segmentStart.Y) * lineDirection.X;
@@ -190,8 +190,8 @@ public readonly partial struct Segment
     /// <param name="rayPoint">The origin of the ray.</param>
     /// <param name="rayDirection">The direction vector of the ray.</param>
     /// <param name="rayNormal">The normal vector to use for the ray.</param>
-    /// <returns>A tuple containing the <see cref="CollisionPoint"/> and the intersection time along the segment. If there is no intersection, the collision point is invalid and the time is -1.</returns>
-    public static (CollisionPoint point, float time) IntersectSegmentRayInfo(Vector2 segmentStart, Vector2 segmentEnd, Vector2 rayPoint, Vector2 rayDirection,
+    /// <returns>A tuple containing the <see cref="IntersectionPoint"/> and the intersection time along the segment. If there is no intersection, the collision point is invalid and the time is -1.</returns>
+    public static (IntersectionPoint point, float time) IntersectSegmentRayInfo(Vector2 segmentStart, Vector2 segmentEnd, Vector2 rayPoint, Vector2 rayDirection,
         Vector2 rayNormal)
     {
         float denominator = (segmentEnd.X - segmentStart.X) * rayDirection.Y - (segmentEnd.Y - segmentStart.Y) * rayDirection.X;
@@ -220,8 +220,8 @@ public readonly partial struct Segment
     /// <param name="segmentEnd">The end point of the segment.</param>
     /// <param name="linePoint">A point on the line.</param>
     /// <param name="lineDirection">The direction vector of the line.</param>
-    /// <returns>A <see cref="CollisionPoint"/> representing the intersection, or an invalid point if there is no intersection.</returns>
-    public static CollisionPoint IntersectSegmentLine(Vector2 segmentStart, Vector2 segmentEnd, Vector2 linePoint, Vector2 lineDirection)
+    /// <returns>A <see cref="IntersectionPoint"/> representing the intersection, or an invalid point if there is no intersection.</returns>
+    public static IntersectionPoint IntersectSegmentLine(Vector2 segmentStart, Vector2 segmentEnd, Vector2 linePoint, Vector2 lineDirection)
     {
         var result = IntersectSegmentRay(segmentStart, segmentEnd, linePoint, lineDirection);
         if (result.Valid) return result;
@@ -283,8 +283,8 @@ public readonly partial struct Segment
     /// <param name="segmentEnd">The end point of the segment.</param>
     /// <param name="rayPoint">The origin of the ray.</param>
     /// <param name="rayDirection">The direction vector of the ray.</param>
-    /// <returns>A <see cref="CollisionPoint"/> representing the intersection, or an invalid point if there is no intersection.</returns>
-    public static CollisionPoint IntersectSegmentRay(Vector2 segmentStart, Vector2 segmentEnd, Vector2 rayPoint, Vector2 rayDirection)
+    /// <returns>A <see cref="IntersectionPoint"/> representing the intersection, or an invalid point if there is no intersection.</returns>
+    public static IntersectionPoint IntersectSegmentRay(Vector2 segmentStart, Vector2 segmentEnd, Vector2 rayPoint, Vector2 rayDirection)
     {
         float denominator = rayDirection.X * (segmentEnd.Y - segmentStart.Y) - rayDirection.Y * (segmentEnd.X - segmentStart.X);
 
@@ -314,8 +314,8 @@ public readonly partial struct Segment
     /// <param name="segment1End">The end point of the first segment.</param>
     /// <param name="segment2Start">The start point of the second segment.</param>
     /// <param name="segment2End">The end point of the second segment.</param>
-    /// <returns>A <see cref="CollisionPoint"/> representing the intersection, or an invalid point if there is no intersection.</returns>
-    public static CollisionPoint IntersectSegmentSegment(Vector2 segment1Start, Vector2 segment1End, Vector2 segment2Start, Vector2 segment2End)
+    /// <returns>A <see cref="IntersectionPoint"/> representing the intersection, or an invalid point if there is no intersection.</returns>
+    public static IntersectionPoint IntersectSegmentSegment(Vector2 segment1Start, Vector2 segment1End, Vector2 segment2Start, Vector2 segment2End)
     {
         //OLD VERSION
         // var info = IntersectSegmentSegmentInfo(aStart, aEnd, bStart, bEnd);
@@ -348,7 +348,7 @@ public readonly partial struct Segment
             // Calculate the normal vector as perpendicular to the direction of the first segment
             var normal = new Vector2(-dir2.Y, dir2.X).Normalize();
 
-            return new CollisionPoint(intersection, normal);
+            return new IntersectionPoint(intersection, normal);
         }
 
         return new();
@@ -362,8 +362,8 @@ public readonly partial struct Segment
     /// <param name="linePoint">A point on the line.</param>
     /// <param name="lineDirection">The direction vector of the line.</param>
     /// <param name="lineNormal">The normal vector to use for the line.</param>
-    /// <returns>A <see cref="CollisionPoint"/> representing the intersection, or an invalid point if there is no intersection.</returns>
-    public static CollisionPoint IntersectSegmentLine(Vector2 segmentStart, Vector2 segmentEnd, Vector2 linePoint, Vector2 lineDirection, Vector2 lineNormal)
+    /// <returns>A <see cref="IntersectionPoint"/> representing the intersection, or an invalid point if there is no intersection.</returns>
+    public static IntersectionPoint IntersectSegmentLine(Vector2 segmentStart, Vector2 segmentEnd, Vector2 linePoint, Vector2 lineDirection, Vector2 lineNormal)
     {
         var result = IntersectSegmentLine(segmentStart, segmentEnd, linePoint, lineDirection);
         if (result.Valid)
@@ -382,8 +382,8 @@ public readonly partial struct Segment
     /// <param name="rayPoint">The origin of the ray.</param>
     /// <param name="rayDirection">The direction vector of the ray.</param>
     /// <param name="rayNormal">The normal vector to use for the ray.</param>
-    /// <returns>A <see cref="CollisionPoint"/> representing the intersection, or an invalid point if there is no intersection.</returns>
-    public static CollisionPoint IntersectSegmentRay(Vector2 segmentStart, Vector2 segmentEnd, Vector2 rayPoint, Vector2 rayDirection, Vector2 rayNormal)
+    /// <returns>A <see cref="IntersectionPoint"/> representing the intersection, or an invalid point if there is no intersection.</returns>
+    public static IntersectionPoint IntersectSegmentRay(Vector2 segmentStart, Vector2 segmentEnd, Vector2 rayPoint, Vector2 rayDirection, Vector2 rayNormal)
     {
         var result = IntersectSegmentRay(segmentStart, segmentEnd, rayPoint, rayDirection);
         if (result.Valid)
@@ -402,8 +402,8 @@ public readonly partial struct Segment
     /// <param name="segment2Start">The start point of the second segment.</param>
     /// <param name="segment2End">The end point of the second segment.</param>
     /// <param name="segment2Normal">The normal vector to use for the second segment.</param>
-    /// <returns>A <see cref="CollisionPoint"/> representing the intersection, or an invalid point if there is no intersection.</returns>
-    public static CollisionPoint IntersectSegmentSegment(Vector2 segment1Start, Vector2 segment1End, Vector2 segment2Start, Vector2 segment2End,
+    /// <returns>A <see cref="IntersectionPoint"/> representing the intersection, or an invalid point if there is no intersection.</returns>
+    public static IntersectionPoint IntersectSegmentSegment(Vector2 segment1Start, Vector2 segment1End, Vector2 segment2Start, Vector2 segment2End,
         Vector2 segment2Normal)
     {
         var result = IntersectSegmentSegment(segment1Start, segment1End, segment2Start, segment2End);
@@ -422,11 +422,11 @@ public readonly partial struct Segment
     /// <param name="segmentEnd">The end point of the segment.</param>
     /// <param name="circleCenter">The center of the circle.</param>
     /// <param name="radius">The radius of the circle.</param>
-    /// <returns>A tuple of <see cref="CollisionPoint"/> representing the intersection points (a, b).</returns>
-    public static (CollisionPoint a, CollisionPoint b) IntersectSegmentCircle(Vector2 segmentStart, Vector2 segmentEnd, Vector2 circleCenter, float radius)
+    /// <returns>A tuple of <see cref="IntersectionPoint"/> representing the intersection points (a, b).</returns>
+    public static (IntersectionPoint a, IntersectionPoint b) IntersectSegmentCircle(Vector2 segmentStart, Vector2 segmentEnd, Vector2 circleCenter, float radius)
     {
-        CollisionPoint a = new();
-        CollisionPoint b = new();
+        IntersectionPoint a = new();
+        IntersectionPoint b = new();
 
         // Calculate the direction vector of the segment
         var segmentDirection = segmentEnd - segmentStart;
@@ -450,14 +450,14 @@ public readonly partial struct Segment
             if (IsPointOnSegment(intersection1, segmentStart, segmentEnd))
             {
                 var normal1 = (intersection1 - circleCenter).Normalize();
-                a = new CollisionPoint(intersection1, normal1);
+                a = new IntersectionPoint(intersection1, normal1);
             }
 
             if (IsPointOnSegment(intersection2, segmentStart, segmentEnd))
             {
                 var normal2 = (intersection2 - circleCenter).Normalize();
-                if (a.Valid) b = new CollisionPoint(intersection2, normal2);
-                else a = new CollisionPoint(intersection2, normal2);
+                if (a.Valid) b = new IntersectionPoint(intersection2, normal2);
+                else a = new IntersectionPoint(intersection2, normal2);
                 // results.Add((intersection2, normal2));
             }
         }
@@ -480,11 +480,11 @@ public readonly partial struct Segment
     /// <param name="a">First vertex of the triangle.</param>
     /// <param name="b">Second vertex of the triangle.</param>
     /// <param name="c">Third vertex of the triangle.</param>
-    /// <returns>A tuple of <see cref="CollisionPoint"/> representing the intersection points (a, b).</returns>
-    public static (CollisionPoint a, CollisionPoint b) IntersectSegmentTriangle(Vector2 segmentStart, Vector2 segmentEnd, Vector2 a, Vector2 b, Vector2 c)
+    /// <returns>A tuple of <see cref="IntersectionPoint"/> representing the intersection points (a, b).</returns>
+    public static (IntersectionPoint a, IntersectionPoint b) IntersectSegmentTriangle(Vector2 segmentStart, Vector2 segmentEnd, Vector2 a, Vector2 b, Vector2 c)
     {
-        CollisionPoint resultA = new();
-        CollisionPoint resultB = new();
+        IntersectionPoint resultA = new();
+        IntersectionPoint resultB = new();
 
         var cp = IntersectSegmentSegment(segmentStart, segmentEnd, a, b);
         if (cp.Valid) resultA = cp;
@@ -517,12 +517,12 @@ public readonly partial struct Segment
     /// <param name="b">Second vertex of the quad.</param>
     /// <param name="c">Third vertex of the quad.</param>
     /// <param name="d">Fourth vertex of the quad.</param>
-    /// <returns>A tuple of <see cref="CollisionPoint"/> representing the intersection points (a, b).</returns>
-    public static (CollisionPoint a, CollisionPoint b) IntersectSegmentQuad(Vector2 segmentStart, Vector2 segmentEnd, Vector2 a, Vector2 b, Vector2 c,
+    /// <returns>A tuple of <see cref="IntersectionPoint"/> representing the intersection points (a, b).</returns>
+    public static (IntersectionPoint a, IntersectionPoint b) IntersectSegmentQuad(Vector2 segmentStart, Vector2 segmentEnd, Vector2 a, Vector2 b, Vector2 c,
         Vector2 d)
     {
-        CollisionPoint resultA = new();
-        CollisionPoint resultB = new();
+        IntersectionPoint resultA = new();
+        IntersectionPoint resultB = new();
 
         var cp = IntersectSegmentSegment(segmentStart, segmentEnd, a, b);
         if (cp.Valid) resultA = cp;
@@ -564,8 +564,8 @@ public readonly partial struct Segment
     /// <param name="b">Second vertex of the rectangle.</param>
     /// <param name="c">Third vertex of the rectangle.</param>
     /// <param name="d">Fourth vertex of the rectangle.</param>
-    /// <returns>A tuple of <see cref="CollisionPoint"/> representing the intersection points (a, b).</returns>
-    public static (CollisionPoint a, CollisionPoint b) IntersectSegmentRect(Vector2 segmentStart, Vector2 segmentEnd, Vector2 a, Vector2 b, Vector2 c,
+    /// <returns>A tuple of <see cref="IntersectionPoint"/> representing the intersection points (a, b).</returns>
+    public static (IntersectionPoint a, IntersectionPoint b) IntersectSegmentRect(Vector2 segmentStart, Vector2 segmentEnd, Vector2 a, Vector2 b, Vector2 c,
         Vector2 d)
     {
         return IntersectSegmentQuad(segmentStart, segmentEnd, a, b, c, d);
@@ -578,12 +578,12 @@ public readonly partial struct Segment
     /// <param name="segmentEnd">The end point of the segment.</param>
     /// <param name="points">The list of polygon vertices.</param>
     /// <param name="maxCollisionPoints">The maximum number of collision points to return. -1 for unlimited.</param>
-    /// <returns>A <see cref="CollisionPoints"/> collection, or null if there are no intersections.</returns>
-    public static CollisionPoints? IntersectSegmentPolygon(Vector2 segmentStart, Vector2 segmentEnd, List<Vector2> points, int maxCollisionPoints = -1)
+    /// <returns>A <see cref="IntersectionPoints"/> collection, or null if there are no intersections.</returns>
+    public static IntersectionPoints? IntersectSegmentPolygon(Vector2 segmentStart, Vector2 segmentEnd, List<Vector2> points, int maxCollisionPoints = -1)
     {
         if (points.Count < 3) return null;
         if (maxCollisionPoints == 0) return null;
-        CollisionPoints? result = null;
+        IntersectionPoints? result = null;
         for (var i = 0; i < points.Count; i++)
         {
             var colPoint = IntersectSegmentSegment(segmentStart, segmentEnd, points[i], points[(i + 1) % points.Count]);
@@ -605,12 +605,12 @@ public readonly partial struct Segment
     /// <param name="segmentEnd">The end point of the segment.</param>
     /// <param name="points">The list of polyline vertices.</param>
     /// <param name="maxCollisionPoints">The maximum number of collision points to return. -1 for unlimited.</param>
-    /// <returns>A <see cref="CollisionPoints"/> collection, or null if there are no intersections.</returns>
-    public static CollisionPoints? IntersectSegmentPolyline(Vector2 segmentStart, Vector2 segmentEnd, List<Vector2> points, int maxCollisionPoints = -1)
+    /// <returns>A <see cref="IntersectionPoints"/> collection, or null if there are no intersections.</returns>
+    public static IntersectionPoints? IntersectSegmentPolyline(Vector2 segmentStart, Vector2 segmentEnd, List<Vector2> points, int maxCollisionPoints = -1)
     {
         if (points.Count < 3) return null;
         if (maxCollisionPoints == 0) return null;
-        CollisionPoints? result = null;
+        IntersectionPoints? result = null;
         for (var i = 0; i < points.Count - 1; i++)
         {
             var colPoint = IntersectSegmentSegment(segmentStart, segmentEnd, points[i], points[i + 1]);
@@ -632,12 +632,12 @@ public readonly partial struct Segment
     /// <param name="segmentEnd">The end point of the segment.</param>
     /// <param name="segments">The set of segments to test against.</param>
     /// <param name="maxCollisionPoints">The maximum number of collision points to return. -1 for unlimited.</param>
-    /// <returns>A <see cref="CollisionPoints"/> collection, or null if there are no intersections.</returns>
-    public static CollisionPoints? IntersectSegmentSegments(Vector2 segmentStart, Vector2 segmentEnd, List<Segment> segments, int maxCollisionPoints = -1)
+    /// <returns>A <see cref="IntersectionPoints"/> collection, or null if there are no intersections.</returns>
+    public static IntersectionPoints? IntersectSegmentSegments(Vector2 segmentStart, Vector2 segmentEnd, List<Segment> segments, int maxCollisionPoints = -1)
     {
         if (segments.Count <= 0) return null;
         if (maxCollisionPoints == 0) return null;
-        CollisionPoints? result = null;
+        IntersectionPoints? result = null;
 
         foreach (var seg in segments)
         {

--- a/ShapeEngine/Geometry/SegmentsDef/SegmentsClosestPoint.cs
+++ b/ShapeEngine/Geometry/SegmentsDef/SegmentsClosestPoint.cs
@@ -662,7 +662,7 @@ public partial class Segments
     /// <param name="p">The point to find the closest segment and point to.</param>
     /// <param name="disSquared">The squared distance between the point and the closest point on the segment.</param>
     /// <returns>A tuple containing the closest segment and the closest point on the segment to the given point.
-    /// Returns a new empty segment and collision point if there are 2 or less segments.</returns>
+    /// Returns a new empty segment and intersection point if there are 2 or less segments.</returns>
     public (Segment segment, IntersectionPoint segmentPoint) GetClosestSegment(Vector2 p, out float disSquared)
     {
         disSquared = -1;

--- a/ShapeEngine/Geometry/SegmentsDef/SegmentsClosestPoint.cs
+++ b/ShapeEngine/Geometry/SegmentsDef/SegmentsClosestPoint.cs
@@ -52,8 +52,8 @@ public partial class Segments
     /// </summary>
     /// <param name="p">The point to find the closest point to.</param>
     /// <param name="disSquared">The squared distance between the point and the closest point.</param>
-    /// <returns>A CollisionPoint representing the closest point. Returns a new CollisionPoint() if there are 2 or less segments.</returns>
-    public CollisionPoint GetClosestPoint(Vector2 p, out float disSquared)
+    /// <returns>A IntersectionPoint representing the closest point. Returns a new IntersectionPoint() if there are 2 or less segments.</returns>
+    public IntersectionPoint GetClosestPoint(Vector2 p, out float disSquared)
     {
         disSquared = -1;
         if (Count <= 2) return new();
@@ -83,8 +83,8 @@ public partial class Segments
     /// <param name="p">The point to find the closest point to.</param>
     /// <param name="disSquared">The squared distance between the point and the closest point.</param>
     /// <param name="index">The index of the segment that contains the closest point.</param>
-    /// <returns>A CollisionPoint representing the closest point. Returns a new CollisionPoint() if there are 2 or less segments.</returns>
-    public CollisionPoint GetClosestPoint(Vector2 p, out float disSquared, out int index)
+    /// <returns>A IntersectionPoint representing the closest point. Returns a new IntersectionPoint() if there are 2 or less segments.</returns>
+    public IntersectionPoint GetClosestPoint(Vector2 p, out float disSquared, out int index)
     {
         disSquared = -1;
         index = -1;
@@ -663,7 +663,7 @@ public partial class Segments
     /// <param name="disSquared">The squared distance between the point and the closest point on the segment.</param>
     /// <returns>A tuple containing the closest segment and the closest point on the segment to the given point.
     /// Returns a new empty segment and collision point if there are 2 or less segments.</returns>
-    public (Segment segment, CollisionPoint segmentPoint) GetClosestSegment(Vector2 p, out float disSquared)
+    public (Segment segment, IntersectionPoint segmentPoint) GetClosestSegment(Vector2 p, out float disSquared)
     {
         disSquared = -1;
         if (Count <= 2) return (new(), new());

--- a/ShapeEngine/Geometry/SegmentsDef/SegmentsIntersectShape.cs
+++ b/ShapeEngine/Geometry/SegmentsDef/SegmentsIntersectShape.cs
@@ -13,10 +13,10 @@ public partial class Segments
     /// </summary>
     /// <param name="r">The ray to intersect with.</param>
     /// <returns>A list of collision points if there are any intersections, otherwise null.</returns>
-    public CollisionPoints? IntersectShape(Ray r)
+    public IntersectionPoints? IntersectShape(Ray r)
     {
         if (Count <= 0) return null;
-        CollisionPoints? points = null;
+        IntersectionPoints? points = null;
 
         foreach (var seg in this)
         {
@@ -36,10 +36,10 @@ public partial class Segments
     /// </summary>
     /// <param name="l">The line to intersect with.</param>
     /// <returns>A list of collision points if there are any intersections, otherwise null.</returns>
-    public CollisionPoints? IntersectShape(Line l)
+    public IntersectionPoints? IntersectShape(Line l)
     {
         if (Count <= 0) return null;
-        CollisionPoints? points = null;
+        IntersectionPoints? points = null;
 
         foreach (var seg in this)
         {
@@ -59,10 +59,10 @@ public partial class Segments
     /// </summary>
     /// <param name="s">The segment to intersect with.</param>
     /// <returns>A list of collision points if there are any intersections, otherwise null.</returns>
-    public CollisionPoints? IntersectShape(Segment s)
+    public IntersectionPoints? IntersectShape(Segment s)
     {
         if (Count <= 0) return null;
-        CollisionPoints? points = null;
+        IntersectionPoints? points = null;
 
         foreach (var seg in this)
         {
@@ -82,10 +82,10 @@ public partial class Segments
     /// </summary>
     /// <param name="c">The circle to intersect with.</param>
     /// <returns>A list of collision points if there are any intersections, otherwise null.</returns>
-    public CollisionPoints? IntersectShape(Circle c)
+    public IntersectionPoints? IntersectShape(Circle c)
     {
         if (Count <= 0) return null;
-        CollisionPoints? points = null;
+        IntersectionPoints? points = null;
         foreach (var seg in this)
         {
             var result = Segment.IntersectSegmentCircle(seg.Start, seg.End, c.Center, c.Radius);
@@ -105,10 +105,10 @@ public partial class Segments
     /// </summary>
     /// <param name="shape">The segments to intersect with.</param>
     /// <returns>A list of collision points if there are any intersections, otherwise null.</returns>
-    public CollisionPoints? IntersectShape(Segments shape)
+    public IntersectionPoints? IntersectShape(Segments shape)
     {
         if (Count <= 0) return null;
-        CollisionPoints? points = null;
+        IntersectionPoints? points = null;
 
         foreach (var seg in this)
         {
@@ -133,7 +133,7 @@ public partial class Segments
     /// <param name="points">The list of collision points to add to.</param>
     /// <param name="returnAfterFirstValid">If true, the method will return after the first valid intersection is found.</param>
     /// <returns>The number of intersections found.</returns>
-    public int IntersectShape(Ray r, ref CollisionPoints points, bool returnAfterFirstValid = false)
+    public int IntersectShape(Ray r, ref IntersectionPoints points, bool returnAfterFirstValid = false)
     {
         if (Count <= 0) return 0;
         var count = 0;
@@ -159,7 +159,7 @@ public partial class Segments
     /// <param name="points">The list of collision points to add to.</param>
     /// <param name="returnAfterFirstValid">If true, the method will return after the first valid intersection is found.</param>
     /// <returns>The number of intersections found.</returns>
-    public int IntersectShape(Line l, ref CollisionPoints points, bool returnAfterFirstValid = false)
+    public int IntersectShape(Line l, ref IntersectionPoints points, bool returnAfterFirstValid = false)
     {
         if (Count <= 0) return 0;
         var count = 0;
@@ -185,7 +185,7 @@ public partial class Segments
     /// <param name="points">The list of collision points to add to.</param>
     /// <param name="returnAfterFirstValid">If true, the method will return after the first valid intersection is found.</param>
     /// <returns>The number of intersections found.</returns>
-    public int IntersectShape(Segment s, ref CollisionPoints points, bool returnAfterFirstValid = false)
+    public int IntersectShape(Segment s, ref IntersectionPoints points, bool returnAfterFirstValid = false)
     {
         if (Count <= 0) return 0;
         var count = 0;
@@ -211,7 +211,7 @@ public partial class Segments
     /// <param name="points">The list of collision points to add to.</param>
     /// <param name="returnAfterFirstValid">If true, the method will return after the first valid intersection is found.</param>
     /// <returns>The number of intersections found.</returns>
-    public int IntersectShape(Circle c, ref CollisionPoints points, bool returnAfterFirstValid = false)
+    public int IntersectShape(Circle c, ref IntersectionPoints points, bool returnAfterFirstValid = false)
     {
         if (Count <= 0) return 0;
         var count = 0;
@@ -243,7 +243,7 @@ public partial class Segments
     /// <param name="points">The list of collision points to add to.</param>
     /// <param name="returnAfterFirstValid">If true, the method will return after the first valid intersection is found.</param>
     /// <returns>The number of intersections found.</returns>
-    public int IntersectShape(Segments shape, ref CollisionPoints points, bool returnAfterFirstValid = false)
+    public int IntersectShape(Segments shape, ref IntersectionPoints points, bool returnAfterFirstValid = false)
     {
         if (Count <= 0) return 0;
         var count = 0;

--- a/ShapeEngine/Geometry/StripedDrawingDef/StripedDrawing.cs
+++ b/ShapeEngine/Geometry/StripedDrawingDef/StripedDrawing.cs
@@ -8,5 +8,5 @@ namespace ShapeEngine.Geometry.StripedDrawingDef;
 /// </summary>
 public static partial class StripedDrawing
 {
-    private static CollisionPoints collisionPointsReference = new CollisionPoints(6);
+    private static IntersectionPoints intersectionPointsReference = new IntersectionPoints(6);
 }

--- a/ShapeEngine/Geometry/StripedDrawingDef/StripedDrawingCircle.cs
+++ b/ShapeEngine/Geometry/StripedDrawingDef/StripedDrawingCircle.cs
@@ -816,7 +816,7 @@ public static partial class StripedDrawing
                 continue;
             }
 
-            var count = Line.IntersectLinePolygon(cur, lineDir, insideShape, ref collisionPointsReference);
+            var count = Line.IntersectLinePolygon(cur, lineDir, insideShape, ref intersectionPointsReference);
 
             if (count <= 0) //ray did not hit the inside shape, draw ray between edge of the outside shape
             {
@@ -826,45 +826,45 @@ public static partial class StripedDrawing
             else
             {
                 //remove all inside shape intersection points that are outside the outside shape
-                for (int j = collisionPointsReference.Count - 1; j >= 0; j--)
+                for (int j = intersectionPointsReference.Count - 1; j >= 0; j--)
                 {
-                    var p = collisionPointsReference[j].Point;
+                    var p = intersectionPointsReference[j].Point;
 
-                    if (!outsideShape.ContainsPoint(p)) collisionPointsReference.RemoveAt(j);
+                    if (!outsideShape.ContainsPoint(p)) intersectionPointsReference.RemoveAt(j);
                 }
 
-                if (outsideShapePoints.a.Valid && !insideShape.ContainsPoint(outsideShapePoints.a.Point)) collisionPointsReference.Add(outsideShapePoints.a);
-                if (outsideShapePoints.b.Valid && !insideShape.ContainsPoint(outsideShapePoints.b.Point)) collisionPointsReference.Add(outsideShapePoints.b);
+                if (outsideShapePoints.a.Valid && !insideShape.ContainsPoint(outsideShapePoints.a.Point)) intersectionPointsReference.Add(outsideShapePoints.a);
+                if (outsideShapePoints.b.Valid && !insideShape.ContainsPoint(outsideShapePoints.b.Point)) intersectionPointsReference.Add(outsideShapePoints.b);
 
                 //all points were remove so just draw the outside shape segment (even with only 1 point left, we continue)
-                if (collisionPointsReference.Count <= 1)
+                if (intersectionPointsReference.Count <= 1)
                 {
                     cur += dir * spacing;
-                    collisionPointsReference.Clear();
+                    intersectionPointsReference.Clear();
                     continue;
                 }
 
-                if (collisionPointsReference.Count == 2) //no sorting or loop needed for exactly 2 points
+                if (intersectionPointsReference.Count == 2) //no sorting or loop needed for exactly 2 points
                 {
-                    var segment = new Segment(collisionPointsReference[0].Point, collisionPointsReference[1].Point);
+                    var segment = new Segment(intersectionPointsReference[0].Point, intersectionPointsReference[1].Point);
                     segment.Draw(striped);
                     cur += dir * spacing;
-                    collisionPointsReference.Clear();
+                    intersectionPointsReference.Clear();
                     continue;
                 }
 
                 //now that only valid points remain, sort them by distance from the current point
-                collisionPointsReference.SortClosestFirst(cur);
+                intersectionPointsReference.SortClosestFirst(cur);
 
-                for (int j = 0; j < collisionPointsReference.Count - 1; j += 2)
+                for (int j = 0; j < intersectionPointsReference.Count - 1; j += 2)
                 {
-                    var p1 = collisionPointsReference[j].Point;
-                    var p2 = collisionPointsReference[j + 1].Point;
+                    var p1 = intersectionPointsReference[j].Point;
+                    var p2 = intersectionPointsReference[j + 1].Point;
                     var segment = new Segment(p1, p2);
                     segment.Draw(striped);
                 }
 
-                collisionPointsReference.Clear();
+                intersectionPointsReference.Clear();
             }
 
             cur += dir * spacing;

--- a/ShapeEngine/Geometry/StripedDrawingDef/StripedDrawingPolygon.cs
+++ b/ShapeEngine/Geometry/StripedDrawingDef/StripedDrawingPolygon.cs
@@ -41,23 +41,23 @@ public static partial class StripedDrawing
         cur -= rayDir * maxDimension; //offsets the point to outside the polygon in the opposite direction of the ray
         for (int i = 0; i < steps; i++)
         {
-            var count = Ray.IntersectRayPolygon(cur, rayDir, polygon, ref collisionPointsReference);
+            var count = Ray.IntersectRayPolygon(cur, rayDir, polygon, ref intersectionPointsReference);
             if (count >= 2) //minimum of 2 points for drawing needed
             {
                 if (count >= 4) //only if there is 4 or more points, sort the points for drawing
                 {
-                    collisionPointsReference.SortClosestFirst(cur);
+                    intersectionPointsReference.SortClosestFirst(cur);
                 }
 
-                for (int j = 0; j < collisionPointsReference.Count - 1; j += 2)
+                for (int j = 0; j < intersectionPointsReference.Count - 1; j += 2)
                 {
-                    var p1 = collisionPointsReference[j].Point;
-                    var p2 = collisionPointsReference[j + 1].Point;
+                    var p1 = intersectionPointsReference[j].Point;
+                    var p2 = intersectionPointsReference[j + 1].Point;
                     SegmentDrawing.DrawSegment(p1, p2, striped);
                 }
             }
 
-            collisionPointsReference.Clear();
+            intersectionPointsReference.Clear();
 
             cur += dir * spacing;
         }
@@ -89,24 +89,24 @@ public static partial class StripedDrawing
         cur -= rayDir * maxDimension; //offsets the point to outside the polygon in the opposite direction of the ray
         for (int i = 0; i < steps; i++)
         {
-            var count = Ray.IntersectRayPolygon(cur, rayDir, polygon, ref collisionPointsReference);
+            var count = Ray.IntersectRayPolygon(cur, rayDir, polygon, ref intersectionPointsReference);
             if (count >= 2) //minimum of 2 points for drawing needed
             {
                 if (count >= 4) //only if there is 4 or more points, sort the points for drawing
                 {
-                    collisionPointsReference.SortClosestFirst(cur);
+                    intersectionPointsReference.SortClosestFirst(cur);
                 }
 
                 var info = i % 2 == 0 ? striped : alternatingStriped;
-                for (int j = 0; j < collisionPointsReference.Count - 1; j += 2)
+                for (int j = 0; j < intersectionPointsReference.Count - 1; j += 2)
                 {
-                    var p1 = collisionPointsReference[j].Point;
-                    var p2 = collisionPointsReference[j + 1].Point;
+                    var p1 = intersectionPointsReference[j].Point;
+                    var p2 = intersectionPointsReference[j + 1].Point;
                     SegmentDrawing.DrawSegment(p1, p2, info);
                 }
             }
 
-            collisionPointsReference.Clear();
+            intersectionPointsReference.Clear();
             cur += dir * spacing;
         }
     }
@@ -137,25 +137,25 @@ public static partial class StripedDrawing
         cur -= rayDir * maxDimension; //offsets the point to outside the polygon in the opposite direction of the ray
         for (int i = 0; i < steps; i++)
         {
-            var count = Ray.IntersectRayPolygon(cur, rayDir, polygon, ref collisionPointsReference);
+            var count = Ray.IntersectRayPolygon(cur, rayDir, polygon, ref intersectionPointsReference);
             if (count >= 2) //minimum of 2 points for drawing needed
             {
                 if (count >= 4) //only if there is 4 or more points, sort the points for drawing
                 {
-                    collisionPointsReference.SortClosestFirst(cur);
+                    intersectionPointsReference.SortClosestFirst(cur);
                 }
 
                 var infoIndex = i % alternatingStriped.Length;
                 var info = alternatingStriped[infoIndex];
-                for (int j = 0; j < collisionPointsReference.Count - 1; j += 2)
+                for (int j = 0; j < intersectionPointsReference.Count - 1; j += 2)
                 {
-                    var p1 = collisionPointsReference[j].Point;
-                    var p2 = collisionPointsReference[j + 1].Point;
+                    var p1 = intersectionPointsReference[j].Point;
+                    var p2 = intersectionPointsReference[j + 1].Point;
                     SegmentDrawing.DrawSegment(p1, p2, info);
                 }
             }
 
-            collisionPointsReference.Clear();
+            intersectionPointsReference.Clear();
             cur += dir * spacing;
         }
     }
@@ -187,23 +187,23 @@ public static partial class StripedDrawing
 
         while (targetLength < maxDimension)
         {
-            var count = Ray.IntersectRayPolygon(cur, rayDir, polygon, ref collisionPointsReference);
+            var count = Ray.IntersectRayPolygon(cur, rayDir, polygon, ref intersectionPointsReference);
             if (count >= 2) //minimum of 2 points for drawing needed
             {
                 if (count >= 4) //only if there is 4 or more points, sort the points for drawing
                 {
-                    collisionPointsReference.SortClosestFirst(cur);
+                    intersectionPointsReference.SortClosestFirst(cur);
                 }
 
-                for (int j = 0; j < collisionPointsReference.Count - 1; j += 2)
+                for (int j = 0; j < intersectionPointsReference.Count - 1; j += 2)
                 {
-                    var p1 = collisionPointsReference[j].Point;
-                    var p2 = collisionPointsReference[j + 1].Point;
+                    var p1 = intersectionPointsReference[j].Point;
+                    var p2 = intersectionPointsReference[j + 1].Point;
                     SegmentDrawing.DrawSegment(p1, p2, striped);
                 }
             }
 
-            collisionPointsReference.Clear();
+            intersectionPointsReference.Clear();
             var time = targetLength / maxDimension;
             if (!spacingCurve.Sample(time, out spacing)) return;
             if (spacing <= 0f) return; //prevents infinite loop
@@ -241,24 +241,24 @@ public static partial class StripedDrawing
         int i = 0;
         while (targetLength < maxDimension)
         {
-            var count = Ray.IntersectRayPolygon(cur, rayDir, polygon, ref collisionPointsReference);
+            var count = Ray.IntersectRayPolygon(cur, rayDir, polygon, ref intersectionPointsReference);
             if (count >= 2) //minimum of 2 points for drawing needed
             {
                 if (count >= 4) //only if there is 4 or more points, sort the points for drawing
                 {
-                    collisionPointsReference.SortClosestFirst(cur);
+                    intersectionPointsReference.SortClosestFirst(cur);
                 }
 
                 var info = i % 2 == 0 ? striped : alternatingStriped;
-                for (int j = 0; j < collisionPointsReference.Count - 1; j += 2)
+                for (int j = 0; j < intersectionPointsReference.Count - 1; j += 2)
                 {
-                    var p1 = collisionPointsReference[j].Point;
-                    var p2 = collisionPointsReference[j + 1].Point;
+                    var p1 = intersectionPointsReference[j].Point;
+                    var p2 = intersectionPointsReference[j + 1].Point;
                     SegmentDrawing.DrawSegment(p1, p2, info);
                 }
             }
 
-            collisionPointsReference.Clear();
+            intersectionPointsReference.Clear();
 
             var time = targetLength / maxDimension;
             if (!spacingCurve.Sample(time, out spacing)) return;
@@ -299,25 +299,25 @@ public static partial class StripedDrawing
         int i = 0;
         while (targetLength < maxDimension)
         {
-            var count = Ray.IntersectRayPolygon(cur, rayDir, polygon, ref collisionPointsReference);
+            var count = Ray.IntersectRayPolygon(cur, rayDir, polygon, ref intersectionPointsReference);
             if (count >= 2) //minimum of 2 points for drawing needed
             {
                 if (count >= 4) //only if there is 4 or more points, sort the points for drawing
                 {
-                    collisionPointsReference.SortClosestFirst(cur);
+                    intersectionPointsReference.SortClosestFirst(cur);
                 }
 
                 var infoIndex = i % alternatingStriped.Length;
                 var info = alternatingStriped[infoIndex];
-                for (int j = 0; j < collisionPointsReference.Count - 1; j += 2)
+                for (int j = 0; j < intersectionPointsReference.Count - 1; j += 2)
                 {
-                    var p1 = collisionPointsReference[j].Point;
-                    var p2 = collisionPointsReference[j + 1].Point;
+                    var p1 = intersectionPointsReference[j].Point;
+                    var p2 = intersectionPointsReference[j + 1].Point;
                     SegmentDrawing.DrawSegment(p1, p2, info);
                 }
             }
 
-            collisionPointsReference.Clear();
+            intersectionPointsReference.Clear();
 
             var time = targetLength / maxDimension;
             if (!spacingCurve.Sample(time, out spacing)) return;
@@ -363,7 +363,7 @@ public static partial class StripedDrawing
 
         for (int i = 0; i < steps; i++)
         {
-            var count = Line.IntersectLinePolygon(cur, lineDir, outsideShape, ref collisionPointsReference);
+            var count = Line.IntersectLinePolygon(cur, lineDir, outsideShape, ref intersectionPointsReference);
             if (count < 2)
             {
                 cur += dir * spacing;
@@ -373,11 +373,11 @@ public static partial class StripedDrawing
             var insideShapePoints = Line.IntersectLineCircle(cur, lineDir, insideShape.Center, insideShape.Radius);
             if (!insideShapePoints.a.Valid || !insideShapePoints.b.Valid) //draw the lines in the outside shape
             {
-                collisionPointsReference.SortClosestFirst(cur);
-                for (int j = 0; j < collisionPointsReference.Count; j += 2)
+                intersectionPointsReference.SortClosestFirst(cur);
+                for (int j = 0; j < intersectionPointsReference.Count; j += 2)
                 {
-                    var p1 = collisionPointsReference[j].Point;
-                    var p2 = collisionPointsReference[j + 1].Point;
+                    var p1 = intersectionPointsReference[j].Point;
+                    var p2 = intersectionPointsReference[j + 1].Point;
                     var segment = new Segment(p1, p2);
                     segment.Draw(striped);
                 }
@@ -385,26 +385,26 @@ public static partial class StripedDrawing
             else
             {
                 //remove all intersection points of the outside shape that are inside the inside shape
-                for (int j = collisionPointsReference.Count - 1; j >= 0; j--)
+                for (int j = intersectionPointsReference.Count - 1; j >= 0; j--)
                 {
-                    var p = collisionPointsReference[j].Point;
-                    if (insideShape.ContainsPoint(p)) collisionPointsReference.RemoveAt(j);
+                    var p = intersectionPointsReference[j].Point;
+                    if (insideShape.ContainsPoint(p)) intersectionPointsReference.RemoveAt(j);
                 }
 
-                if (outsideShape.ContainsPoint(insideShapePoints.a.Point)) collisionPointsReference.Add(insideShapePoints.a);
-                if (outsideShape.ContainsPoint(insideShapePoints.b.Point)) collisionPointsReference.Add(insideShapePoints.b);
+                if (outsideShape.ContainsPoint(insideShapePoints.a.Point)) intersectionPointsReference.Add(insideShapePoints.a);
+                if (outsideShape.ContainsPoint(insideShapePoints.b.Point)) intersectionPointsReference.Add(insideShapePoints.b);
 
-                collisionPointsReference.SortClosestFirst(cur);
-                for (int j = 0; j < collisionPointsReference.Count; j += 2)
+                intersectionPointsReference.SortClosestFirst(cur);
+                for (int j = 0; j < intersectionPointsReference.Count; j += 2)
                 {
-                    var p1 = collisionPointsReference[j].Point;
-                    var p2 = collisionPointsReference[j + 1].Point;
+                    var p1 = intersectionPointsReference[j].Point;
+                    var p2 = intersectionPointsReference[j + 1].Point;
                     var segment = new Segment(p1, p2);
                     segment.Draw(striped);
                 }
             }
 
-            collisionPointsReference.Clear();
+            intersectionPointsReference.Clear();
 
             cur += dir * spacing;
         }
@@ -444,7 +444,7 @@ public static partial class StripedDrawing
 
         for (int i = 0; i < steps; i++)
         {
-            var count = Line.IntersectLinePolygon(cur, lineDir, outsideShape, ref collisionPointsReference);
+            var count = Line.IntersectLinePolygon(cur, lineDir, outsideShape, ref intersectionPointsReference);
             if (count < 2)
             {
                 cur += dir * spacing;
@@ -454,11 +454,11 @@ public static partial class StripedDrawing
             var insideShapePoints = Line.IntersectLineTriangle(cur, lineDir, insideShape.A, insideShape.B, insideShape.C);
             if (!insideShapePoints.a.Valid || !insideShapePoints.b.Valid) //draw the lines in the outside shape
             {
-                collisionPointsReference.SortClosestFirst(cur);
-                for (int j = 0; j < collisionPointsReference.Count; j += 2)
+                intersectionPointsReference.SortClosestFirst(cur);
+                for (int j = 0; j < intersectionPointsReference.Count; j += 2)
                 {
-                    var p1 = collisionPointsReference[j].Point;
-                    var p2 = collisionPointsReference[j + 1].Point;
+                    var p1 = intersectionPointsReference[j].Point;
+                    var p2 = intersectionPointsReference[j + 1].Point;
                     var segment = new Segment(p1, p2);
                     segment.Draw(striped);
                 }
@@ -466,26 +466,26 @@ public static partial class StripedDrawing
             else
             {
                 //remove all intersection points of the outside shape that are inside the inside shape
-                for (int j = collisionPointsReference.Count - 1; j >= 0; j--)
+                for (int j = intersectionPointsReference.Count - 1; j >= 0; j--)
                 {
-                    var p = collisionPointsReference[j].Point;
-                    if (insideShape.ContainsPoint(p)) collisionPointsReference.RemoveAt(j);
+                    var p = intersectionPointsReference[j].Point;
+                    if (insideShape.ContainsPoint(p)) intersectionPointsReference.RemoveAt(j);
                 }
 
-                if (outsideShape.ContainsPoint(insideShapePoints.a.Point)) collisionPointsReference.Add(insideShapePoints.a);
-                if (outsideShape.ContainsPoint(insideShapePoints.b.Point)) collisionPointsReference.Add(insideShapePoints.b);
+                if (outsideShape.ContainsPoint(insideShapePoints.a.Point)) intersectionPointsReference.Add(insideShapePoints.a);
+                if (outsideShape.ContainsPoint(insideShapePoints.b.Point)) intersectionPointsReference.Add(insideShapePoints.b);
 
-                collisionPointsReference.SortClosestFirst(cur);
-                for (int j = 0; j < collisionPointsReference.Count; j += 2)
+                intersectionPointsReference.SortClosestFirst(cur);
+                for (int j = 0; j < intersectionPointsReference.Count; j += 2)
                 {
-                    var p1 = collisionPointsReference[j].Point;
-                    var p2 = collisionPointsReference[j + 1].Point;
+                    var p1 = intersectionPointsReference[j].Point;
+                    var p2 = intersectionPointsReference[j + 1].Point;
                     var segment = new Segment(p1, p2);
                     segment.Draw(striped);
                 }
             }
 
-            collisionPointsReference.Clear();
+            intersectionPointsReference.Clear();
 
             cur += dir * spacing;
         }
@@ -525,7 +525,7 @@ public static partial class StripedDrawing
 
         for (int i = 0; i < steps; i++)
         {
-            var count = Line.IntersectLinePolygon(cur, lineDir, outsideShape, ref collisionPointsReference);
+            var count = Line.IntersectLinePolygon(cur, lineDir, outsideShape, ref intersectionPointsReference);
             if (count < 2)
             {
                 cur += dir * spacing;
@@ -535,11 +535,11 @@ public static partial class StripedDrawing
             var insideShapePoints = Line.IntersectLineQuad(cur, lineDir, insideShape.A, insideShape.B, insideShape.C, insideShape.D);
             if (!insideShapePoints.a.Valid || !insideShapePoints.b.Valid) //draw the lines in the outside shape
             {
-                collisionPointsReference.SortClosestFirst(cur);
-                for (int j = 0; j < collisionPointsReference.Count; j += 2)
+                intersectionPointsReference.SortClosestFirst(cur);
+                for (int j = 0; j < intersectionPointsReference.Count; j += 2)
                 {
-                    var p1 = collisionPointsReference[j].Point;
-                    var p2 = collisionPointsReference[j + 1].Point;
+                    var p1 = intersectionPointsReference[j].Point;
+                    var p2 = intersectionPointsReference[j + 1].Point;
                     var segment = new Segment(p1, p2);
                     segment.Draw(striped);
                 }
@@ -547,26 +547,26 @@ public static partial class StripedDrawing
             else
             {
                 //remove all intersection points of the outside shape that are inside the inside shape
-                for (int j = collisionPointsReference.Count - 1; j >= 0; j--)
+                for (int j = intersectionPointsReference.Count - 1; j >= 0; j--)
                 {
-                    var p = collisionPointsReference[j].Point;
-                    if (insideShape.ContainsPoint(p)) collisionPointsReference.RemoveAt(j);
+                    var p = intersectionPointsReference[j].Point;
+                    if (insideShape.ContainsPoint(p)) intersectionPointsReference.RemoveAt(j);
                 }
 
-                if (outsideShape.ContainsPoint(insideShapePoints.a.Point)) collisionPointsReference.Add(insideShapePoints.a);
-                if (outsideShape.ContainsPoint(insideShapePoints.b.Point)) collisionPointsReference.Add(insideShapePoints.b);
+                if (outsideShape.ContainsPoint(insideShapePoints.a.Point)) intersectionPointsReference.Add(insideShapePoints.a);
+                if (outsideShape.ContainsPoint(insideShapePoints.b.Point)) intersectionPointsReference.Add(insideShapePoints.b);
 
-                collisionPointsReference.SortClosestFirst(cur);
-                for (int j = 0; j < collisionPointsReference.Count; j += 2)
+                intersectionPointsReference.SortClosestFirst(cur);
+                for (int j = 0; j < intersectionPointsReference.Count; j += 2)
                 {
-                    var p1 = collisionPointsReference[j].Point;
-                    var p2 = collisionPointsReference[j + 1].Point;
+                    var p1 = intersectionPointsReference[j].Point;
+                    var p2 = intersectionPointsReference[j + 1].Point;
                     var segment = new Segment(p1, p2);
                     segment.Draw(striped);
                 }
             }
 
-            collisionPointsReference.Clear();
+            intersectionPointsReference.Clear();
 
             cur += dir * spacing;
         }
@@ -606,7 +606,7 @@ public static partial class StripedDrawing
 
         for (int i = 0; i < steps; i++)
         {
-            var count = Line.IntersectLinePolygon(cur, lineDir, outsideShape, ref collisionPointsReference);
+            var count = Line.IntersectLinePolygon(cur, lineDir, outsideShape, ref intersectionPointsReference);
             if (count < 2)
             {
                 cur += dir * spacing;
@@ -616,11 +616,11 @@ public static partial class StripedDrawing
             var insideShapePoints = Line.IntersectLineRect(cur, lineDir, insideShape.A, insideShape.B, insideShape.C, insideShape.D);
             if (!insideShapePoints.a.Valid || !insideShapePoints.b.Valid) //draw the lines in the outside shape
             {
-                collisionPointsReference.SortClosestFirst(cur);
-                for (int j = 0; j < collisionPointsReference.Count; j += 2)
+                intersectionPointsReference.SortClosestFirst(cur);
+                for (int j = 0; j < intersectionPointsReference.Count; j += 2)
                 {
-                    var p1 = collisionPointsReference[j].Point;
-                    var p2 = collisionPointsReference[j + 1].Point;
+                    var p1 = intersectionPointsReference[j].Point;
+                    var p2 = intersectionPointsReference[j + 1].Point;
                     var segment = new Segment(p1, p2);
                     segment.Draw(striped);
                 }
@@ -628,26 +628,26 @@ public static partial class StripedDrawing
             else
             {
                 //remove all intersection points of the outside shape that are inside the inside shape
-                for (int j = collisionPointsReference.Count - 1; j >= 0; j--)
+                for (int j = intersectionPointsReference.Count - 1; j >= 0; j--)
                 {
-                    var p = collisionPointsReference[j].Point;
-                    if (insideShape.ContainsPoint(p)) collisionPointsReference.RemoveAt(j);
+                    var p = intersectionPointsReference[j].Point;
+                    if (insideShape.ContainsPoint(p)) intersectionPointsReference.RemoveAt(j);
                 }
 
-                if (outsideShape.ContainsPoint(insideShapePoints.a.Point)) collisionPointsReference.Add(insideShapePoints.a);
-                if (outsideShape.ContainsPoint(insideShapePoints.b.Point)) collisionPointsReference.Add(insideShapePoints.b);
+                if (outsideShape.ContainsPoint(insideShapePoints.a.Point)) intersectionPointsReference.Add(insideShapePoints.a);
+                if (outsideShape.ContainsPoint(insideShapePoints.b.Point)) intersectionPointsReference.Add(insideShapePoints.b);
 
-                collisionPointsReference.SortClosestFirst(cur);
-                for (int j = 0; j < collisionPointsReference.Count; j += 2)
+                intersectionPointsReference.SortClosestFirst(cur);
+                for (int j = 0; j < intersectionPointsReference.Count; j += 2)
                 {
-                    var p1 = collisionPointsReference[j].Point;
-                    var p2 = collisionPointsReference[j + 1].Point;
+                    var p1 = intersectionPointsReference[j].Point;
+                    var p2 = intersectionPointsReference[j + 1].Point;
                     var segment = new Segment(p1, p2);
                     segment.Draw(striped);
                 }
             }
 
-            collisionPointsReference.Clear();
+            intersectionPointsReference.Clear();
 
             cur += dir * spacing;
         }
@@ -687,22 +687,22 @@ public static partial class StripedDrawing
 
         for (int i = 0; i < steps; i++)
         {
-            var outsideCount = Line.IntersectLinePolygon(cur, lineDir, outsideShape, ref collisionPointsReference);
+            var outsideCount = Line.IntersectLinePolygon(cur, lineDir, outsideShape, ref intersectionPointsReference);
             if (outsideCount < 2)
             {
                 cur += dir * spacing;
                 continue;
             }
 
-            var insideCount = Line.IntersectLinePolygon(cur, lineDir, insideShape, ref collisionPointsReference);
+            var insideCount = Line.IntersectLinePolygon(cur, lineDir, insideShape, ref intersectionPointsReference);
             //this is correct, insideCount <= 0 leads to crashes!
             if (insideCount < 0) //draw the lines in the outside shape
             {
-                collisionPointsReference.SortClosestFirst(cur);
-                for (int j = 0; j < collisionPointsReference.Count; j += 2)
+                intersectionPointsReference.SortClosestFirst(cur);
+                for (int j = 0; j < intersectionPointsReference.Count; j += 2)
                 {
-                    var p1 = collisionPointsReference[j].Point;
-                    var p2 = collisionPointsReference[j + 1].Point;
+                    var p1 = intersectionPointsReference[j].Point;
+                    var p2 = intersectionPointsReference[j + 1].Point;
                     var segment = new Segment(p1, p2);
                     segment.Draw(striped);
                 }
@@ -710,30 +710,30 @@ public static partial class StripedDrawing
             else
             {
                 //remove all intersection points of the outside shape that are inside the inside shape
-                for (int j = collisionPointsReference.Count - 1; j >= 0; j--)
+                for (int j = intersectionPointsReference.Count - 1; j >= 0; j--)
                 {
-                    var p = collisionPointsReference[j].Point;
+                    var p = intersectionPointsReference[j].Point;
                     if (j >= outsideCount) //we are processing the points from the inside shape
                     {
-                        if (!outsideShape.ContainsPoint(p)) collisionPointsReference.RemoveAt(j);
+                        if (!outsideShape.ContainsPoint(p)) intersectionPointsReference.RemoveAt(j);
                     }
                     else // we are processing the points from the outside shape
                     {
-                        if (insideShape.ContainsPoint(p)) collisionPointsReference.RemoveAt(j);
+                        if (insideShape.ContainsPoint(p)) intersectionPointsReference.RemoveAt(j);
                     }
                 }
 
-                collisionPointsReference.SortClosestFirst(cur);
-                for (int j = 0; j < collisionPointsReference.Count; j += 2)
+                intersectionPointsReference.SortClosestFirst(cur);
+                for (int j = 0; j < intersectionPointsReference.Count; j += 2)
                 {
-                    var p1 = collisionPointsReference[j].Point;
-                    var p2 = collisionPointsReference[j + 1].Point;
+                    var p1 = intersectionPointsReference[j].Point;
+                    var p2 = intersectionPointsReference[j + 1].Point;
                     var segment = new Segment(p1, p2);
                     segment.Draw(striped);
                 }
             }
 
-            collisionPointsReference.Clear();
+            intersectionPointsReference.Clear();
 
             cur += dir * spacing;
         }

--- a/ShapeEngine/Geometry/StripedDrawingDef/StripedDrawingQuad.cs
+++ b/ShapeEngine/Geometry/StripedDrawingDef/StripedDrawingQuad.cs
@@ -832,7 +832,7 @@ public static partial class StripedDrawing
                 continue;
             }
 
-            var count = Line.IntersectLinePolygon(cur, lineDir, insideShape, ref collisionPointsReference);
+            var count = Line.IntersectLinePolygon(cur, lineDir, insideShape, ref intersectionPointsReference);
 
             if (count <= 0) //ray did not hit the inside shape, draw ray between edge of the outside shape
             {
@@ -842,45 +842,45 @@ public static partial class StripedDrawing
             else
             {
                 //remove all inside shape intersection points that are outside the outside shape
-                for (int j = collisionPointsReference.Count - 1; j >= 0; j--)
+                for (int j = intersectionPointsReference.Count - 1; j >= 0; j--)
                 {
-                    var p = collisionPointsReference[j].Point;
+                    var p = intersectionPointsReference[j].Point;
 
-                    if (!outsideShape.ContainsPoint(p)) collisionPointsReference.RemoveAt(j);
+                    if (!outsideShape.ContainsPoint(p)) intersectionPointsReference.RemoveAt(j);
                 }
 
-                if (outsideShapePoints.a.Valid && !insideShape.ContainsPoint(outsideShapePoints.a.Point)) collisionPointsReference.Add(outsideShapePoints.a);
-                if (outsideShapePoints.b.Valid && !insideShape.ContainsPoint(outsideShapePoints.b.Point)) collisionPointsReference.Add(outsideShapePoints.b);
+                if (outsideShapePoints.a.Valid && !insideShape.ContainsPoint(outsideShapePoints.a.Point)) intersectionPointsReference.Add(outsideShapePoints.a);
+                if (outsideShapePoints.b.Valid && !insideShape.ContainsPoint(outsideShapePoints.b.Point)) intersectionPointsReference.Add(outsideShapePoints.b);
 
                 //all points were remove so just draw the outside shape segment (even with only 1 point left, we continue)
-                if (collisionPointsReference.Count <= 1)
+                if (intersectionPointsReference.Count <= 1)
                 {
                     cur += dir * spacing;
-                    collisionPointsReference.Clear();
+                    intersectionPointsReference.Clear();
                     continue;
                 }
 
-                if (collisionPointsReference.Count == 2) //no sorting or loop needed for exactly 2 points
+                if (intersectionPointsReference.Count == 2) //no sorting or loop needed for exactly 2 points
                 {
-                    var segment = new Segment(collisionPointsReference[0].Point, collisionPointsReference[1].Point);
+                    var segment = new Segment(intersectionPointsReference[0].Point, intersectionPointsReference[1].Point);
                     segment.Draw(striped);
                     cur += dir * spacing;
-                    collisionPointsReference.Clear();
+                    intersectionPointsReference.Clear();
                     continue;
                 }
 
                 //now that only valid points remain, sort them by distance from the current point
-                collisionPointsReference.SortClosestFirst(cur);
+                intersectionPointsReference.SortClosestFirst(cur);
 
-                for (int j = 0; j < collisionPointsReference.Count - 1; j += 2)
+                for (int j = 0; j < intersectionPointsReference.Count - 1; j += 2)
                 {
-                    var p1 = collisionPointsReference[j].Point;
-                    var p2 = collisionPointsReference[j + 1].Point;
+                    var p1 = intersectionPointsReference[j].Point;
+                    var p2 = intersectionPointsReference[j + 1].Point;
                     var segment = new Segment(p1, p2);
                     segment.Draw(striped);
                 }
 
-                collisionPointsReference.Clear();
+                intersectionPointsReference.Clear();
             }
 
             cur += dir * spacing;

--- a/ShapeEngine/Geometry/StripedDrawingDef/StripedDrawingRect.cs
+++ b/ShapeEngine/Geometry/StripedDrawingDef/StripedDrawingRect.cs
@@ -824,7 +824,7 @@ public static partial class StripedDrawing
                 continue;
             }
 
-            var count = Line.IntersectLinePolygon(cur, lineDir, insideShape, ref collisionPointsReference);
+            var count = Line.IntersectLinePolygon(cur, lineDir, insideShape, ref intersectionPointsReference);
 
             if (count <= 0) //ray did not hit the inside shape, draw ray between edge of the outside shape
             {
@@ -834,45 +834,45 @@ public static partial class StripedDrawing
             else
             {
                 //remove all inside shape intersection points that are outside the outside shape
-                for (int j = collisionPointsReference.Count - 1; j >= 0; j--)
+                for (int j = intersectionPointsReference.Count - 1; j >= 0; j--)
                 {
-                    var p = collisionPointsReference[j].Point;
+                    var p = intersectionPointsReference[j].Point;
 
-                    if (!outsideShape.ContainsPoint(p)) collisionPointsReference.RemoveAt(j);
+                    if (!outsideShape.ContainsPoint(p)) intersectionPointsReference.RemoveAt(j);
                 }
 
-                if (outsideShapePoints.a.Valid && !insideShape.ContainsPoint(outsideShapePoints.a.Point)) collisionPointsReference.Add(outsideShapePoints.a);
-                if (outsideShapePoints.b.Valid && !insideShape.ContainsPoint(outsideShapePoints.b.Point)) collisionPointsReference.Add(outsideShapePoints.b);
+                if (outsideShapePoints.a.Valid && !insideShape.ContainsPoint(outsideShapePoints.a.Point)) intersectionPointsReference.Add(outsideShapePoints.a);
+                if (outsideShapePoints.b.Valid && !insideShape.ContainsPoint(outsideShapePoints.b.Point)) intersectionPointsReference.Add(outsideShapePoints.b);
 
                 //all points were remove so just draw the outside shape segment (even with only 1 point left, we continue)
-                if (collisionPointsReference.Count <= 1)
+                if (intersectionPointsReference.Count <= 1)
                 {
                     cur += dir * spacing;
-                    collisionPointsReference.Clear();
+                    intersectionPointsReference.Clear();
                     continue;
                 }
 
-                if (collisionPointsReference.Count == 2) //no sorting or loop needed for exactly 2 points
+                if (intersectionPointsReference.Count == 2) //no sorting or loop needed for exactly 2 points
                 {
-                    var segment = new Segment(collisionPointsReference[0].Point, collisionPointsReference[1].Point);
+                    var segment = new Segment(intersectionPointsReference[0].Point, intersectionPointsReference[1].Point);
                     segment.Draw(striped);
                     cur += dir * spacing;
-                    collisionPointsReference.Clear();
+                    intersectionPointsReference.Clear();
                     continue;
                 }
 
                 //now that only valid points remain, sort them by distance from the current point
-                collisionPointsReference.SortClosestFirst(cur);
+                intersectionPointsReference.SortClosestFirst(cur);
 
-                for (int j = 0; j < collisionPointsReference.Count - 1; j += 2)
+                for (int j = 0; j < intersectionPointsReference.Count - 1; j += 2)
                 {
-                    var p1 = collisionPointsReference[j].Point;
-                    var p2 = collisionPointsReference[j + 1].Point;
+                    var p1 = intersectionPointsReference[j].Point;
+                    var p2 = intersectionPointsReference[j + 1].Point;
                     var segment = new Segment(p1, p2);
                     segment.Draw(striped);
                 }
 
-                collisionPointsReference.Clear();
+                intersectionPointsReference.Clear();
             }
 
             cur += dir * spacing;

--- a/ShapeEngine/Geometry/StripedDrawingDef/StripedDrawingTriangle.cs
+++ b/ShapeEngine/Geometry/StripedDrawingDef/StripedDrawingTriangle.cs
@@ -834,7 +834,7 @@ public static partial class StripedDrawing
                 continue;
             }
 
-            var count = Line.IntersectLinePolygon(cur, lineDir, insideShape, ref collisionPointsReference);
+            var count = Line.IntersectLinePolygon(cur, lineDir, insideShape, ref intersectionPointsReference);
 
             if (count <= 0) //ray did not hit the inside shape, draw ray between edge of the outside shape
             {
@@ -844,45 +844,45 @@ public static partial class StripedDrawing
             else
             {
                 //remove all inside shape intersection points that are outside the outside shape
-                for (int j = collisionPointsReference.Count - 1; j >= 0; j--)
+                for (int j = intersectionPointsReference.Count - 1; j >= 0; j--)
                 {
-                    var p = collisionPointsReference[j].Point;
+                    var p = intersectionPointsReference[j].Point;
 
-                    if (!outsideShape.ContainsPoint(p)) collisionPointsReference.RemoveAt(j);
+                    if (!outsideShape.ContainsPoint(p)) intersectionPointsReference.RemoveAt(j);
                 }
 
-                if (outsideShapePoints.a.Valid && !insideShape.ContainsPoint(outsideShapePoints.a.Point)) collisionPointsReference.Add(outsideShapePoints.a);
-                if (outsideShapePoints.b.Valid && !insideShape.ContainsPoint(outsideShapePoints.b.Point)) collisionPointsReference.Add(outsideShapePoints.b);
+                if (outsideShapePoints.a.Valid && !insideShape.ContainsPoint(outsideShapePoints.a.Point)) intersectionPointsReference.Add(outsideShapePoints.a);
+                if (outsideShapePoints.b.Valid && !insideShape.ContainsPoint(outsideShapePoints.b.Point)) intersectionPointsReference.Add(outsideShapePoints.b);
 
                 //all points were remove so just draw the outside shape segment (even with only 1 point left, we continue)
-                if (collisionPointsReference.Count <= 1)
+                if (intersectionPointsReference.Count <= 1)
                 {
                     cur += dir * spacing;
-                    collisionPointsReference.Clear();
+                    intersectionPointsReference.Clear();
                     continue;
                 }
 
-                if (collisionPointsReference.Count == 2) //no sorting or loop needed for exactly 2 points
+                if (intersectionPointsReference.Count == 2) //no sorting or loop needed for exactly 2 points
                 {
-                    var segment = new Segment(collisionPointsReference[0].Point, collisionPointsReference[1].Point);
+                    var segment = new Segment(intersectionPointsReference[0].Point, intersectionPointsReference[1].Point);
                     segment.Draw(striped);
                     cur += dir * spacing;
-                    collisionPointsReference.Clear();
+                    intersectionPointsReference.Clear();
                     continue;
                 }
 
                 //now that only valid points remain, sort them by distance from the current point
-                collisionPointsReference.SortClosestFirst(cur);
+                intersectionPointsReference.SortClosestFirst(cur);
 
-                for (int j = 0; j < collisionPointsReference.Count - 1; j += 2)
+                for (int j = 0; j < intersectionPointsReference.Count - 1; j += 2)
                 {
-                    var p1 = collisionPointsReference[j].Point;
-                    var p2 = collisionPointsReference[j + 1].Point;
+                    var p1 = intersectionPointsReference[j].Point;
+                    var p2 = intersectionPointsReference[j + 1].Point;
                     var segment = new Segment(p1, p2);
                     segment.Draw(striped);
                 }
 
-                collisionPointsReference.Clear();
+                intersectionPointsReference.Clear();
             }
 
             cur += dir * spacing;

--- a/ShapeEngine/Geometry/TriangleDef/TriangleClosestPoint.cs
+++ b/ShapeEngine/Geometry/TriangleDef/TriangleClosestPoint.cs
@@ -59,7 +59,7 @@ public readonly partial struct Triangle
     /// This method checks all three edges of the triangle and returns the closest point with its corresponding
     /// surface normal. The normal points outward from the triangle's surface at the closest point.
     /// </remarks>
-    public CollisionPoint GetClosestPoint(Vector2 p, out float disSquared)
+    public IntersectionPoint GetClosestPoint(Vector2 p, out float disSquared)
     {
         var min = Segment.GetClosestPointSegmentPoint(A, B, p, out disSquared);
         var normal = B - A;
@@ -94,7 +94,7 @@ public readonly partial struct Triangle
     /// This method extends the basic closest point functionality by also providing the index of the edge
     /// that contains the closest point, which is useful for edge-specific operations and analysis.
     /// </remarks>
-    public CollisionPoint GetClosestPoint(Vector2 p, out float disSquared, out int index)
+    public IntersectionPoint GetClosestPoint(Vector2 p, out float disSquared, out int index)
     {
         var min = Segment.GetClosestPointSegmentPoint(A, B, p, out disSquared);
         var normal = B - A;
@@ -840,7 +840,7 @@ public readonly partial struct Triangle
     /// This method is useful when you need to know which specific edge of the triangle is closest to a point,
     /// along with the exact closest point on that edge and its surface normal.
     /// </remarks>
-    public (Segment segment, CollisionPoint segmentPoint) GetClosestSegment(Vector2 p, out float disSquared)
+    public (Segment segment, IntersectionPoint segmentPoint) GetClosestSegment(Vector2 p, out float disSquared)
     {
         var closestSegment = SegmentAToB;
         var closestResult = closestSegment.GetClosestPoint(p, out disSquared);

--- a/ShapeEngine/Geometry/TriangleDef/TriangleClosestPoint.cs
+++ b/ShapeEngine/Geometry/TriangleDef/TriangleClosestPoint.cs
@@ -54,7 +54,7 @@ public readonly partial struct Triangle
     /// </summary>
     /// <param name="p">The point to find the closest point to.</param>
     /// <param name="disSquared">When this method returns, contains the squared distance to the closest point.</param>
-    /// <returns>A collision point containing the closest point and its surface normal.</returns>
+    /// <returns>A intersection point containing the closest point and its surface normal.</returns>
     /// <remarks>
     /// This method checks all three edges of the triangle and returns the closest point with its corresponding
     /// surface normal. The normal points outward from the triangle's surface at the closest point.
@@ -89,7 +89,7 @@ public readonly partial struct Triangle
     /// <param name="p">The point to find the closest point to.</param>
     /// <param name="disSquared">When this method returns, contains the squared distance to the closest point.</param>
     /// <param name="index">When this method returns, contains the index of the edge containing the closest point (0=A-B, 1=B-C, 2=C-A).</param>
-    /// <returns>A collision point containing the closest point and its surface normal.</returns>
+    /// <returns>A intersection point containing the closest point and its surface normal.</returns>
     /// <remarks>
     /// This method extends the basic closest point functionality by also providing the index of the edge
     /// that contains the closest point, which is useful for edge-specific operations and analysis.

--- a/ShapeEngine/Geometry/TriangleDef/TriangleIntersectShape.cs
+++ b/ShapeEngine/Geometry/TriangleDef/TriangleIntersectShape.cs
@@ -17,12 +17,12 @@ public readonly partial struct Triangle
     /// Tests for intersection between this triangle and a collider, returning collision points if found.
     /// </summary>
     /// <param name="collider">The collider to test intersection with.</param>
-    /// <returns>A CollisionPoints object containing intersection data if intersections are found; otherwise, null.</returns>
+    /// <returns>A IntersectionPoints object containing intersection data if intersections are found; otherwise, null.</returns>
     /// <remarks>
     /// This method determines the shape type of the collider and delegates to the appropriate
     /// shape-specific intersection method. If the collider is disabled, this method returns null.
     /// </remarks>
-    public CollisionPoints? Intersect(Collider collider)
+    public IntersectionPoints? Intersect(Collider collider)
     {
         if (!collider.Enabled) return null;
 
@@ -64,16 +64,16 @@ public readonly partial struct Triangle
     /// Tests for intersection between this triangle and a collection of line segments.
     /// </summary>
     /// <param name="segments">The collection of segments to test intersection with.</param>
-    /// <returns>A CollisionPoints object containing intersection data if intersections are found; otherwise, null.</returns>
+    /// <returns>A IntersectionPoints object containing intersection data if intersections are found; otherwise, null.</returns>
     /// <remarks>
     /// This method tests intersection with each segment in the collection and combines all intersection points.
     /// </remarks>
-    public CollisionPoints? IntersectShape(Segments segments)
+    public IntersectionPoints? IntersectShape(Segments segments)
     {
         if (segments == null) throw new ArgumentNullException(nameof(segments));
         if (segments.Count <= 0) return null;
 
-        CollisionPoints? points = null;
+        IntersectionPoints? points = null;
 
         foreach (var seg in segments)
         {
@@ -106,14 +106,14 @@ public readonly partial struct Triangle
     /// Tests for intersection between this triangle and a ray.
     /// </summary>
     /// <param name="r">The ray to test intersection with.</param>
-    /// <returns>A CollisionPoints object containing intersection data if intersections are found; otherwise, null.</returns>
+    /// <returns>A IntersectionPoints object containing intersection data if intersections are found; otherwise, null.</returns>
     /// <remarks>
     /// This method checks intersection with the ray against all three edges of the triangle.
     /// A ray can intersect a triangle at most at two points.
     /// </remarks>
-    public CollisionPoints? IntersectShape(Ray r)
+    public IntersectionPoints? IntersectShape(Ray r)
     {
-        CollisionPoints? points = null;
+        IntersectionPoints? points = null;
         var result = Segment.IntersectSegmentRay(A, B, r.Point, r.Direction, r.Normal);
         if (result.Valid)
         {
@@ -142,14 +142,14 @@ public readonly partial struct Triangle
     /// Tests for intersection between this triangle and a line.
     /// </summary>
     /// <param name="l">The line to test intersection with.</param>
-    /// <returns>A CollisionPoints object containing intersection data if intersections are found; otherwise, null.</returns>
+    /// <returns>A IntersectionPoints object containing intersection data if intersections are found; otherwise, null.</returns>
     /// <remarks>
     /// This method checks intersection with the infinite line against all three edges of the triangle.
     /// A line can intersect a triangle at most at two points.
     /// </remarks>
-    public CollisionPoints? IntersectShape(Line l)
+    public IntersectionPoints? IntersectShape(Line l)
     {
-        CollisionPoints? points = null;
+        IntersectionPoints? points = null;
         var result = Segment.IntersectSegmentLine(A, B, l.Point, l.Direction, l.Normal);
         if (result.Valid)
         {
@@ -178,14 +178,14 @@ public readonly partial struct Triangle
     /// Tests for intersection between this triangle and a line segment.
     /// </summary>
     /// <param name="s">The segment to test intersection with.</param>
-    /// <returns>A CollisionPoints object containing intersection data if intersections are found; otherwise, null.</returns>
+    /// <returns>A IntersectionPoints object containing intersection data if intersections are found; otherwise, null.</returns>
     /// <remarks>
     /// This method checks intersection with the line segment against all three edges of the triangle.
     /// A segment can intersect a triangle at most at two points.
     /// </remarks>
-    public CollisionPoints? IntersectShape(Segment s)
+    public IntersectionPoints? IntersectShape(Segment s)
     {
-        CollisionPoints? points = null;
+        IntersectionPoints? points = null;
         var result = Segment.IntersectSegmentSegment(A, B, s.Start, s.End);
         if (result.Valid)
         {
@@ -214,14 +214,14 @@ public readonly partial struct Triangle
     /// Tests for intersection between this triangle and a circle.
     /// </summary>
     /// <param name="c">The circle to test intersection with.</param>
-    /// <returns>A CollisionPoints object containing intersection data if intersections are found; otherwise, null.</returns>
+    /// <returns>A IntersectionPoints object containing intersection data if intersections are found; otherwise, null.</returns>
     /// <remarks>
     /// This method checks intersection with the circle against all three edges of the triangle.
     /// A circle can intersect multiple edges of a triangle, potentially creating many intersection points.
     /// </remarks>
-    public CollisionPoints? IntersectShape(Circle c)
+    public IntersectionPoints? IntersectShape(Circle c)
     {
-        CollisionPoints? points = null;
+        IntersectionPoints? points = null;
         var result = Segment.IntersectSegmentCircle(A, B, c.Center, c.Radius);
         if (result.a.Valid || result.b.Valid)
         {
@@ -253,14 +253,14 @@ public readonly partial struct Triangle
     /// Tests for intersection between this triangle and another triangle.
     /// </summary>
     /// <param name="t">The triangle to test intersection with.</param>
-    /// <returns>A CollisionPoints object containing intersection data if intersections are found; otherwise, null.</returns>
+    /// <returns>A IntersectionPoints object containing intersection data if intersections are found; otherwise, null.</returns>
     /// <remarks>
     /// This method performs a comprehensive intersection test by checking all edges of both triangles
     /// against each other. Two triangles can have complex intersection patterns with multiple points.
     /// </remarks>
-    public CollisionPoints? IntersectShape(Triangle t)
+    public IntersectionPoints? IntersectShape(Triangle t)
     {
-        CollisionPoints? points = null;
+        IntersectionPoints? points = null;
         var result = Segment.IntersectSegmentSegment(A, B, t.A, t.B);
         if (result.Valid)
         {
@@ -332,13 +332,13 @@ public readonly partial struct Triangle
     /// Tests for intersection between this triangle and a rectangle.
     /// </summary>
     /// <param name="r">The rectangle to test intersection with.</param>
-    /// <returns>A CollisionPoints object containing intersection data if intersections are found; otherwise, null.</returns>
+    /// <returns>A IntersectionPoints object containing intersection data if intersections are found; otherwise, null.</returns>
     /// <remarks>
     /// This method checks intersection by testing all triangle edges against all rectangle edges.
     /// </remarks>
-    public CollisionPoints? IntersectShape(Rect r)
+    public IntersectionPoints? IntersectShape(Rect r)
     {
-        CollisionPoints? points = null;
+        IntersectionPoints? points = null;
         var a = r.TopLeft;
         var b = r.BottomLeft;
         var result = Segment.IntersectSegmentSegment(A, B, a, b);
@@ -436,13 +436,13 @@ public readonly partial struct Triangle
     /// Tests for intersection between this triangle and a quadrilateral.
     /// </summary>
     /// <param name="q">The quad to test intersection with.</param>
-    /// <returns>A CollisionPoints object containing intersection data if intersections are found; otherwise, null.</returns>
+    /// <returns>A IntersectionPoints object containing intersection data if intersections are found; otherwise, null.</returns>
     /// <remarks>
     /// This method checks intersection by testing all triangle edges against all quadrilateral edges.
     /// </remarks>
-    public CollisionPoints? IntersectShape(Quad q)
+    public IntersectionPoints? IntersectShape(Quad q)
     {
-        CollisionPoints? points = null;
+        IntersectionPoints? points = null;
         var result = Segment.IntersectSegmentSegment(A, B, q.A, q.B);
         if (result.Valid)
         {
@@ -536,16 +536,16 @@ public readonly partial struct Triangle
     /// Tests for intersection between this triangle and a polygon.
     /// </summary>
     /// <param name="p">The polygon to test intersection with.</param>
-    /// <returns>A CollisionPoints object containing intersection data if intersections are found; otherwise, null.</returns>
+    /// <returns>A IntersectionPoints object containing intersection data if intersections are found; otherwise, null.</returns>
     /// <remarks>
     /// This method checks intersection by testing all triangle edges against all polygon edges.
     /// The polygon can have any number of vertices.
     /// </remarks>
-    public CollisionPoints? IntersectShape(Polygon p)
+    public IntersectionPoints? IntersectShape(Polygon p)
     {
         if (p.Count < 3) return null;
 
-        CollisionPoints? points = null;
+        IntersectionPoints? points = null;
         for (var i = 0; i < p.Count; i++)
         {
             var colPoint = Segment.IntersectSegmentSegment(A, B, p[i], p[(i + 1) % p.Count]);
@@ -577,16 +577,16 @@ public readonly partial struct Triangle
     /// Tests for intersection between this triangle and a polyline.
     /// </summary>
     /// <param name="pl">The polyline to test intersection with.</param>
-    /// <returns>A CollisionPoints object containing intersection data if intersections are found; otherwise, null.</returns>
+    /// <returns>A IntersectionPoints object containing intersection data if intersections are found; otherwise, null.</returns>
     /// <remarks>
     /// This method checks intersection by testing all triangle edges against all polyline segments.
     /// Unlike polygons, polylines are not closed shapes.
     /// </remarks>
-    public CollisionPoints? IntersectShape(Polyline pl)
+    public IntersectionPoints? IntersectShape(Polyline pl)
     {
         if (pl.Count < 2) return null;
 
-        CollisionPoints? points = null;
+        IntersectionPoints? points = null;
         for (var i = 0; i < pl.Count - 1; i++)
         {
             var colPoint = Segment.IntersectSegmentSegment(A, B, pl[i], pl[i + 1]);
@@ -622,10 +622,10 @@ public readonly partial struct Triangle
     /// <param name="returnAfterFirstValid">If true, returns immediately after finding the first valid intersection.</param>
     /// <returns>The number of intersection points found and added to the collection.</returns>
     /// <remarks>
-    /// This performance-optimized method avoids allocating new CollisionPoints objects by reusing an existing collection.
+    /// This performance-optimized method avoids allocating new IntersectionPoints objects by reusing an existing collection.
     /// Useful for high-frequency intersection testing where garbage collection pressure should be minimized.
     /// </remarks>
-    public int Intersect(Collider collider, ref CollisionPoints points, bool returnAfterFirstValid = false)
+    public int Intersect(Collider collider, ref IntersectionPoints points, bool returnAfterFirstValid = false)
     {
         if (!collider.Enabled) return 0;
 
@@ -671,9 +671,9 @@ public readonly partial struct Triangle
     /// <param name="returnAfterFirstValid">If true, returns immediately after finding the first valid intersection.</param>
     /// <returns>The number of intersection points found and added to the collection.</returns>
     /// <remarks>
-    /// This performance-optimized method avoids allocating new CollisionPoints objects.
+    /// This performance-optimized method avoids allocating new IntersectionPoints objects.
     /// </remarks>
-    public int IntersectShape(Ray r, ref CollisionPoints points, bool returnAfterFirstValid = false)
+    public int IntersectShape(Ray r, ref IntersectionPoints points, bool returnAfterFirstValid = false)
     {
         var count = 0;
         var result = Segment.IntersectSegmentRay(A, B, r.Point, r.Direction, r.Normal);
@@ -712,9 +712,9 @@ public readonly partial struct Triangle
     /// <param name="returnAfterFirstValid">If true, returns immediately after finding the first valid intersection.</param>
     /// <returns>The number of intersection points found and added to the collection.</returns>
     /// <remarks>
-    /// This performance-optimized method avoids allocating new CollisionPoints objects.
+    /// This performance-optimized method avoids allocating new IntersectionPoints objects.
     /// </remarks>
-    public int IntersectShape(Line l, ref CollisionPoints points, bool returnAfterFirstValid = false)
+    public int IntersectShape(Line l, ref IntersectionPoints points, bool returnAfterFirstValid = false)
     {
         var count = 0;
         var result = Segment.IntersectSegmentLine(A, B, l.Point, l.Direction, l.Normal);
@@ -753,9 +753,9 @@ public readonly partial struct Triangle
     /// <param name="returnAfterFirstValid">If true, returns immediately after finding the first valid intersection.</param>
     /// <returns>The number of intersection points found and added to the collection.</returns>
     /// <remarks>
-    /// This performance-optimized method avoids allocating new CollisionPoints objects.
+    /// This performance-optimized method avoids allocating new IntersectionPoints objects.
     /// </remarks>
-    public int IntersectShape(Segment s, ref CollisionPoints points, bool returnAfterFirstValid = false)
+    public int IntersectShape(Segment s, ref IntersectionPoints points, bool returnAfterFirstValid = false)
     {
         var count = 0;
         var result = Segment.IntersectSegmentSegment(A, B, s.Start, s.End);
@@ -794,9 +794,9 @@ public readonly partial struct Triangle
     /// <param name="returnAfterFirstValid">If true, returns immediately after finding the first valid intersection.</param>
     /// <returns>The number of intersection points found and added to the collection.</returns>
     /// <remarks>
-    /// This performance-optimized method avoids allocating new CollisionPoints objects.
+    /// This performance-optimized method avoids allocating new IntersectionPoints objects.
     /// </remarks>
-    public int IntersectShape(Circle c, ref CollisionPoints points, bool returnAfterFirstValid = false)
+    public int IntersectShape(Circle c, ref IntersectionPoints points, bool returnAfterFirstValid = false)
     {
         var count = 0;
         var result = Segment.IntersectSegmentCircle(A, B, c.Center, c.Radius);
@@ -854,9 +854,9 @@ public readonly partial struct Triangle
     /// <param name="returnAfterFirstValid">If true, returns immediately after finding the first valid intersection.</param>
     /// <returns>The number of intersection points found and added to the collection.</returns>
     /// <remarks>
-    /// This performance-optimized method avoids allocating new CollisionPoints objects.
+    /// This performance-optimized method avoids allocating new IntersectionPoints objects.
     /// </remarks>
-    public int IntersectShape(Triangle t, ref CollisionPoints points, bool returnAfterFirstValid = false)
+    public int IntersectShape(Triangle t, ref IntersectionPoints points, bool returnAfterFirstValid = false)
     {
         var count = 0;
         var result = Segment.IntersectSegmentSegment(A, B, t.A, t.B);
@@ -942,9 +942,9 @@ public readonly partial struct Triangle
     /// <param name="returnAfterFirstValid">If true, returns immediately after finding the first valid intersection.</param>
     /// <returns>The number of intersection points found and added to the collection.</returns>
     /// <remarks>
-    /// This performance-optimized method avoids allocating new CollisionPoints objects.
+    /// This performance-optimized method avoids allocating new IntersectionPoints objects.
     /// </remarks>
-    public int IntersectShape(Quad q, ref CollisionPoints points, bool returnAfterFirstValid = false)
+    public int IntersectShape(Quad q, ref IntersectionPoints points, bool returnAfterFirstValid = false)
     {
         var count = 0;
         var result = Segment.IntersectSegmentSegment(A, B, q.A, q.B);
@@ -1055,9 +1055,9 @@ public readonly partial struct Triangle
     /// <param name="returnAfterFirstValid">If true, returns immediately after finding the first valid intersection.</param>
     /// <returns>The number of intersection points found and added to the collection.</returns>
     /// <remarks>
-    /// This performance-optimized method avoids allocating new CollisionPoints objects.
+    /// This performance-optimized method avoids allocating new IntersectionPoints objects.
     /// </remarks>
-    public int IntersectShape(Rect r, ref CollisionPoints points, bool returnAfterFirstValid = false)
+    public int IntersectShape(Rect r, ref IntersectionPoints points, bool returnAfterFirstValid = false)
     {
         var count = 0;
         var a = r.TopLeft;
@@ -1172,9 +1172,9 @@ public readonly partial struct Triangle
     /// <param name="returnAfterFirstValid">If true, returns immediately after finding the first valid intersection.</param>
     /// <returns>The number of intersection points found and added to the collection.</returns>
     /// <remarks>
-    /// This performance-optimized method avoids allocating new CollisionPoints objects.
+    /// This performance-optimized method avoids allocating new IntersectionPoints objects.
     /// </remarks>
-    public int IntersectShape(Polygon p, ref CollisionPoints points, bool returnAfterFirstValid = false)
+    public int IntersectShape(Polygon p, ref IntersectionPoints points, bool returnAfterFirstValid = false)
     {
         if (p.Count < 3) return 0;
 
@@ -1217,9 +1217,9 @@ public readonly partial struct Triangle
     /// <param name="returnAfterFirstValid">If true, returns immediately after finding the first valid intersection.</param>
     /// <returns>The number of intersection points found and added to the collection.</returns>
     /// <remarks>
-    /// This performance-optimized method avoids allocating new CollisionPoints objects.
+    /// This performance-optimized method avoids allocating new IntersectionPoints objects.
     /// </remarks>
-    public int IntersectShape(Polyline pl, ref CollisionPoints points, bool returnAfterFirstValid = false)
+    public int IntersectShape(Polyline pl, ref IntersectionPoints points, bool returnAfterFirstValid = false)
     {
         if (pl.Count < 2) return 0;
 
@@ -1262,10 +1262,10 @@ public readonly partial struct Triangle
     /// <param name="returnAfterFirstValid">If true, returns immediately after finding the first valid intersection.</param>
     /// <returns>The number of intersection points found and added to the collection.</returns>
     /// <remarks>
-    /// This performance-optimized method avoids allocating new CollisionPoints objects by reusing an existing collection.
+    /// This performance-optimized method avoids allocating new IntersectionPoints objects by reusing an existing collection.
     /// Useful for high-frequency intersection testing where garbage collection pressure should be minimized.
     /// </remarks>
-    public int IntersectShape(Segments shape, ref CollisionPoints points, bool returnAfterFirstValid = false)
+    public int IntersectShape(Segments shape, ref IntersectionPoints points, bool returnAfterFirstValid = false)
     {
         if (shape.Count <= 0) return 0;
 

--- a/ShapeEngine/Geometry/TriangulationDef/TriangulationClosestPoint.cs
+++ b/ShapeEngine/Geometry/TriangulationDef/TriangulationClosestPoint.cs
@@ -27,7 +27,7 @@ public partial class Triangulation
     {
         if (Count <= 0) return new();
 
-        var closestPoint = new CollisionPoint();
+        var closestPoint = new IntersectionPoint();
         var disSquared = -1f;
         var triangleIndex = -1;
 
@@ -44,7 +44,7 @@ public partial class Triangulation
             }
         }
 
-        return new(closestPoint, new CollisionPoint(p, (closestPoint.Point - p).Normalize()), disSquared, triangleIndex);
+        return new(closestPoint, new IntersectionPoint(p, (closestPoint.Point - p).Normalize()), disSquared, triangleIndex);
     }
 
     /// <summary>
@@ -53,9 +53,9 @@ public partial class Triangulation
     /// <param name="p">The point to which the closest triangle is sought.</param>
     /// <param name="disSquared">The squared distance to the closest point.</param>
     /// <param name="triangleIndex">The index of the closest triangle in the triangulation.</param>
-    /// <returns>A tuple containing the closest <see cref="CollisionPoint"/> and the corresponding <see cref="Triangle"/>.</returns>
+    /// <returns>A tuple containing the closest <see cref="IntersectionPoint"/> and the corresponding <see cref="Triangle"/>.</returns>
     /// <remarks>If the triangulation is empty, returns default values.</remarks>
-    public (CollisionPoint point, Triangle triangle) GetClosestTriangle(Vector2 p, out float disSquared, out int triangleIndex)
+    public (IntersectionPoint point, Triangle triangle) GetClosestTriangle(Vector2 p, out float disSquared, out int triangleIndex)
     {
         disSquared = -1;
         triangleIndex = -1;
@@ -63,7 +63,7 @@ public partial class Triangulation
 
         var closestTriangle = new Triangle();
         var contained = false;
-        var closestPoint = new CollisionPoint();
+        var closestPoint = new IntersectionPoint();
 
         for (var i = 0; i < Count; i++)
         {
@@ -103,9 +103,9 @@ public partial class Triangulation
     /// <param name="triangles">The list of triangles to search.</param>
     /// <param name="p">The point to which the closest point is sought.</param>
     /// <param name="disSquared">The squared distance to the closest point.</param>
-    /// <returns>The <see cref="CollisionPoint"/> in the triangles closest to the specified point.</returns>
-    /// <remarks>If the list is empty, returns a default <see cref="CollisionPoint"/>.</remarks>
-    public static CollisionPoint GetClosestPointTriangulationPoint(List<Triangle> triangles, Vector2 p, out float disSquared)
+    /// <returns>The <see cref="IntersectionPoint"/> in the triangles closest to the specified point.</returns>
+    /// <remarks>If the list is empty, returns a default <see cref="IntersectionPoint"/>.</remarks>
+    public static IntersectionPoint GetClosestPointTriangulationPoint(List<Triangle> triangles, Vector2 p, out float disSquared)
     {
         disSquared = -1;
         if (triangles.Count <= 0) return new();
@@ -132,9 +132,9 @@ public partial class Triangulation
     /// </summary>
     /// <param name="p">The point to which the closest point is sought.</param>
     /// <param name="disSquared">The squared distance to the closest point.</param>
-    /// <returns>The closest <see cref="CollisionPoint"/> in the triangulation to the specified point.</returns>
-    /// <remarks>If the triangulation is empty, returns a default <see cref="CollisionPoint"/>.</remarks>
-    public CollisionPoint GetClosestPoint(Vector2 p, out float disSquared)
+    /// <returns>The closest <see cref="IntersectionPoint"/> in the triangulation to the specified point.</returns>
+    /// <remarks>If the triangulation is empty, returns a default <see cref="IntersectionPoint"/>.</remarks>
+    public IntersectionPoint GetClosestPoint(Vector2 p, out float disSquared)
     {
         disSquared = -1;
         if (Count <= 0) return new();
@@ -164,9 +164,9 @@ public partial class Triangulation
     /// <param name="disSquared">The squared distance to the closest point.</param>
     /// <param name="triangleIndex">The index of the closest triangle in the triangulation.</param>
     /// <param name="segmentIndex">The index of the closest segment in the triangle.</param>
-    /// <returns>The closest <see cref="CollisionPoint"/> in the triangulation to the specified point.</returns>
-    /// <remarks>If the triangulation is empty, returns a default <see cref="CollisionPoint"/>.</remarks>
-    public CollisionPoint GetClosestPoint(Vector2 p, out float disSquared, out int triangleIndex, out int segmentIndex)
+    /// <returns>The closest <see cref="IntersectionPoint"/> in the triangulation to the specified point.</returns>
+    /// <remarks>If the triangulation is empty, returns a default <see cref="IntersectionPoint"/>.</remarks>
+    public IntersectionPoint GetClosestPoint(Vector2 p, out float disSquared, out int triangleIndex, out int segmentIndex)
     {
         disSquared = -1;
         triangleIndex = -1;
@@ -527,9 +527,9 @@ public partial class Triangulation
     /// <param name="p">The point to which the closest segment is sought.</param>
     /// <param name="disSquared">The squared distance to the closest segment.</param>
     /// <param name="triangleIndex">The index of the triangle containing the closest segment.</param>
-    /// <returns>A tuple containing the closest <see cref="Segment"/> and the corresponding <see cref="CollisionPoint"/>.</returns>
+    /// <returns>A tuple containing the closest <see cref="Segment"/> and the corresponding <see cref="IntersectionPoint"/>.</returns>
     /// <remarks>If the triangulation is empty, returns default values.</remarks>
-    public (Segment segment, CollisionPoint segmentPoint) GetClosestSegment(Vector2 p, out float disSquared, out int triangleIndex)
+    public (Segment segment, IntersectionPoint segmentPoint) GetClosestSegment(Vector2 p, out float disSquared, out int triangleIndex)
     {
         triangleIndex = -1;
         disSquared = -1f;

--- a/ShapeEngine/Geometry/TriangulationDef/TriangulationIntersectShape.cs
+++ b/ShapeEngine/Geometry/TriangulationDef/TriangulationIntersectShape.cs
@@ -19,11 +19,11 @@ public partial class Triangulation
     /// Checks for intersections between the triangles in this triangulation and the specified collider.
     /// </summary>
     /// <param name="collider">The collider to check for intersections.</param>
-    /// <returns>A dictionary mapping the index of each intersecting triangle to the resulting <see cref="CollisionPoints"/>. Returns <c>null</c> if no intersections are found.</returns>
+    /// <returns>A dictionary mapping the index of each intersecting triangle to the resulting <see cref="IntersectionPoints"/>. Returns <c>null</c> if no intersections are found.</returns>
     /// <remarks>Only triangles with valid intersections are included in the result.</remarks>
-    public Dictionary<int, CollisionPoints>? Intersect(Collider collider)
+    public Dictionary<int, IntersectionPoints>? Intersect(Collider collider)
     {
-        Dictionary<int, CollisionPoints>? result = null;
+        Dictionary<int, IntersectionPoints>? result = null;
         for (int i = 0; i < Count; i++)
         {
             var tri = this[i];
@@ -42,11 +42,11 @@ public partial class Triangulation
     /// Checks for intersections between the triangles in this triangulation and the specified line.
     /// </summary>
     /// <param name="shape">The line to check for intersections.</param>
-    /// <returns>A dictionary mapping the index of each intersecting triangle to the resulting <see cref="CollisionPoints"/>. Returns <c>null</c> if no intersections are found.</returns>
+    /// <returns>A dictionary mapping the index of each intersecting triangle to the resulting <see cref="IntersectionPoints"/>. Returns <c>null</c> if no intersections are found.</returns>
     /// <remarks>Only triangles with valid intersections are included in the result.</remarks>
-    public Dictionary<int, CollisionPoints>? IntersectShape(Line shape)
+    public Dictionary<int, IntersectionPoints>? IntersectShape(Line shape)
     {
-        Dictionary<int, CollisionPoints>? result = null;
+        Dictionary<int, IntersectionPoints>? result = null;
         for (int i = 0; i < Count; i++)
         {
             var tri = this[i];
@@ -65,11 +65,11 @@ public partial class Triangulation
     /// Checks for intersections between the triangles in this triangulation and the specified ray.
     /// </summary>
     /// <param name="shape">The ray to check for intersections.</param>
-    /// <returns>A dictionary mapping the index of each intersecting triangle to the resulting <see cref="CollisionPoints"/>. Returns <c>null</c> if no intersections are found.</returns>
+    /// <returns>A dictionary mapping the index of each intersecting triangle to the resulting <see cref="IntersectionPoints"/>. Returns <c>null</c> if no intersections are found.</returns>
     /// <remarks>Only triangles with valid intersections are included in the result.</remarks>
-    public Dictionary<int, CollisionPoints>? IntersectShape(Ray shape)
+    public Dictionary<int, IntersectionPoints>? IntersectShape(Ray shape)
     {
-        Dictionary<int, CollisionPoints>? result = null;
+        Dictionary<int, IntersectionPoints>? result = null;
         for (int i = 0; i < Count; i++)
         {
             var tri = this[i];
@@ -88,11 +88,11 @@ public partial class Triangulation
     /// Checks for intersections between the triangles in this triangulation and the specified segment.
     /// </summary>
     /// <param name="shape">The segment to check for intersections.</param>
-    /// <returns>A dictionary mapping the index of each intersecting triangle to the resulting <see cref="CollisionPoints"/>. Returns <c>null</c> if no intersections are found.</returns>
+    /// <returns>A dictionary mapping the index of each intersecting triangle to the resulting <see cref="IntersectionPoints"/>. Returns <c>null</c> if no intersections are found.</returns>
     /// <remarks>Only triangles with valid intersections are included in the result.</remarks>
-    public Dictionary<int, CollisionPoints>? IntersectShape(Segment shape)
+    public Dictionary<int, IntersectionPoints>? IntersectShape(Segment shape)
     {
-        Dictionary<int, CollisionPoints>? result = null;
+        Dictionary<int, IntersectionPoints>? result = null;
         for (int i = 0; i < Count; i++)
         {
             var tri = this[i];
@@ -111,11 +111,11 @@ public partial class Triangulation
     /// Checks for intersections between the triangles in this triangulation and the specified circle.
     /// </summary>
     /// <param name="shape">The circle to check for intersections.</param>
-    /// <returns>A dictionary mapping the index of each intersecting triangle to the resulting <see cref="CollisionPoints"/>. Returns <c>null</c> if no intersections are found.</returns>
+    /// <returns>A dictionary mapping the index of each intersecting triangle to the resulting <see cref="IntersectionPoints"/>. Returns <c>null</c> if no intersections are found.</returns>
     /// <remarks>Only triangles with valid intersections are included in the result.</remarks>
-    public Dictionary<int, CollisionPoints>? IntersectShape(Circle shape)
+    public Dictionary<int, IntersectionPoints>? IntersectShape(Circle shape)
     {
-        Dictionary<int, CollisionPoints>? result = null;
+        Dictionary<int, IntersectionPoints>? result = null;
         for (int i = 0; i < Count; i++)
         {
             var tri = this[i];
@@ -134,11 +134,11 @@ public partial class Triangulation
     /// Checks for intersections between the triangles in this triangulation and the specified triangle.
     /// </summary>
     /// <param name="shape">The triangle to check for intersections.</param>
-    /// <returns>A dictionary mapping the index of each intersecting triangle to the resulting <see cref="CollisionPoints"/>. Returns <c>null</c> if no intersections are found.</returns>
+    /// <returns>A dictionary mapping the index of each intersecting triangle to the resulting <see cref="IntersectionPoints"/>. Returns <c>null</c> if no intersections are found.</returns>
     /// <remarks>Only triangles with valid intersections are included in the result.</remarks>
-    public Dictionary<int, CollisionPoints>? IntersectShape(Triangle shape)
+    public Dictionary<int, IntersectionPoints>? IntersectShape(Triangle shape)
     {
-        Dictionary<int, CollisionPoints>? result = null;
+        Dictionary<int, IntersectionPoints>? result = null;
         for (int i = 0; i < Count; i++)
         {
             var tri = this[i];
@@ -157,11 +157,11 @@ public partial class Triangulation
     /// Checks for intersections between the triangles in this triangulation and the specified rectangle.
     /// </summary>
     /// <param name="shape">The rectangle to check for intersections.</param>
-    /// <returns>A dictionary mapping the index of each intersecting triangle to the resulting <see cref="CollisionPoints"/>. Returns <c>null</c> if no intersections are found.</returns>
+    /// <returns>A dictionary mapping the index of each intersecting triangle to the resulting <see cref="IntersectionPoints"/>. Returns <c>null</c> if no intersections are found.</returns>
     /// <remarks>Only triangles with valid intersections are included in the result.</remarks>
-    public Dictionary<int, CollisionPoints>? IntersectShape(Rect shape)
+    public Dictionary<int, IntersectionPoints>? IntersectShape(Rect shape)
     {
-        Dictionary<int, CollisionPoints>? result = null;
+        Dictionary<int, IntersectionPoints>? result = null;
         for (int i = 0; i < Count; i++)
         {
             var tri = this[i];
@@ -180,11 +180,11 @@ public partial class Triangulation
     /// Checks for intersections between the triangles in this triangulation and the specified quad.
     /// </summary>
     /// <param name="shape">The quad to check for intersections.</param>
-    /// <returns>A dictionary mapping the index of each intersecting triangle to the resulting <see cref="CollisionPoints"/>. Returns <c>null</c> if no intersections are found.</returns>
+    /// <returns>A dictionary mapping the index of each intersecting triangle to the resulting <see cref="IntersectionPoints"/>. Returns <c>null</c> if no intersections are found.</returns>
     /// <remarks>Only triangles with valid intersections are included in the result.</remarks>
-    public Dictionary<int, CollisionPoints>? IntersectShape(Quad shape)
+    public Dictionary<int, IntersectionPoints>? IntersectShape(Quad shape)
     {
-        Dictionary<int, CollisionPoints>? result = null;
+        Dictionary<int, IntersectionPoints>? result = null;
         for (int i = 0; i < Count; i++)
         {
             var tri = this[i];
@@ -203,11 +203,11 @@ public partial class Triangulation
     /// Checks for intersections between the triangles in this triangulation and the specified polygon.
     /// </summary>
     /// <param name="shape">The polygon to check for intersections.</param>
-    /// <returns>A dictionary mapping the index of each intersecting triangle to the resulting <see cref="CollisionPoints"/>. Returns <c>null</c> if no intersections are found.</returns>
+    /// <returns>A dictionary mapping the index of each intersecting triangle to the resulting <see cref="IntersectionPoints"/>. Returns <c>null</c> if no intersections are found.</returns>
     /// <remarks>Only triangles with valid intersections are included in the result.</remarks>
-    public Dictionary<int, CollisionPoints>? IntersectShape(Polygon shape)
+    public Dictionary<int, IntersectionPoints>? IntersectShape(Polygon shape)
     {
-        Dictionary<int, CollisionPoints>? result = null;
+        Dictionary<int, IntersectionPoints>? result = null;
         for (int i = 0; i < Count; i++)
         {
             var tri = this[i];
@@ -226,11 +226,11 @@ public partial class Triangulation
     /// Checks for intersections between the triangles in this triangulation and the specified polyline.
     /// </summary>
     /// <param name="shape">The polyline to check for intersections.</param>
-    /// <returns>A dictionary mapping the index of each intersecting triangle to the resulting <see cref="CollisionPoints"/>. Returns <c>null</c> if no intersections are found.</returns>
+    /// <returns>A dictionary mapping the index of each intersecting triangle to the resulting <see cref="IntersectionPoints"/>. Returns <c>null</c> if no intersections are found.</returns>
     /// <remarks>Only triangles with valid intersections are included in the result.</remarks>
-    public Dictionary<int, CollisionPoints>? IntersectShape(Polyline shape)
+    public Dictionary<int, IntersectionPoints>? IntersectShape(Polyline shape)
     {
-        Dictionary<int, CollisionPoints>? result = null;
+        Dictionary<int, IntersectionPoints>? result = null;
         for (int i = 0; i < Count; i++)
         {
             var tri = this[i];
@@ -249,11 +249,11 @@ public partial class Triangulation
     /// Checks for intersections between the triangles in this triangulation and the specified segments.
     /// </summary>
     /// <param name="shape">The segments to check for intersections.</param>
-    /// <returns>A dictionary mapping the index of each intersecting triangle to the resulting <see cref="CollisionPoints"/>. Returns <c>null</c> if no intersections are found.</returns>
+    /// <returns>A dictionary mapping the index of each intersecting triangle to the resulting <see cref="IntersectionPoints"/>. Returns <c>null</c> if no intersections are found.</returns>
     /// <remarks>Only triangles with valid intersections are included in the result.</remarks>
-    public Dictionary<int, CollisionPoints>? IntersectShape(Segments shape)
+    public Dictionary<int, IntersectionPoints>? IntersectShape(Segments shape)
     {
-        Dictionary<int, CollisionPoints>? result = null;
+        Dictionary<int, IntersectionPoints>? result = null;
         for (int i = 0; i < Count; i++)
         {
             var tri = this[i];


### PR DESCRIPTION
## Summary

This PR renames `CollisionPoint` to `IntersectionPoint` throughout the codebase. The original name reflected its use in collision response logic; however, as the codebase evolved, this structure began serving a broader purpose—representing points where shapes intersect in a variety of contexts, not limited to collisions. The new name, `IntersectionPoint`, more clearly describes its general role, improves readability, and reduces ambiguity for future maintainers.

**Benefits:**
- More accurate and descriptive naming for current and future usage
- Improves clarity and maintainability of the code
- Reduces confusion for contributors unfamiliar with the original intent

_No functional changes are introduced; this is a pure refactor focused on naming consistency._

### Commits:
- Refactor: CollisionPoint and CollisionPoints renamed to IntersectionPoint and IntersectionPoints. (e626844cd94589bbdaae79a6786b554c201d1432)