### PR TITLE
Normalized float

### DIFF
--- a/ShapeEngine/Core/Structs/NormalizedDouble.cs
+++ b/ShapeEngine/Core/Structs/NormalizedDouble.cs
@@ -6,6 +6,16 @@ namespace ShapeEngine.Core.Structs;
 public readonly struct NormalizedDouble  : IEquatable<NormalizedDouble>
 {
     /// <summary>
+    /// Represents the normalized double value 0.
+    /// </summary>
+    public static readonly NormalizedDouble Zero = new(0.0);
+    
+    /// <summary>
+    /// Represents the normalized double value 1.
+    /// </summary>
+    public static readonly NormalizedDouble One = new(1.0);
+    
+    /// <summary>
     /// Initializes a new instance of <see cref="NormalizedDouble"/>, clamping the value to <c>[0, 1]</c>.
     /// </summary>
     /// <param name="value">The value to clamp.</param>
@@ -24,6 +34,20 @@ public readonly struct NormalizedDouble  : IEquatable<NormalizedDouble>
     /// </summary>
     public NormalizedDouble Inverse => new(1.0 - Value);
 
+    /// <summary>
+    /// Returns a <see cref="NormalizedDouble"/> representing the minimum of this value and another.
+    /// </summary>
+    /// <param name="other">The other <see cref="NormalizedDouble"/> to compare with.</param>
+    /// <returns>The minimum value as a <see cref="NormalizedDouble"/>.</returns>
+    public NormalizedDouble Min(NormalizedDouble other) => new(Math.Min(Value, other.Value));
+    
+    /// <summary>
+    /// Returns a <see cref="NormalizedDouble"/> representing the maximum of this value and another.
+    /// </summary>
+    /// <param name="other">The other <see cref="NormalizedDouble"/> to compare with.</param>
+    /// <returns>The maximum value as a <see cref="NormalizedDouble"/>.</returns>
+    public NormalizedDouble Max(NormalizedDouble other) => new(Math.Max(Value, other.Value));
+    
     /// <summary>
     /// Linearly interpolates between two double values using a normalized interpolation factor.
     /// </summary>

--- a/ShapeEngine/Core/Structs/NormalizedFloat.cs
+++ b/ShapeEngine/Core/Structs/NormalizedFloat.cs
@@ -6,6 +6,16 @@ namespace ShapeEngine.Core.Structs;
 public readonly struct NormalizedFloat : IEquatable<NormalizedFloat>
 {
     /// <summary>
+    /// Represents the normalized float value 0.
+    /// </summary>
+    public static readonly NormalizedFloat Zero = new(0f);
+    
+    /// <summary>
+    /// Represents the normalized float value 1.
+    /// </summary>
+    public static readonly NormalizedFloat One = new(1f);
+    
+    /// <summary>
     /// Initializes a new instance of <see cref="NormalizedFloat"/>, clamping the value to <c>[0, 1]</c>.
     /// </summary>
     /// <param name="value">The value to clamp.</param>
@@ -24,6 +34,19 @@ public readonly struct NormalizedFloat : IEquatable<NormalizedFloat>
     /// </summary>
     public NormalizedFloat Inverse => new(1f - Value);
     
+    /// <summary>
+    /// Returns a <see cref="NormalizedFloat"/> representing the minimum of this value and another.
+    /// </summary>
+    /// <param name="other">The other <see cref="NormalizedFloat"/> to compare with.</param>
+    /// <returns>The minimum value as a <see cref="NormalizedFloat"/>.</returns>
+    public NormalizedFloat Min(NormalizedFloat other) => new(MathF.Min(Value, other.Value));
+    
+    /// <summary>
+    /// Returns a <see cref="NormalizedFloat"/> representing the maximum of this value and another.
+    /// </summary>
+    /// <param name="other">The other <see cref="NormalizedFloat"/> to compare with.</param>
+    /// <returns>The maximum value as a <see cref="NormalizedFloat"/>.</returns>
+    public NormalizedFloat Max(NormalizedFloat other) => new(MathF.Max(Value, other.Value));
 
     /// <summary>
     /// Linearly interpolates between two float values using a normalized interpolation factor.

--- a/ShapeEngine/Core/Structs/SignedNormalizedDouble.cs
+++ b/ShapeEngine/Core/Structs/SignedNormalizedDouble.cs
@@ -7,6 +7,21 @@ namespace ShapeEngine.Core.Structs;
 public readonly struct SignedNormalizedDouble : IEquatable<SignedNormalizedDouble>
 {
     /// <summary>
+    /// Represents the signed normalized double value -1.
+    /// </summary>
+    public static readonly SignedNormalizedDouble MinusOne = new(-1.0);
+    
+    /// <summary>
+    /// Represents the signed normalized double value 0.
+    /// </summary>
+    public static readonly SignedNormalizedDouble Zero = new(0.0);
+    
+    /// <summary>
+    /// Represents the signed normalized double value 1.
+    /// </summary>
+    public static readonly SignedNormalizedDouble One = new(1.0);
+    
+    /// <summary>
     /// Initializes a new instance of <see cref="SignedNormalizedDouble"/>, clamping the value to <c>[-1, 1]</c>.
     /// </summary>
     /// <param name="value">The value to clamp.</param>
@@ -19,13 +34,26 @@ public readonly struct SignedNormalizedDouble : IEquatable<SignedNormalizedDoubl
     /// Gets the signed normalized value in the range <c>[-1, 1]</c>.
     /// </summary>
     public double Value { get; }
-
     
     /// <summary>
     /// Gets the inverse (negated value) of this <see cref="SignedNormalizedDouble"/>.
     /// </summary>
     public SignedNormalizedDouble Inverse => new(-Value);
   
+    /// <summary>
+    /// Returns a <see cref="SignedNormalizedDouble"/> representing the minimum of this value and another.
+    /// </summary>
+    /// <param name="other">The other <see cref="SignedNormalizedDouble"/> to compare with.</param>
+    /// <returns>The minimum value as a <see cref="SignedNormalizedDouble"/>.</returns>
+    public SignedNormalizedDouble Min(SignedNormalizedDouble other) => new(Math.Min(Value, other.Value));
+    
+    /// <summary>
+    /// Returns a <see cref="SignedNormalizedDouble"/> representing the maximum of this value and another.
+    /// </summary>
+    /// <param name="other">The other <see cref="SignedNormalizedDouble"/> to compare with.</param>
+    /// <returns>The maximum value as a <see cref="SignedNormalizedDouble"/>.</returns>
+    public SignedNormalizedDouble Max(SignedNormalizedDouble other) => new(Math.Max(Value, other.Value));
+    
     /// <summary>
     /// Linearly interpolates between two double values using a normalized interpolation factor.
     /// </summary>

--- a/ShapeEngine/Core/Structs/SignedNormalizedFloat.cs
+++ b/ShapeEngine/Core/Structs/SignedNormalizedFloat.cs
@@ -6,6 +6,21 @@ namespace ShapeEngine.Core.Structs;
 public readonly struct SignedNormalizedFloat : IEquatable<SignedNormalizedFloat>
 {
     /// <summary>
+    /// Represents the signed normalized float value -1.
+    /// </summary>
+    public static readonly SignedNormalizedFloat MinusOne = new(-1f);
+    
+    /// <summary>
+    /// Represents the signed normalized float value 0.
+    /// </summary>
+    public static readonly SignedNormalizedFloat Zero = new(0f);
+    
+    /// <summary>
+    /// Represents the signed normalized float value 1.
+    /// </summary>
+    public static readonly SignedNormalizedFloat One = new(1f);
+    
+    /// <summary>
     /// Initializes a new instance of <see cref="SignedNormalizedFloat"/>, clamping the value to <c>[-1, 1]</c>.
     /// </summary>
     /// <param name="value">The value to clamp.</param>
@@ -23,6 +38,20 @@ public readonly struct SignedNormalizedFloat : IEquatable<SignedNormalizedFloat>
     /// Gets the inverse of the current <see cref="SignedNormalizedFloat"/> value.
     /// </summary>
     public SignedNormalizedFloat Inverse => new(-Value);
+    
+    /// <summary>
+    /// Returns a <see cref="SignedNormalizedFloat"/> representing the minimum of this value and another.
+    /// </summary>
+    /// <param name="other">The other <see cref="SignedNormalizedFloat"/> to compare with.</param>
+    /// <returns>The minimum value as a <see cref="SignedNormalizedFloat"/>.</returns>
+    public SignedNormalizedFloat Min(SignedNormalizedFloat other) => new(MathF.Min(Value, other.Value));
+    
+    /// <summary>
+    /// Returns a <see cref="SignedNormalizedFloat"/> representing the maximum of this value and another.
+    /// </summary>
+    /// <param name="other">The other <see cref="SignedNormalizedFloat"/> to compare with.</param>
+    /// <returns>The maximum value as a <see cref="SignedNormalizedFloat"/>.</returns>
+    public SignedNormalizedFloat Max(SignedNormalizedFloat other) => new(MathF.Max(Value, other.Value));
     
   
     /// <summary>


### PR DESCRIPTION
This pull request introduces four new structs (`NormalizedDouble`, `NormalizedFloat`, `SignedNormalizedDouble`, and `SignedNormalizedFloat`) to represent normalized numeric values within specific ranges and provide utility methods for interpolation, clamping, and conversions. These structs aim to simplify operations involving normalized values while ensuring type safety and consistency.

### New Structs for Normalized Values:
* **`NormalizedDouble`**: Represents a double value normalized to the range `[0, 1]`. Includes methods for linear interpolation (`Lerp`), inverse interpolation (`InverseLerp`), and operators for arithmetic operations with clamping. It also supports conversions to/from other normalized types.

* **`NormalizedFloat`**: Represents a float value normalized to the range `[0, 1]`. Similar to `NormalizedDouble`, it provides interpolation methods, arithmetic operators, and type conversions.

### New Structs for Signed Normalized Values:
* **`SignedNormalizedDouble`**: Represents a double value normalized to the range `[-1, 1]`. It includes interpolation methods, arithmetic operators, and conversions to/from other normalized types, mapping between `[0, 1]` and `[-1, 1]` ranges.

* **`SignedNormalizedFloat`**: Represents a float value normalized to the range `[-1, 1]`. It provides similar functionality to `SignedNormalizedDouble`, with type-safe conversions and clamping.