### PR TITLE
Shape fixes

### DIFF
--- a/ShapeEngine/Geometry/CircleDef/CircleClosestPoint.cs
+++ b/ShapeEngine/Geometry/CircleDef/CircleClosestPoint.cs
@@ -15,6 +15,56 @@ namespace ShapeEngine.Geometry.CircleDef;
 
 public readonly partial struct Circle
 {
+        /// <summary>
+    /// Finds the closest point on the circle's perimeter to any collider in the given collision object.
+    /// </summary>
+    /// <param name="collisionObject">The collision object containing one or more colliders to compare against.</param>
+    /// <returns>
+    /// A <see cref="ClosestPointResult"/> containing the closest point information for the nearest collider.
+    /// </returns>
+    public ClosestPointResult GetClosestPoint(CollisionObject collisionObject)
+    {
+        if (!collisionObject.HasColliders) return new();
+        var closestPoint = new ClosestPointResult();
+        foreach (var collider in collisionObject.Colliders)
+        {
+            var result = GetClosestPoint(collider);
+            if(!result.Valid) continue;
+            if (!closestPoint.Valid) closestPoint = result;
+            else
+            {
+                if (result.DistanceSquared < closestPoint.DistanceSquared) closestPoint = result;
+            }
+        }
+        return closestPoint;
+    }
+  
+    /// <summary>
+    /// Finds the closest point on this circle's perimeter to the given collider.
+    /// </summary>
+    /// <param name="collider">The collider to compare against.</param>
+    /// <returns>
+    /// A <see cref="ClosestPointResult"/> containing the closest point information for the collider.
+    /// </returns>
+    public ClosestPointResult GetClosestPoint(Collider collider)
+    {
+        if (!collider.Enabled) return new();
+        switch (collider.GetShapeType())
+        {
+            case ShapeType.Line: return GetClosestPoint(collider.GetLineShape());
+            case ShapeType.Ray: return GetClosestPoint(collider.GetRayShape());
+            case ShapeType.Circle: return GetClosestPoint(collider.GetCircleShape());
+            case ShapeType.Segment: return GetClosestPoint(collider.GetSegmentShape());
+            case ShapeType.Triangle: return GetClosestPoint(collider.GetTriangleShape());
+            case ShapeType.Rect: return GetClosestPoint(collider.GetRectShape());
+            case ShapeType.Quad: return GetClosestPoint(collider.GetQuadShape());
+            case ShapeType.Poly: return GetClosestPoint(collider.GetPolygonShape());
+            case ShapeType.PolyLine: return GetClosestPoint(collider.GetPolylineShape());
+        }
+
+        return new();
+    }
+    
     /// <summary>
     /// Gets the closest point on the circle to a given point.
     /// </summary>

--- a/ShapeEngine/Geometry/CircleDef/CircleContains.cs
+++ b/ShapeEngine/Geometry/CircleDef/CircleContains.cs
@@ -130,6 +130,7 @@ public readonly partial struct Circle
     /// <returns><c>true</c> if the collider is inside the circle; otherwise, <c>false</c>.</returns>
     public bool ContainsCollider(Collider collider)
     {
+        if (!collider.Enabled) return false;
         switch (collider.GetShapeType())
         {
             case ShapeType.Circle: return ContainsShape(collider.GetCircleShape());

--- a/ShapeEngine/Geometry/CircleDef/CircleIntersectShape.cs
+++ b/ShapeEngine/Geometry/CircleDef/CircleIntersectShape.cs
@@ -14,6 +14,28 @@ namespace ShapeEngine.Geometry.CircleDef;
 public readonly partial struct Circle
 {
     /// <summary>
+    /// Computes intersection points between this circle and all colliders in the specified <see cref="CollisionObject"/>.
+    /// </summary>
+    /// <param name="collisionObject">The collision object containing colliders to test for intersection.</param>
+    /// <returns>
+    /// A <see cref="Dictionary{Collider, IntersectionPoints}"/> mapping each collider to its intersection points,
+    /// or null if no colliders are present or no intersections are found.
+    /// </returns>
+    public Dictionary<Collider, IntersectionPoints>? Intersect(CollisionObject collisionObject)
+    {
+        if (!collisionObject.HasColliders) return null;
+
+        Dictionary<Collider, IntersectionPoints>? intersections = null;
+        foreach (var collider in collisionObject.Colliders)
+        {
+            var result = Intersect(collider);
+            if(result == null) continue;
+            intersections ??= new();
+            intersections.Add(collider, result);
+        }
+        return intersections;
+    }
+    /// <summary>
     /// Calculates the intersection points between this circle and a collider.
     /// </summary>
     /// <param name="collider">The collider to test for intersection. Can represent various shapes.</param>

--- a/ShapeEngine/Geometry/CircleDef/CircleOverlap.cs
+++ b/ShapeEngine/Geometry/CircleDef/CircleOverlap.cs
@@ -15,6 +15,21 @@ namespace ShapeEngine.Geometry.CircleDef;
 public readonly partial struct Circle
 {
     /// <summary>
+    /// Checks if the circle overlaps with any collider in the given <see cref="CollisionObject"/>.
+    /// </summary>
+    /// <param name="collision">The collision object containing colliders to check for overlap.</param>
+    /// <returns>True if any collider in the collision object overlaps the circle; otherwise, false.</returns>
+    public bool Overlap(CollisionObject collision)
+    {
+        if (!collision.HasColliders) return false;
+        foreach (var collider in collision.Colliders)
+        {
+            if(Overlap(collider)) return true;
+        }
+
+        return false;
+    }
+    /// <summary>
     /// Determines whether this circle overlaps with the specified collider.
     /// </summary>
     /// <param name="collider">The collider to test for overlap with this circle.

--- a/ShapeEngine/Geometry/LineDef/LineClosestPoint.cs
+++ b/ShapeEngine/Geometry/LineDef/LineClosestPoint.cs
@@ -16,6 +16,56 @@ namespace ShapeEngine.Geometry.LineDef;
 public readonly partial struct Line
 {
     /// <summary>
+    /// Finds the closest point on the Line's perimeter to any collider in the given collision object.
+    /// </summary>
+    /// <param name="collisionObject">The collision object containing one or more colliders to compare against.</param>
+    /// <returns>
+    /// A <see cref="ClosestPointResult"/> containing the closest point information for the nearest collider.
+    /// </returns>
+    public ClosestPointResult GetClosestPoint(CollisionObject collisionObject)
+    {
+        if (!collisionObject.HasColliders) return new();
+        var closestPoint = new ClosestPointResult();
+        foreach (var collider in collisionObject.Colliders)
+        {
+            var result = GetClosestPoint(collider);
+            if(!result.Valid) continue;
+            if (!closestPoint.Valid) closestPoint = result;
+            else
+            {
+                if (result.DistanceSquared < closestPoint.DistanceSquared) closestPoint = result;
+            }
+        }
+        return closestPoint;
+    }
+  
+    /// <summary>
+    /// Finds the closest point on this Line's perimeter to the given collider.
+    /// </summary>
+    /// <param name="collider">The collider to compare against.</param>
+    /// <returns>
+    /// A <see cref="ClosestPointResult"/> containing the closest point information for the collider.
+    /// </returns>
+    public ClosestPointResult GetClosestPoint(Collider collider)
+    {
+        if (!collider.Enabled) return new();
+        switch (collider.GetShapeType())
+        {
+            case ShapeType.Line: return GetClosestPoint(collider.GetLineShape());
+            case ShapeType.Ray: return GetClosestPoint(collider.GetRayShape());
+            case ShapeType.Circle: return GetClosestPoint(collider.GetCircleShape());
+            case ShapeType.Segment: return GetClosestPoint(collider.GetSegmentShape());
+            case ShapeType.Triangle: return GetClosestPoint(collider.GetTriangleShape());
+            case ShapeType.Rect: return GetClosestPoint(collider.GetRectShape());
+            case ShapeType.Quad: return GetClosestPoint(collider.GetQuadShape());
+            case ShapeType.Poly: return GetClosestPoint(collider.GetPolygonShape());
+            case ShapeType.PolyLine: return GetClosestPoint(collider.GetPolylineShape());
+        }
+
+        return new();
+    }
+    
+    /// <summary>
     /// Calculates the closest point on this line to a given point in 2D space.
     /// </summary>
     /// <param name="point">The point from which the closest point on the line is sought.</param>

--- a/ShapeEngine/Geometry/LineDef/LineIntersectShape.cs
+++ b/ShapeEngine/Geometry/LineDef/LineIntersectShape.cs
@@ -14,6 +14,77 @@ namespace ShapeEngine.Geometry.LineDef;
 public readonly partial struct Line
 {
     /// <summary>
+    /// Computes intersection points between this line and all colliders in the specified <see cref="CollisionObject"/>.
+    /// </summary>
+    /// <param name="collisionObject">The collision object containing colliders to test for intersection.</param>
+    /// <returns>
+    /// A <see cref="Dictionary{Collider, IntersectionPoints}"/> mapping each collider to its intersection points,
+    /// or null if no colliders are present or no intersections are found.
+    /// </returns>
+    public Dictionary<Collider, IntersectionPoints>? Intersect(CollisionObject collisionObject)
+    {
+        if (!collisionObject.HasColliders) return null;
+
+        Dictionary<Collider, IntersectionPoints>? intersections = null;
+        foreach (var collider in collisionObject.Colliders)
+        {
+            var result = Intersect(collider);
+            if(result == null) continue;
+            intersections ??= new();
+            intersections.Add(collider, result);
+        }
+        return intersections;
+    }
+    
+    /// <summary>
+    /// Computes the intersection points between this line and a collider shape, if any.
+    /// </summary>
+    /// <param name="collider">The <see cref="Collider"/> whose shape will be checked for intersection with this line.</param>
+    /// <returns>
+    /// A <see cref="IntersectionPoints"/> object containing the intersection points, or null if no intersections exist or the collider is disabled.
+    /// </returns>
+    /// <remarks>
+    /// The function dispatches to the appropriate intersection method based on the collider's shape type.
+    /// </remarks>
+    public IntersectionPoints? Intersect(Collider collider)
+    {
+        if (!collider.Enabled) return null;
+
+        switch (collider.GetShapeType())
+        {
+            case ShapeType.Circle:
+                var c = collider.GetCircleShape();
+                return IntersectShape(c);
+            case ShapeType.Ray:
+                var rayShape = collider.GetRayShape();
+                return IntersectShape(rayShape);
+            case ShapeType.Line:
+                var l = collider.GetLineShape();
+                return IntersectShape(l);
+            case ShapeType.Segment:
+                var s = collider.GetSegmentShape();
+                return IntersectShape(s);
+            case ShapeType.Triangle:
+                var t = collider.GetTriangleShape();
+                return IntersectShape(t);
+            case ShapeType.Rect:
+                var r = collider.GetRectShape();
+                return IntersectShape(r);
+            case ShapeType.Quad:
+                var q = collider.GetQuadShape();
+                return IntersectShape(q);
+            case ShapeType.Poly:
+                var p = collider.GetPolygonShape();
+                return IntersectShape(p);
+            case ShapeType.PolyLine:
+                var pl = collider.GetPolylineShape();
+                return IntersectShape(pl);
+        }
+
+        return null;
+    }
+    
+    /// <summary>
     /// Computes the intersection points between this line and a <see cref="Segment"/> shape.
     /// </summary>
     /// <param name="segment">The <see cref="Segment"/> to check for intersection.</param>

--- a/ShapeEngine/Geometry/LineDef/LineIntersection.cs
+++ b/ShapeEngine/Geometry/LineDef/LineIntersection.cs
@@ -249,52 +249,6 @@ public readonly partial struct Line
     public IntersectionPoints? IntersectSegments(Segments segments, int maxCollisionPoints = -1) =>
         IntersectLineSegments(Point, Direction, segments, maxCollisionPoints);
 
-    /// <summary>
-    /// Computes the intersection points between this line and a collider shape, if any.
-    /// </summary>
-    /// <param name="collider">The <see cref="Collider"/> whose shape will be checked for intersection with this line.</param>
-    /// <returns>
-    /// A <see cref="IntersectionPoints"/> object containing the intersection points, or null if no intersections exist or the collider is disabled.
-    /// </returns>
-    /// <remarks>
-    /// The function dispatches to the appropriate intersection method based on the collider's shape type.
-    /// </remarks>
-    public IntersectionPoints? Intersect(Collider collider)
-    {
-        if (!collider.Enabled) return null;
-
-        switch (collider.GetShapeType())
-        {
-            case ShapeType.Circle:
-                var c = collider.GetCircleShape();
-                return IntersectShape(c);
-            case ShapeType.Ray:
-                var rayShape = collider.GetRayShape();
-                return IntersectShape(rayShape);
-            case ShapeType.Line:
-                var l = collider.GetLineShape();
-                return IntersectShape(l);
-            case ShapeType.Segment:
-                var s = collider.GetSegmentShape();
-                return IntersectShape(s);
-            case ShapeType.Triangle:
-                var t = collider.GetTriangleShape();
-                return IntersectShape(t);
-            case ShapeType.Rect:
-                var r = collider.GetRectShape();
-                return IntersectShape(r);
-            case ShapeType.Quad:
-                var q = collider.GetQuadShape();
-                return IntersectShape(q);
-            case ShapeType.Poly:
-                var p = collider.GetPolygonShape();
-                return IntersectShape(p);
-            case ShapeType.PolyLine:
-                var pl = collider.GetPolylineShape();
-                return IntersectShape(pl);
-        }
-
-        return null;
-    }
+    
 
 }

--- a/ShapeEngine/Geometry/LineDef/LineOverlap.cs
+++ b/ShapeEngine/Geometry/LineDef/LineOverlap.cs
@@ -104,6 +104,22 @@ public readonly partial struct Line
     public bool OverlapSegments(List<Segment> segments) => OverlapLineSegments(Point, Direction, segments);
 
     /// <summary>
+    /// Checks if the line overlaps with any collider in the given <see cref="CollisionObject"/>.
+    /// </summary>
+    /// <param name="collision">The collision object containing colliders to check for overlap.</param>
+    /// <returns>True if any collider in the collision object overlaps the line; otherwise, false.</returns>
+    public bool Overlap(CollisionObject collision)
+    {
+        if (!collision.HasColliders) return false;
+        foreach (var collider in collision.Colliders)
+        {
+            if(Overlap(collider)) return true;
+        }
+
+        return false;
+    }
+    
+    /// <summary>
     /// Determines whether this infinite line overlaps (intersects) with the shape of the specified <see cref="Collider"/>.
     /// </summary>
     /// <param name="collider">The <see cref="Collider"/> whose shape will be checked for overlap with this line.</param>

--- a/ShapeEngine/Geometry/PointsDef/PointsClosestPoint.cs
+++ b/ShapeEngine/Geometry/PointsDef/PointsClosestPoint.cs
@@ -87,6 +87,57 @@ public partial class Points
     }
 
     /// <summary>
+    /// Finds the closest point between any of the points to any collider in the given collision object.
+    /// </summary>
+    /// <param name="collisionObject">The collision object containing one or more colliders to compare against.</param>
+    /// <returns>
+    /// A <see cref="ClosestPointResult"/> containing the closest point information for the nearest collider.
+    /// </returns>
+    public ClosestPointResult GetClosestPoint(CollisionObject collisionObject)
+    {
+        if (!collisionObject.HasColliders) return new();
+        var closestPoint = new ClosestPointResult();
+        foreach (var collider in collisionObject.Colliders)
+        {
+            var result = GetClosestPoint(collider);
+            if(!result.Valid) continue;
+            if (!closestPoint.Valid) closestPoint = result;
+            else
+            {
+                if (result.DistanceSquared < closestPoint.DistanceSquared) closestPoint = result;
+            }
+        }
+        return closestPoint;
+    }
+  
+    /// <summary>
+    /// Finds the closest point between any of the points to the given collider.
+    /// </summary>
+    /// <param name="collider">The collider to compare against.</param>
+    /// <returns>
+    /// A <see cref="ClosestPointResult"/> containing the closest point information for the collider.
+    /// </returns>
+    public ClosestPointResult GetClosestPoint(Collider collider)
+    {
+        if (!collider.Enabled) return new();
+        switch (collider.GetShapeType())
+        {
+            case ShapeType.Line: return GetClosestPoint(collider.GetLineShape());
+            case ShapeType.Ray: return GetClosestPoint(collider.GetRayShape());
+            case ShapeType.Circle: return GetClosestPoint(collider.GetCircleShape());
+            case ShapeType.Segment: return GetClosestPoint(collider.GetSegmentShape());
+            case ShapeType.Triangle: return GetClosestPoint(collider.GetTriangleShape());
+            case ShapeType.Rect: return GetClosestPoint(collider.GetRectShape());
+            case ShapeType.Quad: return GetClosestPoint(collider.GetQuadShape());
+            case ShapeType.Poly: return GetClosestPoint(collider.GetPolygonShape());
+            case ShapeType.PolyLine: return GetClosestPoint(collider.GetPolylineShape());
+        }
+
+        return new();
+    }
+    
+    
+    /// <summary>
     /// Finds the closest point in this collection to the specified <see cref="Line"/>.
     /// </summary>
     /// <param name="other">The <see cref="Line"/> to compare against.</param>

--- a/ShapeEngine/Geometry/PolygonDef/PolygonClosestPoint.cs
+++ b/ShapeEngine/Geometry/PolygonDef/PolygonClosestPoint.cs
@@ -17,6 +17,55 @@ namespace ShapeEngine.Geometry.PolygonDef;
 public partial class Polygon
 {
     /// <summary>
+    /// Finds the closest point on the polygon's perimeter to any collider in the given collision object.
+    /// </summary>
+    /// <param name="collisionObject">The collision object containing one or more colliders to compare against.</param>
+    /// <returns>
+    /// A <see cref="ClosestPointResult"/> containing the closest point information for the nearest collider.
+    /// </returns>
+    public ClosestPointResult GetClosestPoint(CollisionObject collisionObject)
+    {
+        if (!collisionObject.HasColliders) return new();
+        var closestPoint = new ClosestPointResult();
+        foreach (var collider in collisionObject.Colliders)
+        {
+            var result = GetClosestPoint(collider);
+            if(!result.Valid) continue;
+            if (!closestPoint.Valid) closestPoint = result;
+            else
+            {
+                if (result.DistanceSquared < closestPoint.DistanceSquared) closestPoint = result;
+            }
+        }
+        return closestPoint;
+    }
+    /// <summary>
+    /// Finds the closest point on this polygon's perimeter to the given collider.
+    /// </summary>
+    /// <param name="collider">The collider to compare against.</param>
+    /// <returns>
+    /// A <see cref="ClosestPointResult"/> containing the closest point information for the collider.
+    /// </returns>
+    public ClosestPointResult GetClosestPoint(Collider collider)
+    {
+        if (!collider.Enabled) return new();
+        switch (collider.GetShapeType())
+        {
+            case ShapeType.Line: return GetClosestPoint(collider.GetLineShape());
+            case ShapeType.Ray: return GetClosestPoint(collider.GetRayShape());
+            case ShapeType.Circle: return GetClosestPoint(collider.GetCircleShape());
+            case ShapeType.Segment: return GetClosestPoint(collider.GetSegmentShape());
+            case ShapeType.Triangle: return GetClosestPoint(collider.GetTriangleShape());
+            case ShapeType.Rect: return GetClosestPoint(collider.GetRectShape());
+            case ShapeType.Quad: return GetClosestPoint(collider.GetQuadShape());
+            case ShapeType.Poly: return GetClosestPoint(collider.GetPolygonShape());
+            case ShapeType.PolyLine: return GetClosestPoint(collider.GetPolylineShape());
+        }
+
+        return new();
+    }
+    
+    /// <summary>
     /// Finds the closest point on a polygon (defined by a list of points) to a given point.
     /// </summary>
     /// <param name="points">The polygon points.</param>
@@ -695,5 +744,4 @@ public partial class Polygon
 
         return new(closestSegment, closest);
     }
-
 }

--- a/ShapeEngine/Geometry/PolygonDef/PolygonContains.cs
+++ b/ShapeEngine/Geometry/PolygonDef/PolygonContains.cs
@@ -39,6 +39,7 @@ public partial class Polygon
     /// </remarks>
     public bool ContainsCollider(Collider collider)
     {
+        if (!collider.Enabled) return false;
         switch (collider.GetShapeType())
         {
             case ShapeType.Circle: return ContainsShape(collider.GetCircleShape());

--- a/ShapeEngine/Geometry/PolygonDef/PolygonIntersectShape.cs
+++ b/ShapeEngine/Geometry/PolygonDef/PolygonIntersectShape.cs
@@ -38,6 +38,29 @@ public partial class Polygon
         }
         return points;
     }
+    
+    /// <summary>
+    /// Computes intersection points between this polygon and all colliders in the specified <see cref="CollisionObject"/>.
+    /// </summary>
+    /// <param name="collisionObject">The collision object containing colliders to test for intersection.</param>
+    /// <returns>
+    /// A <see cref="Dictionary{Collider, IntersectionPoints}"/> mapping each collider to its intersection points,
+    /// or null if no colliders are present or no intersections are found.
+    /// </returns>
+    public Dictionary<Collider, IntersectionPoints>? Intersect(CollisionObject collisionObject)
+    {
+        if (!collisionObject.HasColliders) return null;
+
+        Dictionary<Collider, IntersectionPoints>? intersections = null;
+        foreach (var collider in collisionObject.Colliders)
+        {
+            var result = Intersect(collider);
+            if(result == null) continue;
+            intersections ??= new();
+            intersections.Add(collider, result);
+        }
+        return intersections;
+    }
     /// <summary>
     /// Computes intersection points between this polygon and a collider.
     /// </summary>

--- a/ShapeEngine/Geometry/PolygonDef/PolygonOverlap.cs
+++ b/ShapeEngine/Geometry/PolygonDef/PolygonOverlap.cs
@@ -14,6 +14,7 @@ namespace ShapeEngine.Geometry.PolygonDef;
 
 public partial class Polygon
 {
+    
     /// <summary>
     /// Checks if this polygon overlaps with a line segment.
     /// </summary>
@@ -113,6 +114,22 @@ public partial class Polygon
     /// <param name="ray">The ray shape.</param>
     /// <returns>True if the ray overlaps the polygon; otherwise, false.</returns>
     public bool OverlapShape(Ray ray) => OverlapPolygonRay(this, ray.Point, ray.Direction);
+    
+    /// <summary>
+    /// Checks if the quad overlaps with any collider in the given <see cref="CollisionObject"/>.
+    /// </summary>
+    /// <param name="collision">The collision object containing colliders to check for overlap.</param>
+    /// <returns>True if any collider in the collision object overlaps the quad; otherwise, false.</returns>
+    public bool Overlap(CollisionObject collision)
+    {
+        if (!collision.HasColliders) return false;
+        foreach (var collider in collision.Colliders)
+        {
+            if(Overlap(collider)) return true;
+        }
+
+        return false;
+    }
     
     /// <summary>
     /// Checks if this polygon overlaps with a generic collider shape.

--- a/ShapeEngine/Geometry/PolylineDef/PolylineClosestPoint.cs
+++ b/ShapeEngine/Geometry/PolylineDef/PolylineClosestPoint.cs
@@ -209,6 +209,56 @@ public partial class Polyline
     }
 
     /// <summary>
+    /// Finds the closest point on the polyline's perimeter to any collider in the given collision object.
+    /// </summary>
+    /// <param name="collisionObject">The collision object containing one or more colliders to compare against.</param>
+    /// <returns>
+    /// A <see cref="ClosestPointResult"/> containing the closest point information for the nearest collider.
+    /// </returns>
+    public ClosestPointResult GetClosestPoint(CollisionObject collisionObject)
+    {
+        if (!collisionObject.HasColliders) return new();
+        var closestPoint = new ClosestPointResult();
+        foreach (var collider in collisionObject.Colliders)
+        {
+            var result = GetClosestPoint(collider);
+            if(!result.Valid) continue;
+            if (!closestPoint.Valid) closestPoint = result;
+            else
+            {
+                if (result.DistanceSquared < closestPoint.DistanceSquared) closestPoint = result;
+            }
+        }
+        return closestPoint;
+    }
+  
+    /// <summary>
+    /// Finds the closest point on this polyline's perimeter to the given collider.
+    /// </summary>
+    /// <param name="collider">The collider to compare against.</param>
+    /// <returns>
+    /// A <see cref="ClosestPointResult"/> containing the closest point information for the collider.
+    /// </returns>
+    public ClosestPointResult GetClosestPoint(Collider collider)
+    {
+        if (!collider.Enabled) return new();
+        switch (collider.GetShapeType())
+        {
+            case ShapeType.Line: return GetClosestPoint(collider.GetLineShape());
+            case ShapeType.Ray: return GetClosestPoint(collider.GetRayShape());
+            case ShapeType.Circle: return GetClosestPoint(collider.GetCircleShape());
+            case ShapeType.Segment: return GetClosestPoint(collider.GetSegmentShape());
+            case ShapeType.Triangle: return GetClosestPoint(collider.GetTriangleShape());
+            case ShapeType.Rect: return GetClosestPoint(collider.GetRectShape());
+            case ShapeType.Quad: return GetClosestPoint(collider.GetQuadShape());
+            case ShapeType.Poly: return GetClosestPoint(collider.GetPolygonShape());
+            case ShapeType.PolyLine: return GetClosestPoint(collider.GetPolylineShape());
+        }
+
+        return new();
+    }
+    
+    /// <summary>
     /// Finds the closest point between this polyline and a given line.
     /// </summary>
     /// <param name="other">The <see cref="Line"/> to compare against.</param>

--- a/ShapeEngine/Geometry/PolylineDef/PolylineIntersectShape.cs
+++ b/ShapeEngine/Geometry/PolylineDef/PolylineIntersectShape.cs
@@ -14,6 +14,29 @@ namespace ShapeEngine.Geometry.PolylineDef;
 public partial class Polyline
 {
     /// <summary>
+    /// Computes intersection points between this polyline and all colliders in the specified <see cref="CollisionObject"/>.
+    /// </summary>
+    /// <param name="collisionObject">The collision object containing colliders to test for intersection.</param>
+    /// <returns>
+    /// A <see cref="Dictionary{Collider, IntersectionPoints}"/> mapping each collider to its intersection points,
+    /// or null if no colliders are present or no intersections are found.
+    /// </returns>
+    public Dictionary<Collider, IntersectionPoints>? Intersect(CollisionObject collisionObject)
+    {
+        if (!collisionObject.HasColliders) return null;
+
+        Dictionary<Collider, IntersectionPoints>? intersections = null;
+        foreach (var collider in collisionObject.Colliders)
+        {
+            var result = Intersect(collider);
+            if(result == null) continue;
+            intersections ??= new();
+            intersections.Add(collider, result);
+        }
+        return intersections;
+    }
+    
+    /// <summary>
     /// Computes the intersection points between this polyline and another collider's shape.
     /// </summary>
     /// <param name="collider">The collider whose shape will be tested for intersection with this polyline.</param>

--- a/ShapeEngine/Geometry/PolylineDef/PolylineOverlap.cs
+++ b/ShapeEngine/Geometry/PolylineDef/PolylineOverlap.cs
@@ -127,6 +127,21 @@ public partial class Polyline
     public bool OverlapShape(Ray ray) => OverlapPolylineRay(this, ray.Point, ray.Direction);
 
     /// <summary>
+    /// Checks if the polyline overlaps with any collider in the given <see cref="CollisionObject"/>.
+    /// </summary>
+    /// <param name="collision">The collision object containing colliders to check for overlap.</param>
+    /// <returns>True if any collider in the collision object overlaps the polyline; otherwise, false.</returns>
+    public bool Overlap(CollisionObject collision)
+    {
+        if (!collision.HasColliders) return false;
+        foreach (var collider in collision.Colliders)
+        {
+            if(Overlap(collider)) return true;
+        }
+        return false;
+    }
+    
+    /// <summary>
     /// Determines whether the polyline overlaps the specified <see cref="Collider"/>.
     /// </summary>
     /// <param name="collider">The collider to test for overlap.</param>

--- a/ShapeEngine/Geometry/QuadDef/QuadClosestPoint.cs
+++ b/ShapeEngine/Geometry/QuadDef/QuadClosestPoint.cs
@@ -139,6 +139,56 @@ public readonly partial struct Quad
     }
 
     /// <summary>
+    /// Finds the closest point on the quad's perimeter to any collider in the given collision object.
+    /// </summary>
+    /// <param name="collisionObject">The collision object containing one or more colliders to compare against.</param>
+    /// <returns>
+    /// A <see cref="ClosestPointResult"/> containing the closest point information for the nearest collider.
+    /// </returns>
+    public ClosestPointResult GetClosestPoint(CollisionObject collisionObject)
+    {
+        if (!collisionObject.HasColliders) return new();
+        var closestPoint = new ClosestPointResult();
+        foreach (var collider in collisionObject.Colliders)
+        {
+            var result = GetClosestPoint(collider);
+            if(!result.Valid) continue;
+            if (!closestPoint.Valid) closestPoint = result;
+            else
+            {
+                if (result.DistanceSquared < closestPoint.DistanceSquared) closestPoint = result;
+            }
+        }
+        return closestPoint;
+    }
+  
+    /// <summary>
+    /// Finds the closest point on this quad's perimeter to the given collider.
+    /// </summary>
+    /// <param name="collider">The collider to compare against.</param>
+    /// <returns>
+    /// A <see cref="ClosestPointResult"/> containing the closest point information for the collider.
+    /// </returns>
+    public ClosestPointResult GetClosestPoint(Collider collider)
+    {
+        if (!collider.Enabled) return new();
+        switch (collider.GetShapeType())
+        {
+            case ShapeType.Line: return GetClosestPoint(collider.GetLineShape());
+            case ShapeType.Ray: return GetClosestPoint(collider.GetRayShape());
+            case ShapeType.Circle: return GetClosestPoint(collider.GetCircleShape());
+            case ShapeType.Segment: return GetClosestPoint(collider.GetSegmentShape());
+            case ShapeType.Triangle: return GetClosestPoint(collider.GetTriangleShape());
+            case ShapeType.Rect: return GetClosestPoint(collider.GetRectShape());
+            case ShapeType.Quad: return GetClosestPoint(collider.GetQuadShape());
+            case ShapeType.Poly: return GetClosestPoint(collider.GetPolygonShape());
+            case ShapeType.PolyLine: return GetClosestPoint(collider.GetPolylineShape());
+        }
+
+        return new();
+    }
+    
+    /// <summary>
     /// Finds the closest point between this quad's perimeter and a line.
     /// </summary>
     /// <param name="other">The line to compare against.</param>

--- a/ShapeEngine/Geometry/QuadDef/QuadContains.cs
+++ b/ShapeEngine/Geometry/QuadDef/QuadContains.cs
@@ -68,14 +68,11 @@ public readonly partial struct Quad
     /// <summary>
     /// Determines whether the specified collider is contained within this quad.
     /// </summary>
-    /// <param name="collider">The collider to test.</param>
+    /// <param name="collider">The collider to test. Has to be enabled.</param>
     /// <returns><c>true</c> if the collider is inside the quad; otherwise, <c>false</c>.</returns>
-    
-    //TODO: QuadIntersectShape checks if collider is enabled -> shouldn't it check it here as well.
-    //Also check of overlap checks it or not and check all other shapes for this as well
-    //Either Contains, Overlap, Intersection, and ClosestPoint check if collider is enabled or not but it should be consistent across shapes.
     public bool ContainsCollider(Collider collider)
     {
+        if (!collider.Enabled) return false;
         switch (collider.GetShapeType())
         {
             case ShapeType.Circle: return ContainsShape(collider.GetCircleShape());

--- a/ShapeEngine/Geometry/QuadDef/QuadIntersectShape.cs
+++ b/ShapeEngine/Geometry/QuadDef/QuadIntersectShape.cs
@@ -14,6 +14,28 @@ namespace ShapeEngine.Geometry.QuadDef;
 public readonly partial struct Quad
 {
     /// <summary>
+    /// Computes intersection points between this quad and all colliders in the specified <see cref="CollisionObject"/>.
+    /// </summary>
+    /// <param name="collisionObject">The collision object containing colliders to test for intersection.</param>
+    /// <returns>
+    /// A <see cref="Dictionary{Collider, IntersectionPoints}"/> mapping each collider to its intersection points,
+    /// or null if no colliders are present or no intersections are found.
+    /// </returns>
+    public Dictionary<Collider, IntersectionPoints>? Intersect(CollisionObject collisionObject)
+    {
+        if (!collisionObject.HasColliders) return null;
+
+        Dictionary<Collider, IntersectionPoints>? intersections = null;
+        foreach (var collider in collisionObject.Colliders)
+        {
+            var result = Intersect(collider);
+            if(result == null) continue;
+            intersections ??= new();
+            intersections.Add(collider, result);
+        }
+        return intersections;
+    }
+    /// <summary>
     /// Computes intersection points between this quad and the specified collider.
     /// </summary>
     /// <param name="collider">The collider to test for intersection.</param>
@@ -693,7 +715,7 @@ public readonly partial struct Quad
     /// <summary>
     /// Computes intersection points between this quad and a collider, adding results to an existing <see cref="IntersectionPoints"/> collection.
     /// </summary>
-    /// <param name="collider">The collider to test for intersection.</param>
+    /// <param name="collider">The collider to test for intersection. Has to be enabled.</param>
     /// <param name="points">The collection to add intersection points to.</param>
     /// <param name="returnAfterFirstValid">If true, returns after the first intersection is found.</param>
     /// <returns>The number of intersection points found.</returns>

--- a/ShapeEngine/Geometry/QuadDef/QuadOverlap.cs
+++ b/ShapeEngine/Geometry/QuadDef/QuadOverlap.cs
@@ -98,23 +98,25 @@ public readonly partial struct Quad
     public bool OverlapSegments(List<Segment> segments) => OverlapQuadSegments(A, B, C, D, segments);
 
     /// <summary>
-    /// Checks if the quad overlaps with a line shape.
+    /// Checks if the quad overlaps with any collider in the given <see cref="CollisionObject"/>.
     /// </summary>
-    /// <param name="line">The line shape to check.</param>
-    /// <returns>True if the line overlaps the quad; otherwise, false.</returns>
-    public bool OverlapShape(Line line) => OverlapQuadLine(A, B, C, D, line.Point, line.Direction);
+    /// <param name="collision">The collision object containing colliders to check for overlap.</param>
+    /// <returns>True if any collider in the collision object overlaps the quad; otherwise, false.</returns>
+    public bool Overlap(CollisionObject collision)
+    {
+        if (!collision.HasColliders) return false;
+        foreach (var collider in collision.Colliders)
+        {
+            if(Overlap(collider)) return true;
+        }
 
-    /// <summary>
-    /// Checks if the quad overlaps with a ray shape.
-    /// </summary>
-    /// <param name="ray">The ray shape to check.</param>
-    /// <returns>True if the ray overlaps the quad; otherwise, false.</returns>
-    public bool OverlapShape(Ray ray) => OverlapQuadRay(A, B, C, D, ray.Point, ray.Direction);
-
+        return false;
+    }
+    
     /// <summary>
     /// Checks if the quad overlaps with a collider's shape.
     /// </summary>
-    /// <param name="collider">The collider whose shape to check.</param>
+    /// <param name="collider">The collider whose shape to check. Has to be enabled.</param>
     /// <returns>True if the collider's shape overlaps the quad; otherwise, false.</returns>
     /// <remarks>Supports multiple shape types, including circle, segment, line,
     /// ray, triangle, rect, quad, polygon, and polyline.</remarks>
@@ -156,6 +158,21 @@ public readonly partial struct Quad
         return false;
     }
 
+    
+    /// <summary>
+    /// Checks if the quad overlaps with a line shape.
+    /// </summary>
+    /// <param name="line">The line shape to check.</param>
+    /// <returns>True if the line overlaps the quad; otherwise, false.</returns>
+    public bool OverlapShape(Line line) => OverlapQuadLine(A, B, C, D, line.Point, line.Direction);
+
+    /// <summary>
+    /// Checks if the quad overlaps with a ray shape.
+    /// </summary>
+    /// <param name="ray">The ray shape to check.</param>
+    /// <returns>True if the ray overlaps the quad; otherwise, false.</returns>
+    public bool OverlapShape(Ray ray) => OverlapQuadRay(A, B, C, D, ray.Point, ray.Direction);
+    
     /// <summary>
     /// Checks if the quad overlaps with a set of segments.
     /// </summary>

--- a/ShapeEngine/Geometry/RayDef/RayClosestPoint.cs
+++ b/ShapeEngine/Geometry/RayDef/RayClosestPoint.cs
@@ -15,6 +15,57 @@ namespace ShapeEngine.Geometry.RayDef;
 
 public readonly partial struct Ray
 {
+    
+    /// <summary>
+    /// Finds the closest point on the ray to any collider in the given collision object.
+    /// </summary>
+    /// <param name="collisionObject">The collision object containing one or more colliders to compare against.</param>
+    /// <returns>
+    /// A <see cref="ClosestPointResult"/> containing the closest point information for the nearest collider.
+    /// </returns>
+    public ClosestPointResult GetClosestPoint(CollisionObject collisionObject)
+    {
+        if (!collisionObject.HasColliders) return new();
+        var closestPoint = new ClosestPointResult();
+        foreach (var collider in collisionObject.Colliders)
+        {
+            var result = GetClosestPoint(collider);
+            if(!result.Valid) continue;
+            if (!closestPoint.Valid) closestPoint = result;
+            else
+            {
+                if (result.DistanceSquared < closestPoint.DistanceSquared) closestPoint = result;
+            }
+        }
+        return closestPoint;
+    }
+  
+    /// <summary>
+    /// Finds the closest point on this ray to the given collider.
+    /// </summary>
+    /// <param name="collider">The collider to compare against.</param>
+    /// <returns>
+    /// A <see cref="ClosestPointResult"/> containing the closest point information for the collider.
+    /// </returns>
+    public ClosestPointResult GetClosestPoint(Collider collider)
+    {
+        if (!collider.Enabled) return new();
+        switch (collider.GetShapeType())
+        {
+            case ShapeType.Line: return GetClosestPoint(collider.GetLineShape());
+            case ShapeType.Ray: return GetClosestPoint(collider.GetRayShape());
+            case ShapeType.Circle: return GetClosestPoint(collider.GetCircleShape());
+            case ShapeType.Segment: return GetClosestPoint(collider.GetSegmentShape());
+            case ShapeType.Triangle: return GetClosestPoint(collider.GetTriangleShape());
+            case ShapeType.Rect: return GetClosestPoint(collider.GetRectShape());
+            case ShapeType.Quad: return GetClosestPoint(collider.GetQuadShape());
+            case ShapeType.Poly: return GetClosestPoint(collider.GetPolygonShape());
+            case ShapeType.PolyLine: return GetClosestPoint(collider.GetPolylineShape());
+        }
+
+        return new();
+    }
+    
     /// <summary>
     /// Finds the closest point on this ray to a given point.
     /// </summary>

--- a/ShapeEngine/Geometry/RayDef/RayIntersectShape.cs
+++ b/ShapeEngine/Geometry/RayDef/RayIntersectShape.cs
@@ -14,6 +14,29 @@ namespace ShapeEngine.Geometry.RayDef;
 public readonly partial struct Ray
 {
     /// <summary>
+    /// Computes intersection points between this ray and all colliders in the specified <see cref="CollisionObject"/>.
+    /// </summary>
+    /// <param name="collisionObject">The collision object containing colliders to test for intersection.</param>
+    /// <returns>
+    /// A <see cref="Dictionary{Collider, IntersectionPoints}"/> mapping each collider to its intersection points,
+    /// or null if no colliders are present or no intersections are found.
+    /// </returns>
+    public Dictionary<Collider, IntersectionPoints>? Intersect(CollisionObject collisionObject)
+    {
+        if (!collisionObject.HasColliders) return null;
+
+        Dictionary<Collider, IntersectionPoints>? intersections = null;
+        foreach (var collider in collisionObject.Colliders)
+        {
+            var result = Intersect(collider);
+            if(result == null) continue;
+            intersections ??= new();
+            intersections.Add(collider, result);
+        }
+        return intersections;
+    }
+    
+    /// <summary>
     /// Computes all intersection points between this ray and a generic collider shape.
     /// </summary>
     /// <param name="collider">The collider to test for intersection. Must be enabled.</param>

--- a/ShapeEngine/Geometry/RayDef/RayOverlap.cs
+++ b/ShapeEngine/Geometry/RayDef/RayOverlap.cs
@@ -14,6 +14,7 @@ namespace ShapeEngine.Geometry.RayDef;
 
 public readonly partial struct Ray
 {
+    
     /// <summary>
     /// Determines whether this ray overlaps the specified point.
     /// </summary>
@@ -92,6 +93,22 @@ public readonly partial struct Ray
     /// <param name="segments">The list of segments to check for overlap.</param>
     /// <returns>True if the ray overlaps any of the segments; otherwise, false.</returns>
     public bool OverlapSegments(List<Segment> segments) => OverlapRaySegments(Point, Direction, segments);
+    
+    /// <summary>
+    /// Checks if the ray overlaps with any collider in the given <see cref="CollisionObject"/>.
+    /// </summary>
+    /// <param name="collision">The collision object containing colliders to check for overlap.</param>
+    /// <returns>True if any collider in the collision object overlaps the quad; otherwise, false.</returns>
+    public bool Overlap(CollisionObject collision)
+    {
+        if (!collision.HasColliders) return false;
+        foreach (var collider in collision.Colliders)
+        {
+            if(Overlap(collider)) return true;
+        }
+
+        return false;
+    }
     /// <summary>
     /// Determines whether this ray overlaps the specified collider.
     /// </summary>

--- a/ShapeEngine/Geometry/RectDef/Rect.cs
+++ b/ShapeEngine/Geometry/RectDef/Rect.cs
@@ -353,13 +353,18 @@ public readonly partial struct Rect : IEquatable<Rect>
     /// <param name="brCorner">Bottom-right corner slant amount.</param>
     /// <param name="blCorner">Bottom-left corner slant amount.</param>
     /// <returns>A <see cref="Polygon"/> object containing the slanted corner points.</returns>
-    public Polygon GetSlantedCornerPoints(float tlCorner, float trCorner, float brCorner, float blCorner)
+    public Polygon? GetSlantedCornerPoints(float tlCorner, float trCorner, float brCorner, float blCorner)
     {
+        if (tlCorner < 0) return null;
+        if (trCorner < 0) return null;
+        if (brCorner < 0) return null;
+        if (blCorner < 0) return null;
+        
         var tl = TopLeft;
         var tr = TopRight;
         var br = BottomRight;
         var bl = BottomLeft;
-        //TODO: should return nullable polygon? If all corner values are not valid than a new polygon is still created and returned...
+        
         Polygon points = new();
         
         //It is enough to check if tlCorner is positive, I do not know why I checked if tlCorner is smaller than 1 as well... 
@@ -395,18 +400,25 @@ public readonly partial struct Rect : IEquatable<Rect>
     /// <summary>
     /// Get the points to draw a rectangle with slanted corners. The corner values are the percentage of the width/height of the rectange the should be used for the slant.
     /// </summary>
-    /// <param name="tlCorner">Should be between 0 - 1</param>
-    /// <param name="trCorner">Should be between 0 - 1</param>
-    /// <param name="brCorner">Should be between 0 - 1</param>
-    /// <param name="blCorner">Should be between 0 - 1</param>
+    /// <param name="tlCorner">Should be between <c>0-1</c></param>
+    /// <param name="trCorner">Should be between <c>0-1</c></param>
+    /// <param name="brCorner">Should be between <c>0-1</c></param>
+    /// <param name="blCorner">Should be between <c>0-1</c></param>
     /// <returns>Returns points in ccw order.</returns>
-    public Polygon GetSlantedCornerPointsRelative(float tlCorner, float trCorner, float brCorner, float blCorner)
+    public Polygon? GetSlantedCornerPointsRelative(float tlCorner, float trCorner, float brCorner, float blCorner)
     {
+        if (tlCorner is < 0f or > 1f) return null;
+        if (trCorner is < 0f or > 1f) return null;
+        if (brCorner is < 0f or > 1f) return null;
+        if (blCorner is < 0f or > 1f) return null;
+        
+        
         var tl = TopLeft;
         var tr = TopRight;
         var br = BottomRight;
         var bl = BottomLeft;
-        //TODO: should return nullable polygon? If all corner values are not valid than a new polygon is still created and returned...
+        
+        
         Polygon points = new();
         if (tlCorner > 0f && tlCorner < 1f)
         {

--- a/ShapeEngine/Geometry/RectDef/Rect.cs
+++ b/ShapeEngine/Geometry/RectDef/Rect.cs
@@ -353,48 +353,30 @@ public readonly partial struct Rect : IEquatable<Rect>
     /// <param name="brCorner">Bottom-right corner slant amount.</param>
     /// <param name="blCorner">Bottom-left corner slant amount.</param>
     /// <returns>A <see cref="Polygon"/> object containing the slanted corner points.</returns>
-    public Polygon? GetSlantedCornerPoints(float tlCorner, float trCorner, float brCorner, float blCorner)
+    public Polygon GetSlantedCornerPoints(float tlCorner, float trCorner, float brCorner, float blCorner)
     {
-        if (tlCorner < 0) return null;
-        if (trCorner < 0) return null;
-        if (brCorner < 0) return null;
-        if (blCorner < 0) return null;
+        Polygon points = [];
         
         var tl = TopLeft;
-        var tr = TopRight;
-        var br = BottomRight;
+        tlCorner = MathF.Max(tlCorner, 0);
+        points.Add(tl + new Vector2(MathF.Min(tlCorner, Width), 0f));
+        points.Add(tl + new Vector2(0f, MathF.Min(tlCorner, Height)));
+        
         var bl = BottomLeft;
+        blCorner = MathF.Max(blCorner, 0);
+        points.Add(bl - new Vector2(0f, MathF.Min(blCorner, Height)));
+        points.Add(bl + new Vector2(MathF.Min(blCorner, Width), 0f));
         
-        Polygon points = new();
+        var br = BottomRight;
+        brCorner = MathF.Max(brCorner, 0);
+        points.Add(br - new Vector2(MathF.Min(brCorner, Width), 0f));
+        points.Add(br - new Vector2(0f, MathF.Min(brCorner, Height)));
+       
+        var tr = TopRight;
+        trCorner = MathF.Max(trCorner, 0);
+        points.Add(tr + new Vector2(0f, MathF.Min(trCorner, Height)));
+        points.Add(tr - new Vector2(MathF.Min(trCorner, Width), 0f));
         
-        //It is enough to check if tlCorner is positive, I do not know why I checked if tlCorner is smaller than 1 as well... 
-        //The corner values are absolute in this function, therefore they can be bigger than 1.
-        if (tlCorner > 0f) // && tlCorner < 1f) -> should not be here?! 
-        {
-            points.Add(tl + new Vector2(MathF.Min(tlCorner, Width), 0f));
-            points.Add(tl + new Vector2(0f, MathF.Min(tlCorner, Height)));
-        }
-        //It is enough to check if blCorner is positive, I do not know why I checked if blCorner is smaller than 1 as well... 
-        //The corner values are absolute in this function, therefore they can be bigger than 1.
-        if (blCorner > 0f) // && blCorner < 1f) should not be here?!
-        {
-            points.Add(bl - new Vector2(0f, MathF.Min(tlCorner, Height)));
-            points.Add(bl + new Vector2(MathF.Min(tlCorner, Width), 0f));
-        }
-        //It is enough to check if brCorner is positive, I do not know why I checked if brCorner is smaller than 1 as well... 
-        //The corner values are absolute in this function, therefore they can be bigger than 1.
-        if (brCorner > 0f) // && brCorner < 1f)should not be here?!
-        {
-            points.Add(br - new Vector2(MathF.Min(tlCorner, Width), 0f));
-            points.Add(br - new Vector2(0f, MathF.Min(tlCorner, Height)));
-        }
-        //It is enough to check if trCorner is positive, I do not know why I checked if trCorner is smaller than 1 as well... 
-        //The corner values are absolute in this function, therefore they can be bigger than 1.
-        if (trCorner > 0f) // && trCorner < 1f)should not be here?!
-        {
-            points.Add(tr + new Vector2(0f, MathF.Min(tlCorner, Height)));
-            points.Add(tr - new Vector2(MathF.Min(tlCorner, Width), 0f));
-        }
         return points;
     }
     /// <summary>
@@ -405,41 +387,30 @@ public readonly partial struct Rect : IEquatable<Rect>
     /// <param name="brCorner">Should be between <c>0-1</c></param>
     /// <param name="blCorner">Should be between <c>0-1</c></param>
     /// <returns>Returns points in ccw order.</returns>
-    public Polygon? GetSlantedCornerPointsRelative(float tlCorner, float trCorner, float brCorner, float blCorner)
+    public Polygon GetSlantedCornerPointsRelative(float tlCorner, float trCorner, float brCorner, float blCorner)
     {
-        if (tlCorner is < 0f or > 1f) return null;
-        if (trCorner is < 0f or > 1f) return null;
-        if (brCorner is < 0f or > 1f) return null;
-        if (blCorner is < 0f or > 1f) return null;
-        
+        Polygon points = [];
         
         var tl = TopLeft;
-        var tr = TopRight;
-        var br = BottomRight;
+        tlCorner = ShapeMath.Clamp(tlCorner, 0f, 1f);
+        points.Add(tl + new Vector2(tlCorner * Width, 0f));
+        points.Add(tl + new Vector2(0f, tlCorner * Height));
+        
         var bl = BottomLeft;
+        blCorner = ShapeMath.Clamp(blCorner, 0f, 1f);
+        points.Add(bl - new Vector2(0f, blCorner * Height));
+        points.Add(bl + new Vector2(blCorner * Width, 0f));
         
+        var br = BottomRight;
+        brCorner = ShapeMath.Clamp(brCorner, 0f, 1f);
+        points.Add(br - new Vector2(brCorner * Width, 0f));
+        points.Add(br - new Vector2(0f, brCorner * Height));
         
-        Polygon points = new();
-        if (tlCorner > 0f && tlCorner < 1f)
-        {
-            points.Add(tl + new Vector2(tlCorner * Width, 0f));
-            points.Add(tl + new Vector2(0f, tlCorner * Height));
-        }
-        if (blCorner > 0f && blCorner < 1f)
-        {
-            points.Add(bl - new Vector2(0f, tlCorner * Height));
-            points.Add(bl + new Vector2(tlCorner * Width, 0f));
-        }
-        if (brCorner > 0f && brCorner < 1f)
-        {
-            points.Add(br - new Vector2(tlCorner * Width, 0f));
-            points.Add(br - new Vector2(0f, tlCorner * Height));
-        }
-        if (trCorner > 0f && trCorner < 1f)
-        {
-            points.Add(tr + new Vector2(0f, tlCorner * Height));
-            points.Add(tr - new Vector2(tlCorner * Width, 0f));
-        }
+        var tr = TopRight;
+        trCorner = ShapeMath.Clamp(trCorner, 0f, 1f);
+        points.Add(tr + new Vector2(0f, trCorner * Height));
+        points.Add(tr - new Vector2(trCorner * Width, 0f));
+        
         return points;
     }
     #endregion

--- a/ShapeEngine/Geometry/RectDef/RectClosestPoint.cs
+++ b/ShapeEngine/Geometry/RectDef/RectClosestPoint.cs
@@ -16,6 +16,57 @@ namespace ShapeEngine.Geometry.RectDef;
 public readonly partial struct Rect
 {
     /// <summary>
+    /// Finds the closest point on the rect's perimeter to any collider in the given collision object.
+    /// </summary>
+    /// <param name="collisionObject">The collision object containing one or more colliders to compare against.</param>
+    /// <returns>
+    /// A <see cref="ClosestPointResult"/> containing the closest point information for the nearest collider.
+    /// </returns>
+    public ClosestPointResult GetClosestPoint(CollisionObject collisionObject)
+    {
+        if (!collisionObject.HasColliders) return new();
+        var closestPoint = new ClosestPointResult();
+        foreach (var collider in collisionObject.Colliders)
+        {
+            var result = GetClosestPoint(collider);
+            if(!result.Valid) continue;
+            if (!closestPoint.Valid) closestPoint = result;
+            else
+            {
+                if (result.DistanceSquared < closestPoint.DistanceSquared) closestPoint = result;
+            }
+        }
+        return closestPoint;
+    }
+  
+    /// <summary>
+    /// Finds the closest point on this rect's perimeter to the given collider.
+    /// </summary>
+    /// <param name="collider">The collider to compare against.</param>
+    /// <returns>
+    /// A <see cref="ClosestPointResult"/> containing the closest point information for the collider.
+    /// </returns>
+    public ClosestPointResult GetClosestPoint(Collider collider)
+    {
+        if (!collider.Enabled) return new();
+        switch (collider.GetShapeType())
+        {
+            case ShapeType.Line: return GetClosestPoint(collider.GetLineShape());
+            case ShapeType.Ray: return GetClosestPoint(collider.GetRayShape());
+            case ShapeType.Circle: return GetClosestPoint(collider.GetCircleShape());
+            case ShapeType.Segment: return GetClosestPoint(collider.GetSegmentShape());
+            case ShapeType.Triangle: return GetClosestPoint(collider.GetTriangleShape());
+            case ShapeType.Rect: return GetClosestPoint(collider.GetRectShape());
+            case ShapeType.Quad: return GetClosestPoint(collider.GetQuadShape());
+            case ShapeType.Poly: return GetClosestPoint(collider.GetPolygonShape());
+            case ShapeType.PolyLine: return GetClosestPoint(collider.GetPolylineShape());
+        }
+
+        return new();
+    }
+    
+    
+    /// <summary>
     /// Returns the closest point on the rectangle (defined by four corners) to a given point.
     /// </summary>
     /// <param name="a">Top-left corner of the rectangle.</param>

--- a/ShapeEngine/Geometry/RectDef/RectContains.cs
+++ b/ShapeEngine/Geometry/RectDef/RectContains.cs
@@ -86,7 +86,6 @@ public readonly partial struct Rect
 
         return true;
     }
-
     /// <summary>
     /// Determines whether the specified collider is fully contained within this rectangle.
     /// </summary>
@@ -97,6 +96,8 @@ public readonly partial struct Rect
     /// </remarks>
     public bool ContainsCollider(Collider collider)
     {
+        if (!collider.Enabled) return false;
+        
         switch (collider.GetShapeType())
         {
             case ShapeType.Circle: return ContainsShape(collider.GetCircleShape());

--- a/ShapeEngine/Geometry/RectDef/RectIntersectShape.cs
+++ b/ShapeEngine/Geometry/RectDef/RectIntersectShape.cs
@@ -14,6 +14,29 @@ namespace ShapeEngine.Geometry.RectDef;
 public readonly partial struct Rect
 {
     /// <summary>
+    /// Computes intersection points between this rect and all colliders in the specified <see cref="CollisionObject"/>.
+    /// </summary>
+    /// <param name="collisionObject">The collision object containing colliders to test for intersection.</param>
+    /// <returns>
+    /// A <see cref="Dictionary{Collider, IntersectionPoints}"/> mapping each collider to its intersection points,
+    /// or null if no colliders are present or no intersections are found.
+    /// </returns>
+    public Dictionary<Collider, IntersectionPoints>? Intersect(CollisionObject collisionObject)
+    {
+        if (!collisionObject.HasColliders) return null;
+
+        Dictionary<Collider, IntersectionPoints>? intersections = null;
+        foreach (var collider in collisionObject.Colliders)
+        {
+            var result = Intersect(collider);
+            if(result == null) continue;
+            intersections ??= new();
+            intersections.Add(collider, result);
+        }
+        return intersections;
+    }
+    
+    /// <summary>
     /// Computes intersection points between this rectangle and the specified collider.
     /// </summary>
     /// <param name="collider">The collider to test for intersection.</param>

--- a/ShapeEngine/Geometry/RectDef/RectOverlap.cs
+++ b/ShapeEngine/Geometry/RectDef/RectOverlap.cs
@@ -113,6 +113,22 @@ public readonly partial struct Rect
     public bool OverlapShape(Ray ray) => OverlapRectRay(A, B, C, D, ray.Point, ray.Direction);
 
     /// <summary>
+    /// Checks if the rect overlaps with any collider in the given <see cref="CollisionObject"/>.
+    /// </summary>
+    /// <param name="collision">The collision object containing colliders to check for overlap.</param>
+    /// <returns>True if any collider in the collision object overlaps the rect; otherwise, false.</returns>
+    public bool Overlap(CollisionObject collision)
+    {
+        if (!collision.HasColliders) return false;
+        foreach (var collider in collision.Colliders)
+        {
+            if(Overlap(collider)) return true;
+        }
+
+        return false;
+    }
+    
+    /// <summary>
     /// Checks if the rectangle overlaps with the specified collider.
     /// </summary>
     /// <param name="collider">The collider to check for overlap.</param>

--- a/ShapeEngine/Geometry/SegmentDef/SegmentClosestPoint.cs
+++ b/ShapeEngine/Geometry/SegmentDef/SegmentClosestPoint.cs
@@ -15,6 +15,57 @@ namespace ShapeEngine.Geometry.SegmentDef;
 
 public readonly partial struct Segment
 {
+        /// <summary>
+    /// Finds the closest point on the segment to any collider in the given collision object.
+    /// </summary>
+    /// <param name="collisionObject">The collision object containing one or more colliders to compare against.</param>
+    /// <returns>
+    /// A <see cref="ClosestPointResult"/> containing the closest point information for the nearest collider.
+    /// </returns>
+    public ClosestPointResult GetClosestPoint(CollisionObject collisionObject)
+    {
+        if (!collisionObject.HasColliders) return new();
+        var closestPoint = new ClosestPointResult();
+        foreach (var collider in collisionObject.Colliders)
+        {
+            var result = GetClosestPoint(collider);
+            if(!result.Valid) continue;
+            if (!closestPoint.Valid) closestPoint = result;
+            else
+            {
+                if (result.DistanceSquared < closestPoint.DistanceSquared) closestPoint = result;
+            }
+        }
+        return closestPoint;
+    }
+  
+    /// <summary>
+    /// Finds the closest point on this segment to the given collider.
+    /// </summary>
+    /// <param name="collider">The collider to compare against.</param>
+    /// <returns>
+    /// A <see cref="ClosestPointResult"/> containing the closest point information for the collider.
+    /// </returns>
+    public ClosestPointResult GetClosestPoint(Collider collider)
+    {
+        if (!collider.Enabled) return new();
+        switch (collider.GetShapeType())
+        {
+            case ShapeType.Line: return GetClosestPoint(collider.GetLineShape());
+            case ShapeType.Ray: return GetClosestPoint(collider.GetRayShape());
+            case ShapeType.Circle: return GetClosestPoint(collider.GetCircleShape());
+            case ShapeType.Segment: return GetClosestPoint(collider.GetSegmentShape());
+            case ShapeType.Triangle: return GetClosestPoint(collider.GetTriangleShape());
+            case ShapeType.Rect: return GetClosestPoint(collider.GetRectShape());
+            case ShapeType.Quad: return GetClosestPoint(collider.GetQuadShape());
+            case ShapeType.Poly: return GetClosestPoint(collider.GetPolygonShape());
+            case ShapeType.PolyLine: return GetClosestPoint(collider.GetPolylineShape());
+        }
+
+        return new();
+    }
+    
+    
     /// <summary>
     /// Finds the closest point on this segment to a given point.
     /// </summary>

--- a/ShapeEngine/Geometry/SegmentDef/SegmentIntersectShape.cs
+++ b/ShapeEngine/Geometry/SegmentDef/SegmentIntersectShape.cs
@@ -14,6 +14,28 @@ namespace ShapeEngine.Geometry.SegmentDef;
 public readonly partial struct Segment
 {
     /// <summary>
+    /// Computes intersection points between this segment  and all colliders in the specified <see cref="CollisionObject"/>.
+    /// </summary>
+    /// <param name="collisionObject">The collision object containing colliders to test for intersection.</param>
+    /// <returns>
+    /// A <see cref="Dictionary{Collider, IntersectionPoints}"/> mapping each collider to its intersection points,
+    /// or null if no colliders are present or no intersections are found.
+    /// </returns>
+    public Dictionary<Collider, IntersectionPoints>? Intersect(CollisionObject collisionObject)
+    {
+        if (!collisionObject.HasColliders) return null;
+
+        Dictionary<Collider, IntersectionPoints>? intersections = null;
+        foreach (var collider in collisionObject.Colliders)
+        {
+            var result = Intersect(collider);
+            if(result == null) continue;
+            intersections ??= new();
+            intersections.Add(collider, result);
+        }
+        return intersections;
+    }
+    /// <summary>
     /// Computes all intersection points between this segment and a collider shape.
     /// </summary>
     /// <param name="collider">The collider whose shape will be tested for intersection. Must be enabled.</param>

--- a/ShapeEngine/Geometry/SegmentDef/SegmentOverlap.cs
+++ b/ShapeEngine/Geometry/SegmentDef/SegmentOverlap.cs
@@ -93,6 +93,22 @@ public readonly partial struct Segment
     /// <param name="segments">The list of segments to test against.</param>
     /// <returns>True if the segment overlaps any segment in the list; otherwise, false.</returns>
     public bool OverlapSegments(List<Segment> segments) => OverlapSegmentSegments(Start, End, segments);
+  
+    /// <summary>
+    /// Checks if the segment overlaps with any collider in the given <see cref="CollisionObject"/>.
+    /// </summary>
+    /// <param name="collision">The collision object containing colliders to check for overlap.</param>
+    /// <returns>True if any collider in the collision object overlaps the quad; otherwise, false.</returns>
+    public bool Overlap(CollisionObject collision)
+    {
+        if (!collision.HasColliders) return false;
+        foreach (var collider in collision.Colliders)
+        {
+            if(Overlap(collider)) return true;
+        }
+
+        return false;
+    }
     /// <summary>
     /// Determines whether the segment overlaps a collider's shape.
     /// </summary>

--- a/ShapeEngine/Geometry/SegmentsDef/SegmentsClosestPoint.cs
+++ b/ShapeEngine/Geometry/SegmentsDef/SegmentsClosestPoint.cs
@@ -159,6 +159,56 @@ public partial class Segments
     }
 
     /// <summary>
+    /// Finds the closest point on the segments to any collider in the given collision object.
+    /// </summary>
+    /// <param name="collisionObject">The collision object containing one or more colliders to compare against.</param>
+    /// <returns>
+    /// A <see cref="ClosestPointResult"/> containing the closest point information for the nearest collider.
+    /// </returns>
+    public ClosestPointResult GetClosestPoint(CollisionObject collisionObject)
+    {
+        if (!collisionObject.HasColliders) return new();
+        var closestPoint = new ClosestPointResult();
+        foreach (var collider in collisionObject.Colliders)
+        {
+            var result = GetClosestPoint(collider);
+            if(!result.Valid) continue;
+            if (!closestPoint.Valid) closestPoint = result;
+            else
+            {
+                if (result.DistanceSquared < closestPoint.DistanceSquared) closestPoint = result;
+            }
+        }
+        return closestPoint;
+    }
+  
+    /// <summary>
+    /// Finds the closest point on the segments to the given collider.
+    /// </summary>
+    /// <param name="collider">The collider to compare against.</param>
+    /// <returns>
+    /// A <see cref="ClosestPointResult"/> containing the closest point information for the collider.
+    /// </returns>
+    public ClosestPointResult GetClosestPoint(Collider collider)
+    {
+        if (!collider.Enabled) return new();
+        switch (collider.GetShapeType())
+        {
+            case ShapeType.Line: return GetClosestPoint(collider.GetLineShape());
+            case ShapeType.Ray: return GetClosestPoint(collider.GetRayShape());
+            case ShapeType.Circle: return GetClosestPoint(collider.GetCircleShape());
+            case ShapeType.Segment: return GetClosestPoint(collider.GetSegmentShape());
+            case ShapeType.Triangle: return GetClosestPoint(collider.GetTriangleShape());
+            case ShapeType.Rect: return GetClosestPoint(collider.GetRectShape());
+            case ShapeType.Quad: return GetClosestPoint(collider.GetQuadShape());
+            case ShapeType.Poly: return GetClosestPoint(collider.GetPolygonShape());
+            case ShapeType.PolyLine: return GetClosestPoint(collider.GetPolylineShape());
+        }
+
+        return new();
+    }
+    
+    /// <summary>
     /// Gets the closest point on the segments to a given line.
     /// </summary>
     /// <param name="other">The line to find the closest point to.</param>

--- a/ShapeEngine/Geometry/SegmentsDef/SegmentsIntersectShape.cs
+++ b/ShapeEngine/Geometry/SegmentsDef/SegmentsIntersectShape.cs
@@ -1,13 +1,86 @@
 using ShapeEngine.Geometry.CircleDef;
 using ShapeEngine.Geometry.CollisionSystem;
 using ShapeEngine.Geometry.LineDef;
+using ShapeEngine.Geometry.PolygonDef;
+using ShapeEngine.Geometry.PolylineDef;
+using ShapeEngine.Geometry.QuadDef;
 using ShapeEngine.Geometry.RayDef;
+using ShapeEngine.Geometry.RectDef;
 using ShapeEngine.Geometry.SegmentDef;
+using ShapeEngine.Geometry.TriangleDef;
 
 namespace ShapeEngine.Geometry.SegmentsDef;
 
 public partial class Segments
 {
+    /// <summary>
+    /// Computes intersection points between this segments  and all colliders in the specified <see cref="CollisionObject"/>.
+    /// </summary>
+    /// <param name="collisionObject">The collision object containing colliders to test for intersection.</param>
+    /// <returns>
+    /// A <see cref="Dictionary{Collider, IntersectionPoints}"/> mapping each collider to its intersection points,
+    /// or null if no colliders are present or no intersections are found.
+    /// </returns>
+    public Dictionary<Collider, IntersectionPoints>? Intersect(CollisionObject collisionObject)
+    {
+        if (!collisionObject.HasColliders) return null;
+
+        Dictionary<Collider, IntersectionPoints>? intersections = null;
+        foreach (var collider in collisionObject.Colliders)
+        {
+            var result = Intersect(collider);
+            if(result == null) continue;
+            intersections ??= new();
+            intersections.Add(collider, result);
+        }
+        return intersections;
+    }
+    /// <summary>
+    /// Computes all intersection points between this segments and a collider shape.
+    /// </summary>
+    /// <param name="collider">The collider whose shape will be tested for intersection. Must be enabled.</param>
+    /// <returns>A <see cref="IntersectionPoints"/> collection containing intersection points, or null if there are no intersections or the collider is disabled.</returns>
+    /// <remarks>
+    /// The method dispatches to the appropriate shape-specific intersection method based on the collider's shape type.
+    /// </remarks>
+    public IntersectionPoints? Intersect(Collider collider)
+    {
+        if (!collider.Enabled) return null;
+
+        switch (collider.GetShapeType())
+        {
+            case ShapeType.Circle:
+                var c = collider.GetCircleShape();
+                return IntersectShape(c);
+            case ShapeType.Ray:
+                var rayShape = collider.GetRayShape();
+                return IntersectShape(rayShape);
+            case ShapeType.Line:
+                var l = collider.GetLineShape();
+                return IntersectShape(l);
+            case ShapeType.Segment:
+                var s = collider.GetSegmentShape();
+                return IntersectShape(s);
+            case ShapeType.Triangle:
+                var t = collider.GetTriangleShape();
+                return IntersectShape(t);
+            case ShapeType.Rect:
+                var r = collider.GetRectShape();
+                return IntersectShape(r);
+            case ShapeType.Quad:
+                var q = collider.GetQuadShape();
+                return IntersectShape(q);
+            case ShapeType.Poly:
+                var p = collider.GetPolygonShape();
+                return IntersectShape(p);
+            case ShapeType.PolyLine:
+                var pl = collider.GetPolylineShape();
+                return IntersectShape(pl);
+        }
+
+        return null;
+    }
+    
     /// <summary>
     /// Intersects a ray with the segments.
     /// </summary>
@@ -100,6 +173,132 @@ public partial class Segments
         return points;
     }
 
+    /// <summary>
+    /// Computes all intersection points between this segment and a triangle.
+    /// </summary>
+    /// <param name="t">The triangle to test against.</param>
+    /// <returns>A <see cref="IntersectionPoints"/> collection containing intersection points, or null if there are no intersections.</returns>
+    /// <remarks>
+    /// May return up to two intersection points, as a segment can intersect a triangle at most twice.
+    /// </remarks>
+    public IntersectionPoints? IntersectShape(Triangle t)
+    {
+        IntersectionPoints? points = null;
+        foreach (var segment in this)
+        {
+            var result = Segment.IntersectSegmentTriangle(segment.Start, segment.End, t.A, t.B, t.C);
+            if (result.a.Valid || result.b.Valid)
+            {
+                points ??= new();
+                if (result.a.Valid) points.Add(result.a);
+                if (result.b.Valid) points.Add(result.b);
+            }
+        }
+        return points;
+    }
+
+    /// <summary>
+    /// Computes all intersection points between this segment and a quadrilateral.
+    /// </summary>
+    /// <param name="q">The quadrilateral to test against.</param>
+    /// <returns>A <see cref="IntersectionPoints"/> collection containing intersection points, or null if there are no intersections.</returns>
+    /// <remarks>
+    /// May return up to two intersection points, as a segment can intersect a quad at most twice.
+    /// </remarks>
+    public IntersectionPoints? IntersectShape(Quad q)
+    {
+        IntersectionPoints? points = null;
+        foreach (var segment in this)
+        {
+            var result = Segment.IntersectSegmentQuad(segment.Start, segment.End, q.A, q.B, q.C, q.D);
+            if (result.a.Valid || result.b.Valid)
+            {
+                points ??= new();
+                if (result.a.Valid) points.Add(result.a);
+                if (result.b.Valid) points.Add(result.b);
+            }
+        }
+        return points;
+    }
+
+    /// <summary>
+    /// Computes all intersection points between this segment and a rectangle.
+    /// </summary>
+    /// <param name="r">The rectangle to test against.</param>
+    /// <returns>A <see cref="IntersectionPoints"/> collection containing intersection points, or null if there are no intersections.</returns>
+    /// <remarks>
+    /// May return up to two intersection points, as a segment can intersect a rectangle at most twice.
+    /// </remarks>
+    public IntersectionPoints? IntersectShape(Rect r)
+    {
+        IntersectionPoints? points = null;
+        foreach (var segment in this)
+        {
+            var result = Segment.IntersectSegmentRect(segment.Start, segment.End, r.A, r.B, r.C, r.D);
+            if (result.a.Valid || result.b.Valid)
+            {
+                points ??= new();
+                if (result.a.Valid) points.Add(result.a);
+                if (result.b.Valid) points.Add(result.b);
+            }
+        }
+        return points;
+    }
+
+    /// <summary>
+    /// Computes all intersection points between this segment and a polygon.
+    /// </summary>
+    /// <param name="p">The polygon to test against. Must have at least 3 vertices.</param>
+    /// <returns>A <see cref="IntersectionPoints"/> collection containing intersection points, or null if there are no intersections.</returns>
+    /// <remarks>
+    /// Iterates over all polygon edges and collects intersection points with the segment.
+    /// </remarks>
+    public IntersectionPoints? IntersectShape(Polygon p)
+    {
+        if (p.Count < 3) return null;
+        IntersectionPoints? points = null;
+        foreach (var segment in this)
+        {
+            for (var i = 0; i < p.Count; i++)
+            {
+                var colPoint = Segment.IntersectSegmentSegment(segment.Start, segment.End, p[i], p[(i + 1) % p.Count]);
+                if (colPoint.Valid)
+                {
+                    points ??= new();
+                    points.Add(colPoint);
+                }
+            }
+        }
+        return points;
+    }
+
+    /// <summary>
+    /// Computes all intersection points between this segment and a polyline.
+    /// </summary>
+    /// <param name="pl">The polyline to test against. Must have at least 2 vertices.</param>
+    /// <returns>A <see cref="IntersectionPoints"/> collection containing intersection points, or null if there are no intersections.</returns>
+    /// <remarks>
+    /// Iterates over all polyline segments and collects intersection points with the segment.
+    /// </remarks>
+    public IntersectionPoints? IntersectShape(Polyline pl)
+    {
+        if (pl.Count < 2) return null;
+        IntersectionPoints? points = null;
+        foreach (var segment in this)
+        {
+            for (var i = 0; i < pl.Count - 1; i++)
+            {
+                var colPoint = Segment.IntersectSegmentSegment(segment.Start, segment.End, pl[i], pl[i + 1]);
+                if (colPoint.Valid)
+                {
+                    points ??= new();
+                    points.Add(colPoint);
+                }
+            }
+        }
+        return points;
+    }
+    
     /// <summary>
     /// Intersects a set of segments with the segments.
     /// </summary>

--- a/ShapeEngine/Geometry/SegmentsDef/SegmentsOverlap.cs
+++ b/ShapeEngine/Geometry/SegmentsDef/SegmentsOverlap.cs
@@ -1,5 +1,6 @@
 using System.Numerics;
 using ShapeEngine.Geometry.CircleDef;
+using ShapeEngine.Geometry.CollisionSystem;
 using ShapeEngine.Geometry.LineDef;
 using ShapeEngine.Geometry.PolygonDef;
 using ShapeEngine.Geometry.PolylineDef;
@@ -85,6 +86,68 @@ public partial class Segments
     /// <param name="segments">The other set of segments.</param>
     /// <returns>True if the segments overlap with the other set of segments, false otherwise.</returns>
     public bool OverlapSegments(List<Segment> segments) => OverlapSegmentsSegments(this, segments);
+   
+    /// <summary>
+    /// Checks if any of the segments overlaps with any collider in the given <see cref="CollisionObject"/>.
+    /// </summary>
+    /// <param name="collision">The collision object containing colliders to check for overlap.</param>
+    /// <returns>True if any collider in the collision object overlaps the quad; otherwise, false.</returns>
+    public bool Overlap(CollisionObject collision)
+    {
+        if (!collision.HasColliders) return false;
+        foreach (var collider in collision.Colliders)
+        {
+            if(Overlap(collider)) return true;
+        }
+
+        return false;
+    }
+    /// <summary>
+    /// Determines whether any of the segments overlaps with a collider's shape.
+    /// </summary>
+    /// <param name="collider">The collider whose shape to test against. Must be enabled.</param>
+    /// <returns>True if the segment overlaps the collider's shape; otherwise, false.</returns>
+    /// <remarks>
+    /// Dispatches to the appropriate shape-specific overlap method based on the collider's shape type.
+    /// </remarks>
+    public bool Overlap(Collider collider)
+    {
+        if (!collider.Enabled) return false;
+
+        switch (collider.GetShapeType())
+        {
+            case ShapeType.Circle:
+                var c = collider.GetCircleShape();
+                return OverlapShape(c);
+            case ShapeType.Segment:
+                var s = collider.GetSegmentShape();
+                return OverlapShape(s);
+            case ShapeType.Ray:
+                var rayShape = collider.GetRayShape();
+                return OverlapShape(rayShape);
+            case ShapeType.Line:
+                var l = collider.GetLineShape();
+                return OverlapShape(l);
+            case ShapeType.Triangle:
+                var t = collider.GetTriangleShape();
+                return OverlapShape(t);
+            case ShapeType.Rect:
+                var r = collider.GetRectShape();
+                return OverlapShape(r);
+            case ShapeType.Quad:
+                var q = collider.GetQuadShape();
+                return OverlapShape(q);
+            case ShapeType.Poly:
+                var p = collider.GetPolygonShape();
+                return OverlapShape(p);
+            case ShapeType.PolyLine:
+                var pl = collider.GetPolylineShape();
+                return OverlapShape(pl);
+        }
+
+        return false;
+    }
+
     /// <summary>
     /// Checks if the segments overlap with a line.
     /// </summary>

--- a/ShapeEngine/Geometry/TriangleDef/TriangleClosestPoint.cs
+++ b/ShapeEngine/Geometry/TriangleDef/TriangleClosestPoint.cs
@@ -16,6 +16,56 @@ namespace ShapeEngine.Geometry.TriangleDef;
 public readonly partial struct Triangle
 {
     /// <summary>
+    /// Finds the closest point on the triangle's perimeter to any collider in the given collision object.
+    /// </summary>
+    /// <param name="collisionObject">The collision object containing one or more colliders to compare against.</param>
+    /// <returns>
+    /// A <see cref="ClosestPointResult"/> containing the closest point information for the nearest collider.
+    /// </returns>
+    public ClosestPointResult GetClosestPoint(CollisionObject collisionObject)
+    {
+        if (!collisionObject.HasColliders) return new();
+        var closestPoint = new ClosestPointResult();
+        foreach (var collider in collisionObject.Colliders)
+        {
+            var result = GetClosestPoint(collider);
+            if(!result.Valid) continue;
+            if (!closestPoint.Valid) closestPoint = result;
+            else
+            {
+                if (result.DistanceSquared < closestPoint.DistanceSquared) closestPoint = result;
+            }
+        }
+        return closestPoint;
+    }
+  
+    /// <summary>
+    /// Finds the closest point on this triangle's perimeter to the given collider.
+    /// </summary>
+    /// <param name="collider">The collider to compare against.</param>
+    /// <returns>
+    /// A <see cref="ClosestPointResult"/> containing the closest point information for the collider.
+    /// </returns>
+    public ClosestPointResult GetClosestPoint(Collider collider)
+    {
+        if (!collider.Enabled) return new();
+        switch (collider.GetShapeType())
+        {
+            case ShapeType.Line: return GetClosestPoint(collider.GetLineShape());
+            case ShapeType.Ray: return GetClosestPoint(collider.GetRayShape());
+            case ShapeType.Circle: return GetClosestPoint(collider.GetCircleShape());
+            case ShapeType.Segment: return GetClosestPoint(collider.GetSegmentShape());
+            case ShapeType.Triangle: return GetClosestPoint(collider.GetTriangleShape());
+            case ShapeType.Rect: return GetClosestPoint(collider.GetRectShape());
+            case ShapeType.Quad: return GetClosestPoint(collider.GetQuadShape());
+            case ShapeType.Poly: return GetClosestPoint(collider.GetPolygonShape());
+            case ShapeType.PolyLine: return GetClosestPoint(collider.GetPolylineShape());
+        }
+
+        return new();
+    }
+    
+    /// <summary>
     /// Finds the closest point on a triangle's perimeter to a specified point using static triangle vertices.
     /// </summary>
     /// <param name="a">The first vertex of the triangle.</param>

--- a/ShapeEngine/Geometry/TriangleDef/TriangleContains.cs
+++ b/ShapeEngine/Geometry/TriangleDef/TriangleContains.cs
@@ -98,6 +98,7 @@ public readonly partial struct Triangle
     /// </remarks>
     public bool ContainsCollider(Collider collider)
     {
+        if (!collider.Enabled) return false;
         switch (collider.GetShapeType())
         {
             case ShapeType.Circle: return ContainsShape(collider.GetCircleShape());

--- a/ShapeEngine/Geometry/TriangleDef/TriangleIntersectShape.cs
+++ b/ShapeEngine/Geometry/TriangleDef/TriangleIntersectShape.cs
@@ -14,6 +14,28 @@ namespace ShapeEngine.Geometry.TriangleDef;
 public readonly partial struct Triangle
 {
     /// <summary>
+    /// Computes intersection points between this triangle and all colliders in the specified <see cref="CollisionObject"/>.
+    /// </summary>
+    /// <param name="collisionObject">The collision object containing colliders to test for intersection.</param>
+    /// <returns>
+    /// A <see cref="Dictionary{Collider, IntersectionPoints}"/> mapping each collider to its intersection points,
+    /// or null if no colliders are present or no intersections are found.
+    /// </returns>
+    public Dictionary<Collider, IntersectionPoints>? Intersect(CollisionObject collisionObject)
+    {
+        if (!collisionObject.HasColliders) return null;
+
+        Dictionary<Collider, IntersectionPoints>? intersections = null;
+        foreach (var collider in collisionObject.Colliders)
+        {
+            var result = Intersect(collider);
+            if(result == null) continue;
+            intersections ??= new();
+            intersections.Add(collider, result);
+        }
+        return intersections;
+    }
+    /// <summary>
     /// Tests for intersection between this triangle and a collider, returning collision points if found.
     /// </summary>
     /// <param name="collider">The collider to test intersection with.</param>

--- a/ShapeEngine/Geometry/TriangleDef/TriangleOverlap.cs
+++ b/ShapeEngine/Geometry/TriangleDef/TriangleOverlap.cs
@@ -156,6 +156,21 @@ public readonly partial struct Triangle
     public bool OverlapShape(Ray ray) => OverlapTriangleRay(A, B, C, ray.Point, ray.Direction);
 
     /// <summary>
+    /// Checks if the triangle overlaps with any collider in the given <see cref="CollisionObject"/>.
+    /// </summary>
+    /// <param name="collision">The collision object containing colliders to check for overlap.</param>
+    /// <returns>True if any collider in the collision object overlaps the triangle; otherwise, false.</returns>
+    public bool Overlap(CollisionObject collision)
+    {
+        if (!collision.HasColliders) return false;
+        foreach (var collider in collision.Colliders)
+        {
+            if(Overlap(collider)) return true;
+        }
+
+        return false;
+    }
+    /// <summary>
     /// Tests whether this triangle overlaps with a collider of any supported shape type.
     /// </summary>
     /// <param name="collider">The collider to test for overlap with.</param>
@@ -355,8 +370,6 @@ public readonly partial struct Triangle
     {
         if (poly.Count < 3) return false;
 
-        //TODO: This function might not check all possible scenarios for overlaps
-        // in testing it seems to work 100% but AI thinks it does not check for everything
         if (ContainsPoint(poly[0])) return true;
 
         var oddNodes = false;

--- a/ShapeEngine/Geometry/TriangulationDef/TriangulationClosestPoint.cs
+++ b/ShapeEngine/Geometry/TriangulationDef/TriangulationClosestPoint.cs
@@ -232,6 +232,69 @@ public partial class Triangulation
     }
 
     /// <summary>
+    /// Finds the closest point in the triangle collection to any collider in the given collision object.
+    /// </summary>
+    /// <param name="collisionObject">The collision object containing one or more colliders to compare against.</param>
+    /// <param name="triangleIndex">The index of the triangle in the triangulation that is closest.</param>
+    /// <returns>
+    /// A <see cref="ClosestPointResult"/> containing the closest point information for the nearest collider.
+    /// </returns>
+    public ClosestPointResult GetClosestPoint(CollisionObject collisionObject, out int triangleIndex)
+    {
+        triangleIndex = -1;
+        if (!collisionObject.HasColliders) return new();
+        var closestPoint = new ClosestPointResult();
+        foreach (var collider in collisionObject.Colliders)
+        {
+            var result = GetClosestPoint(collider, out int index);
+            if(!result.Valid) continue;
+            if (!closestPoint.Valid)
+            {
+                closestPoint = result;
+                triangleIndex = index;
+            }
+            else
+            {
+                if (result.DistanceSquared < closestPoint.DistanceSquared)
+                {
+                    closestPoint = result;
+                    triangleIndex = index;
+                }
+            }
+        }
+        return closestPoint;
+    }
+
+    /// <summary>
+    /// Finds the closest point on the triangle collection to the given collider.
+    /// </summary>
+    /// <param name="collider">The collider to compare against.</param>
+    /// <param name="triangleIndex">The index of the triangle in the triangulation that is closest to the collider.</param>
+    /// <returns>
+    /// A <see cref="ClosestPointResult"/> containing the closest point information for the collider.
+    /// </returns>
+    public ClosestPointResult GetClosestPoint(Collider collider, out int triangleIndex)
+    {
+        triangleIndex = -1;
+        if (!collider.Enabled) return new();
+        switch (collider.GetShapeType())
+        {
+            case ShapeType.Line: return GetClosestPoint(collider.GetLineShape(), out triangleIndex);
+            case ShapeType.Ray: return GetClosestPoint(collider.GetRayShape(), out triangleIndex);
+            case ShapeType.Circle: return GetClosestPoint(collider.GetCircleShape(), out triangleIndex);
+            case ShapeType.Segment: return GetClosestPoint(collider.GetSegmentShape(), out triangleIndex);
+            case ShapeType.Triangle: return GetClosestPoint(collider.GetTriangleShape(), out triangleIndex);
+            case ShapeType.Rect: return GetClosestPoint(collider.GetRectShape(), out triangleIndex);
+            case ShapeType.Quad: return GetClosestPoint(collider.GetQuadShape(), out triangleIndex);
+            case ShapeType.Poly: return GetClosestPoint(collider.GetPolygonShape(),out triangleIndex);
+            case ShapeType.PolyLine: return GetClosestPoint(collider.GetPolylineShape(),out triangleIndex);
+        }
+
+        return new();
+    }
+    
+    
+    /// <summary>
     /// Finds the closest point in the triangulation to the specified line.
     /// </summary>
     /// <param name="other">The line to find the closest point to.</param>

--- a/ShapeEngine/Geometry/TriangulationDef/TriangulationContainsPoint.cs
+++ b/ShapeEngine/Geometry/TriangulationDef/TriangulationContainsPoint.cs
@@ -1,4 +1,13 @@
 using System.Numerics;
+using ShapeEngine.Geometry.CircleDef;
+using ShapeEngine.Geometry.CollisionSystem;
+using ShapeEngine.Geometry.PointsDef;
+using ShapeEngine.Geometry.PolygonDef;
+using ShapeEngine.Geometry.PolylineDef;
+using ShapeEngine.Geometry.QuadDef;
+using ShapeEngine.Geometry.RectDef;
+using ShapeEngine.Geometry.SegmentDef;
+using ShapeEngine.Geometry.TriangleDef;
 
 namespace ShapeEngine.Geometry.TriangulationDef;
 
@@ -43,5 +52,239 @@ public partial class Triangulation
         triangleIndex = -1;
         return false;
     }
+    
+    /// <summary>
+    /// Checks if any collider of a collision object is contained within any triangle of this triangulation.
+    /// </summary>
+    /// <param name="collisionObject">The collision object to check.</param>
+    /// <param name="triangleIndex">The index of the triangle that contains a collider of the collision object.</param>
+    /// <returns>True if any collider is contained within a triangle, false otherwise.</returns>
+    /// <remarks>Stops at the first collider that is contained in a triangle.</remarks>
+    public bool ContainsCollisionObject(CollisionObject collisionObject, out int triangleIndex)
+    {
+        triangleIndex = -1;
+        if (!collisionObject.HasColliders) return false;
+        foreach (var collider in collisionObject.Colliders)
+        {
+            if (ContainsCollider(collider, out int index))
+            {
+                triangleIndex = index;
+                return true;
+            }
+        }
+        return false;
+    }
+    /// <summary>
+    /// Checks if a collider is contained within any triangle of this triangulation.
+    /// </summary>
+    /// <param name="collider">The collider to check.</param>
+    /// <param name="triangleIndex">The index of the triangle that contains the collider.</param>
+    /// <returns>True if the collider is contained within a triangle, false otherwise.</returns>
+    /// <remarks>The collider is checked based on its shape type.</remarks>
+    public bool ContainsCollider(Collider collider, out int triangleIndex)
+    {
+        triangleIndex = -1;
+        if (!collider.Enabled) return false;
+        
+        switch (collider.GetShapeType())
+        {
+            case ShapeType.Circle: return ContainsShape(collider.GetCircleShape(), out triangleIndex);
+            case ShapeType.Segment: return ContainsShape(collider.GetSegmentShape(), out triangleIndex);
+            case ShapeType.Triangle: return ContainsShape(collider.GetTriangleShape(), out triangleIndex);
+            case ShapeType.Quad: return ContainsShape(collider.GetQuadShape(), out triangleIndex);
+            case ShapeType.Rect: return ContainsShape(collider.GetRectShape(), out triangleIndex);
+            case ShapeType.Poly: return ContainsShape(collider.GetPolygonShape(), out triangleIndex);
+            case ShapeType.PolyLine: return ContainsShape(collider.GetPolylineShape(), out triangleIndex);
+        }
+        return false;
+    }
+    /// <summary>
+    /// Checks if a segment is contained within any triangle of this triangulation.
+    /// </summary>
+    /// <param name="segment">The segment to check.</param>
+    /// <param name="triangleIndex">The index of the triangle that contains the segment.</param>
+    /// <returns>True if the segment is contained in a triangle, false otherwise.</returns>
+    /// <remarks>A segment is contained if both its start and end points are inside a triangle.</remarks>
+    public bool ContainsShape(Segment segment, out int triangleIndex)
+    {
+        triangleIndex = -1;
+        
+        for (int i = 0; i < Count; i++)
+        {
+            var triangle = this[i];
+            if (triangle.ContainsPoints(segment.Start, segment.End))
+            {
+                triangleIndex = i;
+                return true;
+            }
+        }
 
+        return false;
+    }
+
+    /// <summary>
+    /// Checks if a circle is contained within any triangle of this triangulation.
+    /// </summary>
+    /// <param name="circle">The circle to check.</param>
+    /// <param name="triangleIndex">The index of the triangle that contains the circle.</param>
+    /// <returns>True if the circle is contained in a triangle, false otherwise.</returns>
+    /// <remarks>Stops at the first triangle that contains the circle.</remarks>
+    public bool ContainsShape(Circle circle, out int triangleIndex)
+    {
+        triangleIndex = -1;
+        
+        for (int i = 0; i < Count; i++)
+        {
+            var triangle = this[i];
+            if (triangle.ContainsShape(circle))
+            {
+                triangleIndex = i;
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Checks if a rectangle is contained within any triangle of this triangulation.
+    /// </summary>
+    /// <param name="rect">The rectangle to check.</param>
+    /// <param name="triangleIndex">The index of the triangle that contains the rectangle.</param>
+    /// <returns>True if the rectangle is contained in a triangle, false otherwise.</returns>
+    /// <remarks>Stops at the first triangle that contains the rectangle.</remarks>
+    public bool ContainsShape(Rect rect, out int triangleIndex)
+    {
+        triangleIndex = -1;
+        
+        for (int i = 0; i < Count; i++)
+        {
+            var triangle = this[i];
+            if (triangle.ContainsShape(rect))
+            {
+                triangleIndex = i;
+                return true;
+            }
+        }
+
+        return false;
+    }
+    /// <summary>
+    /// Checks if a triangle is contained within any triangle of this triangulation.
+    /// </summary>
+    /// <param name="triangle">The triangle to check.</param>
+    /// <param name="triangleIndex">The index of the triangle that contains the given triangle.</param>
+    /// <returns>True if the triangle is contained in a triangle, false otherwise.</returns>
+    /// <remarks>Stops at the first triangle that contains the given triangle.</remarks>
+    public bool ContainsShape(Triangle triangle, out int triangleIndex)
+    {
+        triangleIndex = -1;
+        
+        for (int i = 0; i < Count; i++)
+        {
+            var tri = this[i];
+            if (tri.ContainsShape(triangle))
+            {
+                triangleIndex = i;
+                return true;
+            }
+        }
+
+        return false;
+    }
+    /// <summary>
+    /// Checks if a quad is contained within any triangle of this triangulation.
+    /// </summary>
+    /// <param name="quad">The quad to check.</param>
+    /// <param name="triangleIndex">The index of the triangle that contains the quad.</param>
+    /// <returns>True if the quad is contained in a triangle, false otherwise.</returns>
+    /// <remarks>Stops at the first triangle that contains the quad.</remarks>
+    public bool ContainsShape(Quad quad, out int triangleIndex)
+    {
+        triangleIndex = -1;
+        
+        for (int i = 0; i < Count; i++)
+        {
+            var triangle = this[i];
+            if (triangle.ContainsShape(quad))
+            {
+                triangleIndex = i;
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Checks if a polyline is contained within any triangle of this triangulation.
+    /// </summary>
+    /// <param name="polyline">The polyline to check.</param>
+    /// <param name="triangleIndex">The index of the triangle that contains the polyline.</param>
+    /// <returns>True if the polyline is contained in a triangle, false otherwise.</returns>
+    /// <remarks>Stops at the first triangle that contains the polyline.</remarks>
+    public bool ContainsShape(Polyline polyline, out int triangleIndex)
+    {
+        triangleIndex = -1;
+        
+        for (int i = 0; i < Count; i++)
+        {
+            var triangle = this[i];
+            if (triangle.ContainsShape(polyline))
+            {
+                triangleIndex = i;
+                return true;
+            }
+        }
+
+        return false;
+    }
+    /// <summary>
+    /// Checks if a polygon is contained within any triangle of this triangulation.
+    /// </summary>
+    /// <param name="polygon">The polygon to check.</param>
+    /// <param name="triangleIndex">The index of the triangle that contains the polygon.</param>
+    /// <returns>True if the polygon is contained in a triangle, false otherwise.</returns>
+    /// <remarks>Stops at the first triangle that contains the polygon.</remarks>
+    public bool ContainsShape(Polygon polygon, out int triangleIndex)
+    {
+        triangleIndex = -1;
+        
+        for (int i = 0; i < Count; i++)
+        {
+            var triangle = this[i];
+            if (triangle.ContainsShape(polygon))
+            {
+                triangleIndex = i;
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Checks if a collection of points is contained within any triangle of this triangulation.
+    /// </summary>
+    /// <param name="points">The points to check.</param>
+    /// <param name="triangleIndex">The index of the triangle that contains the points.</param>
+    /// <returns>True if the points are contained in a triangle, false otherwise.</returns>
+    /// <remarks>Stops at the first triangle that contains the points.</remarks>
+    public bool ContainsShape(Points points, out int triangleIndex)
+    {
+        triangleIndex = -1;
+        
+        for (int i = 0; i < Count; i++)
+        {
+            var triangle = this[i];
+            if (triangle.ContainsShape(points))
+            {
+                triangleIndex = i;
+                return true;
+            }
+        }
+
+        return false;
+    }
+    
 }

--- a/ShapeEngine/Geometry/TriangulationDef/TriangulationIntersectShape.cs
+++ b/ShapeEngine/Geometry/TriangulationDef/TriangulationIntersectShape.cs
@@ -16,6 +16,28 @@ namespace ShapeEngine.Geometry.TriangulationDef;
 public partial class Triangulation
 {
     /// <summary>
+    /// Computes intersection points between the triangles and all colliders in the specified <see cref="CollisionObject"/>.
+    /// </summary>
+    /// <param name="collisionObject">The collision object containing colliders to test for intersection.</param>
+    /// <returns>
+    /// A <see cref="Dictionary{Collider, IntersectionPoints}"/> mapping each collider to its intersection points,
+    /// or null if no colliders are present or no intersections are found.
+    /// </returns>
+    public Dictionary<Collider, Dictionary<int, IntersectionPoints>?>? Intersect(CollisionObject collisionObject)
+    {
+        if (!collisionObject.HasColliders) return null;
+
+        Dictionary<Collider, Dictionary<int, IntersectionPoints>?>? intersections = null;
+        foreach (var collider in collisionObject.Colliders)
+        {
+            var result = Intersect(collider);
+            if(result == null) continue;
+            intersections ??= new();
+            intersections.Add(collider, result);
+        }
+        return intersections;
+    }
+    /// <summary>
     /// Checks for intersections between the triangles in this triangulation and the specified collider.
     /// </summary>
     /// <param name="collider">The collider to check for intersections.</param>
@@ -23,6 +45,7 @@ public partial class Triangulation
     /// <remarks>Only triangles with valid intersections are included in the result.</remarks>
     public Dictionary<int, IntersectionPoints>? Intersect(Collider collider)
     {
+        if (!collider.Enabled) return null;
         Dictionary<int, IntersectionPoints>? result = null;
         for (int i = 0; i < Count; i++)
         {

--- a/ShapeEngine/Geometry/TriangulationDef/TriangulationOverlap.cs
+++ b/ShapeEngine/Geometry/TriangulationDef/TriangulationOverlap.cs
@@ -18,7 +18,7 @@ public partial class Triangulation
     /// Checks if a triangle in the collection overlaps with any collider in the given <see cref="CollisionObject"/>.
     /// </summary>
     /// <param name="collision">The collision object containing colliders to check for overlap.</param>
-    /// <returns>True if any collider in the collision object overlaps the quad; otherwise, false.</returns>
+    /// <returns>True if any collider in the collision object overlaps any triangle in this collection; otherwise, false.</returns>
     public bool Overlap(CollisionObject collision)
     {
         if (!collision.HasColliders) return false;

--- a/ShapeEngine/Geometry/TriangulationDef/TriangulationOverlap.cs
+++ b/ShapeEngine/Geometry/TriangulationDef/TriangulationOverlap.cs
@@ -15,12 +15,28 @@ namespace ShapeEngine.Geometry.TriangulationDef;
 public partial class Triangulation
 {
     /// <summary>
+    /// Checks if a triangle in the collection overlaps with any collider in the given <see cref="CollisionObject"/>.
+    /// </summary>
+    /// <param name="collision">The collision object containing colliders to check for overlap.</param>
+    /// <returns>True if any collider in the collision object overlaps the quad; otherwise, false.</returns>
+    public bool Overlap(CollisionObject collision)
+    {
+        if (!collision.HasColliders) return false;
+        foreach (var collider in collision.Colliders)
+        {
+            if(Overlap(collider)) return true;
+        }
+
+        return false;
+    }
+    /// <summary>
     /// Determines if any triangle in this collection overlaps with the specified collider.
     /// </summary>
     /// <param name="collider">The collider to check for overlap.</param>
     /// <returns><c>true</c> if any triangle overlaps with the collider; otherwise, <c>false</c>.</returns>
     public bool Overlap(Collider collider)
     {
+        if (!collider.Enabled) return false;
         for (int i = 0; i < Count; i++)
         {
             var tri = this[i];


### PR DESCRIPTION
### New Features
This pull request introduces new methods across the  `Segment`, `Line`, `Ray`, `Circle`, `Quad`, `Rect`, `Triangle`, `Polyline`,  and `Polygon` shape types to enhance support for collision detection and geometric operations involving `CollisionObject` instances. These changes improve functionality for finding closest points, detecting overlaps, computing intersections, and validating containment for multiple colliders. 

### Fixes
All shape functions (`overlap`, `intersect`, `contain`, `closest point`) involving colliders now check if the collider is enabled at the beginning.