### PR TITLE
Polygon Cutout/Compound Functionality

### DIFF
--- a/Examples/Scenes/ExampleScenes/BouncyCircles.cs
+++ b/Examples/Scenes/ExampleScenes/BouncyCircles.cs
@@ -185,7 +185,7 @@ namespace Examples.Scenes.ExampleScenes
                     circlePoints.Add(circ.Transform.Position);
                 }
                 var hull = Polygon.FindConvexHull(circlePoints);
-                hull.DrawLines(4f, Colors.Special);
+                hull?.DrawLines(4f, Colors.Special);
             }
 
         }

--- a/ShapeEngine/Geometry/CircleDef/Circle.cs
+++ b/ShapeEngine/Geometry/CircleDef/Circle.cs
@@ -357,6 +357,27 @@ public readonly partial struct Circle : IEquatable<Circle>
         return poly;
     }
     /// <summary>
+    /// Converts the circle into a polygon representation and stores the result in the provided <see cref="Polygon"/>.
+    /// </summary>
+    /// <param name="result">A reference to the <see cref="Polygon"/> to store the result.</param>
+    /// <param name="pointCount">The number of points to use for the polygon. Default is 16.</param>
+    /// <returns><c>true</c> if the conversion was successful; otherwise, <c>false</c>.</returns>
+    public bool ToPolygon(ref Polygon result, int pointCount = 16)
+    {
+        if (Radius <= 0f) return false;
+        
+        if (result.Count > 0) result.Clear();
+        float angleStep = (MathF.PI * 2f) / pointCount;
+        
+        for (var i = 0; i < pointCount; i++)
+        {
+            var p = Center + new Vector2(Radius, 0f).Rotate(angleStep * i);
+            result.Add(p);
+        }
+
+        return true;
+    }
+    /// <summary>
     /// Converts the circle into a polyline representation.
     /// </summary>
     /// <param name="pointCount">The number of points to use for the polyline. Default is 16.</param>

--- a/ShapeEngine/Geometry/CircleDef/CircleClosestPoint.cs
+++ b/ShapeEngine/Geometry/CircleDef/CircleClosestPoint.cs
@@ -15,7 +15,7 @@ namespace ShapeEngine.Geometry.CircleDef;
 
 public readonly partial struct Circle
 {
-        /// <summary>
+    /// <summary>
     /// Finds the closest point on the circle's perimeter to any collider in the given collision object.
     /// </summary>
     /// <param name="collisionObject">The collision object containing one or more colliders to compare against.</param>
@@ -432,6 +432,30 @@ public readonly partial struct Circle
         var vertex = Center + (p - Center).Normalize() * Radius;
         disSquared = (vertex - p).LengthSquared();
         return vertex;
+    }
+    
+    /// <summary>
+    /// Finds the closest point on this shapes perimeter to the given <see cref="IShape"/>.
+    /// </summary>
+    /// <param name="shape">The shape to compare against.</param>
+    /// <returns>
+    /// A <see cref="ClosestPointResult"/> containing the closest point information for the shape.
+    /// </returns>
+    public ClosestPointResult GetClosestPoint(IShape shape)
+    {
+        return shape.GetShapeType() switch
+        {
+            ShapeType.Circle => GetClosestPoint(shape.GetCircleShape()),
+            ShapeType.Segment => GetClosestPoint(shape.GetSegmentShape()),
+            ShapeType.Ray => GetClosestPoint(shape.GetRayShape()),
+            ShapeType.Line => GetClosestPoint(shape.GetLineShape()),
+            ShapeType.Triangle => GetClosestPoint(shape.GetTriangleShape()),
+            ShapeType.Rect => GetClosestPoint(shape.GetRectShape()),
+            ShapeType.Quad => GetClosestPoint(shape.GetQuadShape()),
+            ShapeType.Poly => GetClosestPoint(shape.GetPolygonShape()),
+            ShapeType.PolyLine => GetClosestPoint(shape.GetPolylineShape()),
+            _ => new()
+        };
     }
 
 }

--- a/ShapeEngine/Geometry/CircleDef/CircleContains.cs
+++ b/ShapeEngine/Geometry/CircleDef/CircleContains.cs
@@ -225,4 +225,23 @@ public readonly partial struct Circle
         return ContainsCirclePoints(Center, Radius, points);
     }
 
+    /// <summary>
+    /// Determines whether this shape contains the specified <see cref="IShape"/>.
+    /// </summary>
+    /// <param name="shape">The shape to check.</param>
+    /// <returns><c>true</c> if the shape is inside this shape; otherwise, <c>false</c>.</returns>
+    public bool ContainsShape(IShape shape)
+    {
+        return shape.GetShapeType() switch
+        {
+            ShapeType.Circle => ContainsShape(shape.GetCircleShape()),
+            ShapeType.Segment => ContainsShape(shape.GetSegmentShape()),
+            ShapeType.Triangle => ContainsShape(shape.GetTriangleShape()),
+            ShapeType.Rect => ContainsShape(shape.GetRectShape()),
+            ShapeType.Quad => ContainsShape(shape.GetQuadShape()),
+            ShapeType.Poly => ContainsShape(shape.GetPolygonShape()),
+            ShapeType.PolyLine => ContainsShape(shape.GetPolylineShape()),
+            _ => false
+        };
+    }
 }

--- a/ShapeEngine/Geometry/CircleDef/CircleContainsStatic.cs
+++ b/ShapeEngine/Geometry/CircleDef/CircleContainsStatic.cs
@@ -170,7 +170,7 @@ public readonly partial struct Circle
     /// <returns><c>true</c> if all points are inside or on the circle; otherwise, <c>false</c>.</returns>
     public static bool ContainsCirclePolyline(Vector2 circleCenter, float circleRadius, List<Vector2> polyline)
     {
-        return ContainsCirclePoints(circleCenter, circleRadius, polyline);
+        return polyline.Count >= 2 && ContainsCirclePoints(circleCenter, circleRadius, polyline);
     }
 
     /// <summary>

--- a/ShapeEngine/Geometry/CircleDef/CircleIntersectShape.cs
+++ b/ShapeEngine/Geometry/CircleDef/CircleIntersectShape.cs
@@ -378,6 +378,30 @@ public readonly partial struct Circle
 
         return points;
     }
+    
+    /// <summary>
+    /// Computes intersection points between this shape and a shape implementing <see cref="IShape"/>.
+    /// </summary>
+    /// <param name="shape">The shape to test against.</param>
+    /// <returns>
+    /// A <see cref="IntersectionPoints"/> collection of intersection points, or null if none.
+    /// </returns>
+    public IntersectionPoints? IntersectShape(IShape shape)
+    {
+        return shape.GetShapeType() switch
+        {
+            ShapeType.Circle => IntersectShape(shape.GetCircleShape()),
+            ShapeType.Segment => IntersectShape(shape.GetSegmentShape()),
+            ShapeType.Ray => IntersectShape(shape.GetRayShape()),
+            ShapeType.Line => IntersectShape(shape.GetLineShape()),
+            ShapeType.Triangle => IntersectShape(shape.GetTriangleShape()),
+            ShapeType.Rect => IntersectShape(shape.GetRectShape()),
+            ShapeType.Quad => IntersectShape(shape.GetQuadShape()),
+            ShapeType.Poly => IntersectShape(shape.GetPolygonShape()),
+            ShapeType.PolyLine => IntersectShape(shape.GetPolylineShape()),
+            _ => null
+        };
+    }
 
     /// <summary>
     /// Calculates and adds intersection points between this circle and a collider to the provided <see cref="IntersectionPoints"/> collection.
@@ -902,6 +926,32 @@ public readonly partial struct Circle
         }
 
         return count;
+    }
+    
+    /// <summary>
+    /// Computes the number of intersection points between this shape and a shape implementing <see cref="IShape"/>.
+    /// </summary>
+    /// <param name="shape">The shape to test against.</param>
+    /// <param name="points">A reference to an <see cref="IntersectionPoints"/> collection to store intersection points.</param>
+    /// <param name="returnAfterFirstValid">
+    /// If true, the method returns after finding the first valid intersection point; otherwise, it finds all intersections.
+    /// </param>
+    /// <returns>The number of valid intersection points found.</returns>
+    public int IntersectShape(IShape shape, ref IntersectionPoints points, bool returnAfterFirstValid = false)
+    {
+        return shape.GetShapeType() switch
+        {
+            ShapeType.Circle => IntersectShape(shape.GetCircleShape(), ref points, returnAfterFirstValid),
+            ShapeType.Segment => IntersectShape(shape.GetSegmentShape(), ref points, returnAfterFirstValid),
+            ShapeType.Ray => IntersectShape(shape.GetRayShape(), ref points, returnAfterFirstValid),
+            ShapeType.Line => IntersectShape(shape.GetLineShape(), ref points, returnAfterFirstValid),
+            ShapeType.Triangle => IntersectShape(shape.GetTriangleShape(), ref points, returnAfterFirstValid),
+            ShapeType.Rect => IntersectShape(shape.GetRectShape(), ref points, returnAfterFirstValid),
+            ShapeType.Quad => IntersectShape(shape.GetQuadShape(), ref points, returnAfterFirstValid),
+            ShapeType.Poly => IntersectShape(shape.GetPolygonShape(), ref points, returnAfterFirstValid),
+            ShapeType.PolyLine => IntersectShape(shape.GetPolylineShape(), ref points, returnAfterFirstValid),
+            _ => 0
+        };
     }
 
 }

--- a/ShapeEngine/Geometry/CircleDef/CircleOverlap.cs
+++ b/ShapeEngine/Geometry/CircleDef/CircleOverlap.cs
@@ -213,6 +213,30 @@ public readonly partial struct Circle
     }
 
     /// <summary>
+    /// Determines whether this shape overlaps with the specified <see cref="IShape"/>.
+    /// </summary>
+    /// <param name="shape">The shape to test for overlap with this shape.
+    /// The shape can be any supported type such as circle, segment, ray, line, triangle, rectangle, quad, polygon, or polyline.</param>
+    /// <returns><c>true</c> if this shape overlaps with the specified shape; otherwise, <c>false</c>.</returns>
+    public bool OverlapShape(IShape shape)
+    {
+        return shape.GetShapeType() switch
+        {
+            ShapeType.Circle => OverlapShape(shape.GetCircleShape()),
+            ShapeType.Segment => OverlapShape(shape.GetSegmentShape()),
+            ShapeType.Ray => OverlapShape(shape.GetRayShape()),
+            ShapeType.Line => OverlapShape(shape.GetLineShape()),
+            ShapeType.Triangle => OverlapShape(shape.GetTriangleShape()),
+            ShapeType.Rect => OverlapShape(shape.GetRectShape()),
+            ShapeType.Quad => OverlapShape(shape.GetQuadShape()),
+            ShapeType.Poly => OverlapShape(shape.GetPolygonShape()),
+            ShapeType.PolyLine => OverlapShape(shape.GetPolylineShape()),
+            _ => false
+        };
+    }
+    
+    
+    /// <summary>
     /// Determines whether this circle overlaps with a segment defined by two points.
     /// </summary>
     /// <param name="start">The start point of the segment.</param>

--- a/ShapeEngine/Geometry/CircleDef/CircleOverlapStatic.cs
+++ b/ShapeEngine/Geometry/CircleDef/CircleOverlapStatic.cs
@@ -181,7 +181,7 @@ public readonly partial struct Circle
     /// <returns><c>true</c> if the circle overlaps with the polyline; otherwise, <c>false</c>.</returns>
     public static bool OverlapCirclePolyline(Vector2 center, float radius, List<Vector2> points)
     {
-        if (points.Count < 3) return false;
+        if (points.Count < 2) return false;
         for (var i = 0; i < points.Count - 1; i++)
         {
             if (OverlapCircleSegment(center, radius, points[i], points[i + 1])) return true;

--- a/ShapeEngine/Geometry/CollisionSystem/Collider.cs
+++ b/ShapeEngine/Geometry/CollisionSystem/Collider.cs
@@ -46,7 +46,6 @@ public abstract class Collider : Shape
     /// </summary>
     public event Action<Collider>? OnContactEnded;
     
-    
     private CollisionObject? parent;
     /// <summary>
     /// Gets the parent <see cref="CollisionObject"/> of this collider, or sets it internally.

--- a/ShapeEngine/Geometry/IShape.cs
+++ b/ShapeEngine/Geometry/IShape.cs
@@ -1,4 +1,5 @@
 using ShapeEngine.Geometry.CircleDef;
+using ShapeEngine.Geometry.CollisionSystem;
 using ShapeEngine.Geometry.LineDef;
 using ShapeEngine.Geometry.PolygonDef;
 using ShapeEngine.Geometry.PolylineDef;
@@ -77,4 +78,114 @@ public interface IShape
     /// </summary>
     /// <returns>A <see cref="Polyline"/> representation of the shape.</returns>
     Polyline GetPolylineShape();
+    
+    /// <summary>
+    /// Determines whether this shape overlaps with the specified shape.
+    /// </summary>
+    /// <param name="shape">The other shape to check for overlap.</param>
+    /// <returns><c>true</c> if the shapes overlap; otherwise, <c>false</c>.</returns>
+    public bool OverlapShape(IShape shape)
+    {
+        return GetShapeType() switch
+        {
+            ShapeType.Circle => GetCircleShape().OverlapShape(shape),
+            ShapeType.Segment => GetSegmentShape().OverlapShape(shape),
+            ShapeType.Ray => GetRayShape().OverlapShape(shape),
+            ShapeType.Line => GetLineShape().OverlapShape(shape),
+            ShapeType.Triangle => GetTriangleShape().OverlapShape(shape),
+            ShapeType.Rect => GetRectShape().OverlapShape(shape),
+            ShapeType.Quad => GetQuadShape().OverlapShape(shape),
+            ShapeType.Poly => GetPolygonShape().OverlapShape(shape),
+            ShapeType.PolyLine => GetPolylineShape().OverlapShape(shape),
+            _ => false
+        };
+    }
+    /// <summary>
+    /// Calculates the intersection points between this shape and another shape.
+    /// </summary>
+    /// <param name="shape">The other shape to check for intersection.</param>
+    /// <returns>
+    /// An <see cref="IntersectionPoints"/> object containing the intersection points if any exist; otherwise, <c>null</c>.
+    /// </returns>
+    public IntersectionPoints? IntersectShape(IShape shape)
+    {
+        return GetShapeType() switch
+        {
+            ShapeType.Circle => GetCircleShape().IntersectShape(shape),
+            ShapeType.Segment => GetSegmentShape().IntersectShape(shape),
+            ShapeType.Ray => GetRayShape().IntersectShape(shape),
+            ShapeType.Line => GetLineShape().IntersectShape(shape),
+            ShapeType.Triangle => GetTriangleShape().IntersectShape(shape),
+            ShapeType.Rect => GetRectShape().IntersectShape(shape),
+            ShapeType.Quad => GetQuadShape().IntersectShape(shape),
+            ShapeType.Poly => GetPolygonShape().IntersectShape(shape),
+            ShapeType.PolyLine => GetPolylineShape().IntersectShape(shape),
+            _ => null
+        };
+    }
+    /// <summary>
+    /// Calculates the number of intersection points between this shape and another shape.
+    /// </summary>
+    /// <param name="shape">The other shape to check for intersection.</param>
+    /// <param name="points">A reference to an <see cref="IntersectionPoints"/> object to store the intersection points.</param>
+    /// <param name="returnAfterFirstValid">If <c>true</c>, returns after finding the first valid intersection; otherwise, finds all intersections.</param>
+    /// <returns>The number of intersection points found.</returns>
+    public int IntersectShape(IShape shape, ref IntersectionPoints points, bool returnAfterFirstValid = false)
+    {
+        return GetShapeType() switch
+        {
+            ShapeType.Circle => GetCircleShape().IntersectShape(shape, ref points, returnAfterFirstValid),
+            ShapeType.Segment => GetSegmentShape().IntersectShape(shape, ref points, returnAfterFirstValid),
+            ShapeType.Ray => GetRayShape().IntersectShape(shape, ref points, returnAfterFirstValid),
+            ShapeType.Line => GetLineShape().IntersectShape(shape, ref points, returnAfterFirstValid),
+            ShapeType.Triangle => GetTriangleShape().IntersectShape(shape, ref points, returnAfterFirstValid),
+            ShapeType.Rect => GetRectShape().IntersectShape(shape, ref points, returnAfterFirstValid),
+            ShapeType.Quad => GetQuadShape().IntersectShape(shape, ref points, returnAfterFirstValid),
+            ShapeType.Poly => GetPolygonShape().IntersectShape(shape, ref points, returnAfterFirstValid),
+            ShapeType.PolyLine => GetPolylineShape().IntersectShape(shape, ref points, returnAfterFirstValid),
+            _ => 0
+        };
+    }
+    /// <summary>
+    /// Finds the closest point on this shape to the specified <paramref name="shape"/>.
+    /// </summary>
+    /// <param name="shape">The other shape to which the closest point is calculated.</param>
+    /// <returns>
+    /// A <see cref="ClosestPointResult"/> containing information about the closest point found.
+    /// </returns>
+    public ClosestPointResult GetClosestPoint(IShape shape)
+    {
+        return GetShapeType() switch
+        {
+            ShapeType.Circle => GetCircleShape().GetClosestPoint(shape),
+            ShapeType.Segment => GetSegmentShape().GetClosestPoint(shape),
+            ShapeType.Ray => GetRayShape().GetClosestPoint(shape),
+            ShapeType.Line => GetLineShape().GetClosestPoint(shape),
+            ShapeType.Triangle => GetTriangleShape().GetClosestPoint(shape),
+            ShapeType.Rect => GetRectShape().GetClosestPoint(shape),
+            ShapeType.Quad => GetQuadShape().GetClosestPoint(shape),
+            ShapeType.Poly => GetPolygonShape().GetClosestPoint(shape),
+            ShapeType.PolyLine => GetPolylineShape().GetClosestPoint(shape),
+            _ => new()
+        };
+    }
+    /// <summary>
+    /// Determines whether this shape completely contains the specified <paramref name="shape"/>.
+    /// </summary>
+    /// <param name="shape">The other shape to check for containment.</param>
+    /// <returns><c>true</c> if this shape contains the specified shape; otherwise, <c>false</c>.</returns>
+    public bool ContainsShape(IShape shape)
+    {
+        return GetShapeType() switch
+        {
+            ShapeType.Circle => GetCircleShape().ContainsShape(shape),
+            ShapeType.Triangle => GetTriangleShape().ContainsShape(shape),
+            ShapeType.Rect => GetRectShape().ContainsShape(shape),
+            ShapeType.Quad => GetQuadShape().ContainsShape(shape),
+            ShapeType.Poly => GetPolygonShape().ContainsShape(shape),
+            _ => false
+        };
+    }
+
+
 }

--- a/ShapeEngine/Geometry/LineDef/LineClosestPoint.cs
+++ b/ShapeEngine/Geometry/LineDef/LineClosestPoint.cs
@@ -511,5 +511,29 @@ public readonly partial struct Line
 
         return closestResult.SetOtherSegmentIndex(otherIndex);
     }
+    
+    /// <summary>
+    /// Finds the closest point on this shapes perimeter to the given <see cref="IShape"/>.
+    /// </summary>
+    /// <param name="shape">The shape to compare against.</param>
+    /// <returns>
+    /// A <see cref="ClosestPointResult"/> containing the closest point information for the shape.
+    /// </returns>
+    public ClosestPointResult GetClosestPoint(IShape shape)
+    {
+        return shape.GetShapeType() switch
+        {
+            ShapeType.Circle => GetClosestPoint(shape.GetCircleShape()),
+            ShapeType.Segment => GetClosestPoint(shape.GetSegmentShape()),
+            ShapeType.Ray => GetClosestPoint(shape.GetRayShape()),
+            ShapeType.Line => GetClosestPoint(shape.GetLineShape()),
+            ShapeType.Triangle => GetClosestPoint(shape.GetTriangleShape()),
+            ShapeType.Rect => GetClosestPoint(shape.GetRectShape()),
+            ShapeType.Quad => GetClosestPoint(shape.GetQuadShape()),
+            ShapeType.Poly => GetClosestPoint(shape.GetPolygonShape()),
+            ShapeType.PolyLine => GetClosestPoint(shape.GetPolylineShape()),
+            _ => new()
+        };
+    }
 
 }

--- a/ShapeEngine/Geometry/LineDef/LineIntersectShape.cs
+++ b/ShapeEngine/Geometry/LineDef/LineIntersectShape.cs
@@ -765,5 +765,55 @@ public readonly partial struct Line
 
         return count;
     }
+    
+        /// <summary>
+    /// Computes intersection points between this shape and a shape implementing <see cref="IShape"/>.
+    /// </summary>
+    /// <param name="shape">The shape to test against.</param>
+    /// <returns>
+    /// A <see cref="IntersectionPoints"/> collection of intersection points, or null if none.
+    /// </returns>
+    public IntersectionPoints? IntersectShape(IShape shape)
+    {
+        return shape.GetShapeType() switch
+        {
+            ShapeType.Circle => IntersectShape(shape.GetCircleShape()),
+            ShapeType.Segment => IntersectShape(shape.GetSegmentShape()),
+            ShapeType.Ray => IntersectShape(shape.GetRayShape()),
+            ShapeType.Line => IntersectShape(shape.GetLineShape()),
+            ShapeType.Triangle => IntersectShape(shape.GetTriangleShape()),
+            ShapeType.Rect => IntersectShape(shape.GetRectShape()),
+            ShapeType.Quad => IntersectShape(shape.GetQuadShape()),
+            ShapeType.Poly => IntersectShape(shape.GetPolygonShape()),
+            ShapeType.PolyLine => IntersectShape(shape.GetPolylineShape()),
+            _ => null
+        };
+    }
+    
+    /// <summary>
+    /// Computes the number of intersection points between this shape and a shape implementing <see cref="IShape"/>.
+    /// </summary>
+    /// <param name="shape">The shape to test against.</param>
+    /// <param name="points">A reference to an <see cref="IntersectionPoints"/> collection to store intersection points.</param>
+    /// <param name="returnAfterFirstValid">
+    /// If true, the method returns after finding the first valid intersection point; otherwise, it finds all intersections.
+    /// </param>
+    /// <returns>The number of valid intersection points found.</returns>
+    public int IntersectShape(IShape shape, ref IntersectionPoints points, bool returnAfterFirstValid = false)
+    {
+        return shape.GetShapeType() switch
+        {
+            ShapeType.Circle => IntersectShape(shape.GetCircleShape(), ref points, returnAfterFirstValid),
+            ShapeType.Segment => IntersectShape(shape.GetSegmentShape(), ref points),
+            ShapeType.Ray => IntersectShape(shape.GetRayShape(), ref points),
+            ShapeType.Line => IntersectShape(shape.GetLineShape(), ref points),
+            ShapeType.Triangle => IntersectShape(shape.GetTriangleShape(), ref points, returnAfterFirstValid),
+            ShapeType.Rect => IntersectShape(shape.GetRectShape(), ref points, returnAfterFirstValid),
+            ShapeType.Quad => IntersectShape(shape.GetQuadShape(), ref points, returnAfterFirstValid),
+            ShapeType.Poly => IntersectShape(shape.GetPolygonShape(), ref points, returnAfterFirstValid),
+            ShapeType.PolyLine => IntersectShape(shape.GetPolylineShape(), ref points, returnAfterFirstValid),
+            _ => 0
+        };
+    }
 
 }

--- a/ShapeEngine/Geometry/LineDef/LineIntersection.cs
+++ b/ShapeEngine/Geometry/LineDef/LineIntersection.cs
@@ -179,8 +179,11 @@ public readonly partial struct Line
     /// <returns>
     /// A <see cref="IntersectionPoints"/> object containing the intersection points, or null if no intersections exist.
     /// </returns>
-    public IntersectionPoints? IntersectPolygon(List<Vector2> points, int maxCollisionPoints = -1) =>
-        IntersectLinePolygon(Point, Direction, points, maxCollisionPoints);
+    public IntersectionPoints? IntersectPolygon(List<Vector2> points, int maxCollisionPoints = -1)
+    {
+        if (points.Count < 3) return null;
+        return IntersectLinePolygon(Point, Direction, points, maxCollisionPoints);
+    }
 
     /// <summary>
     /// Computes the intersection points between this infinite line and a polygon.
@@ -192,8 +195,11 @@ public readonly partial struct Line
     /// <returns>
     /// A <see cref="IntersectionPoints"/> object containing the intersection points, or null if no intersections exist.
     /// </returns>
-    public IntersectionPoints? IntersectPolygon(Polygon polygon, int maxCollisionPoints = -1) =>
-        IntersectLinePolygon(Point, Direction, polygon, maxCollisionPoints);
+    public IntersectionPoints? IntersectPolygon(Polygon polygon, int maxCollisionPoints = -1)
+    {
+        if (polygon.Count < 3) return null;
+        return IntersectLinePolygon(Point, Direction, polygon, maxCollisionPoints);
+    }
 
     /// <summary>
     /// Computes the intersection points between this infinite line and a polyline defined by a list of vertices.
@@ -205,8 +211,11 @@ public readonly partial struct Line
     /// <returns>
     /// A <see cref="IntersectionPoints"/> object containing the intersection points, or null if no intersections exist.
     /// </returns>
-    public IntersectionPoints? IntersectPolyline(List<Vector2> points, int maxCollisionPoints = -1) =>
-        IntersectLinePolyline(Point, Direction, points, maxCollisionPoints);
+    public IntersectionPoints? IntersectPolyline(List<Vector2> points, int maxCollisionPoints = -1)
+    {
+        if (points.Count < 2) return null;
+        return IntersectLinePolyline(Point, Direction, points, maxCollisionPoints);
+    }
 
     /// <summary>
     /// Computes the intersection points between this infinite line and a polyline.
@@ -218,8 +227,11 @@ public readonly partial struct Line
     /// <returns>
     /// A <see cref="IntersectionPoints"/> object containing the intersection points, or null if no intersections exist.
     /// </returns>
-    public IntersectionPoints? IntersectPolyline(Polyline polyline, int maxCollisionPoints = -1) =>
-        IntersectLinePolyline(Point, Direction, polyline, maxCollisionPoints);
+    public IntersectionPoints? IntersectPolyline(Polyline polyline, int maxCollisionPoints = -1)
+    {
+        if (polyline.Count < 2) return null;
+        return IntersectLinePolyline(Point, Direction, polyline, maxCollisionPoints);
+    }
 
     /// <summary>
     /// Computes the intersection points between this line and a collection of segments.

--- a/ShapeEngine/Geometry/LineDef/LineIntersectionStatic.cs
+++ b/ShapeEngine/Geometry/LineDef/LineIntersectionStatic.cs
@@ -691,7 +691,7 @@ public readonly partial struct Line
     /// </remarks>
     public static IntersectionPoints? IntersectLinePolyline(Vector2 linePoint, Vector2 lineDirection, List<Vector2> points, int maxCollisionPoints = -1)
     {
-        if (points.Count < 3) return null;
+        if (points.Count < 2) return null;
         if (maxCollisionPoints == 0) return null;
         IntersectionPoints? result = null;
         for (var i = 0; i < points.Count - 1; i++)
@@ -699,7 +699,7 @@ public readonly partial struct Line
             var colPoint = IntersectLineSegment(linePoint, lineDirection, points[i], points[i + 1]);
             if (colPoint.Valid)
             {
-                result ??= new();
+                result ??= [];
                 result.Add(colPoint);
                 if (maxCollisionPoints > 0 && result.Count >= maxCollisionPoints) return result;
             }

--- a/ShapeEngine/Geometry/LineDef/LineOverlap.cs
+++ b/ShapeEngine/Geometry/LineDef/LineOverlap.cs
@@ -231,4 +231,27 @@ public readonly partial struct Line
     /// <param name="segments">A <see cref="Segments"/> collection to check for overlap with this line.</param>
     /// <returns>True if the line overlaps with any segment in the collection; otherwise, false.</returns>
     public bool OverlapShape(Segments segments) => OverlapLineSegments(Point, Direction, segments);
+    
+    /// <summary>
+    /// Determines whether this shape overlaps with the specified <see cref="IShape"/>.
+    /// </summary>
+    /// <param name="shape">The shape to test for overlap with this shape.
+    /// The shape can be any supported type such as circle, segment, ray, line, triangle, rectangle, quad, polygon, or polyline.</param>
+    /// <returns><c>true</c> if this shape overlaps with the specified shape; otherwise, <c>false</c>.</returns>
+    public bool OverlapShape(IShape shape)
+    {
+        return shape.GetShapeType() switch
+        {
+            ShapeType.Circle => OverlapShape(shape.GetCircleShape()),
+            ShapeType.Segment => OverlapShape(shape.GetSegmentShape()),
+            ShapeType.Ray => OverlapShape(shape.GetRayShape()),
+            ShapeType.Line => OverlapShape(shape.GetLineShape()),
+            ShapeType.Triangle => OverlapShape(shape.GetTriangleShape()),
+            ShapeType.Rect => OverlapShape(shape.GetRectShape()),
+            ShapeType.Quad => OverlapShape(shape.GetQuadShape()),
+            ShapeType.Poly => OverlapShape(shape.GetPolygonShape()),
+            ShapeType.PolyLine => OverlapShape(shape.GetPolylineShape()),
+            _ => false
+        };
+    }
 }

--- a/ShapeEngine/Geometry/LineDef/LineOverlap.cs
+++ b/ShapeEngine/Geometry/LineDef/LineOverlap.cs
@@ -87,14 +87,22 @@ public readonly partial struct Line
     /// </summary>
     /// <param name="points">A list of vertices defining the polygon. The polygon is assumed to be closed and non-self-intersecting.</param>
     /// <returns>True if the line and polygon overlap; otherwise, false.</returns>
-    public bool OverlapPolygon(List<Vector2> points) => OverlapLinePolygon(Point, Direction, points);
+    public bool OverlapPolygon(List<Vector2> points)
+    {
+        if (points.Count < 3) return false;
+        return OverlapLinePolygon(Point, Direction, points);
+    }
 
     /// <summary>
     /// Determines whether this infinite line and a polyline overlap (i.e., the line passes through or touches any segment of the polyline).
     /// </summary>
     /// <param name="points">A list of vertices defining the polyline. The polyline is assumed to be open and non-self-intersecting.</param>
     /// <returns>True if the line and polyline overlap; otherwise, false.</returns>
-    public bool OverlapPolyline(List<Vector2> points) => OverlapLinePolyline(Point, Direction, points);
+    public bool OverlapPolyline(List<Vector2> points)
+    {
+        if (points.Count < 2) return false;
+        return OverlapLinePolyline(Point, Direction, points);
+    }
 
     /// <summary>
     /// Determines whether this infinite line and any segment in the provided list overlap (i.e., intersect at any point).

--- a/ShapeEngine/Geometry/LineDef/LineOverlapStatic.cs
+++ b/ShapeEngine/Geometry/LineDef/LineOverlapStatic.cs
@@ -230,7 +230,7 @@ public readonly partial struct Line
     /// <returns>True if the line and polyline overlap; otherwise, false.</returns>
     public static bool OverlapLinePolyline(Vector2 linePoint, Vector2 lineDirection, List<Vector2> points)
     {
-        if (points.Count < 3) return false;
+        if (points.Count < 2) return false;
         for (var i = 0; i < points.Count - 1; i++)
         {
             var colPoint = IntersectLineSegment(linePoint, lineDirection, points[i], points[i + 1]);

--- a/ShapeEngine/Geometry/PointsDef/Points.cs
+++ b/ShapeEngine/Geometry/PointsDef/Points.cs
@@ -160,6 +160,21 @@ public partial class Points : ShapeList<Vector2>, IEquatable<Points>
     /// <returns>A new <see cref="Polygon"/> instance containing the same points.</returns>
     public Polygon ToPolygon() => new(this);
 
+    public bool ToPolygon(ref Polygon result)
+    {
+        if (Count < 3) return false;
+        
+        if(result.Count > 0) result.Clear();
+        
+        for (var i = 0; i < Count; i++)
+        {
+            var point = this[i];
+            result.Add(point);
+        }
+
+        return true;
+    }
+
     /// <summary>
     /// Converts this collection of points into a <see cref="Polyline"/> shape.
     /// </summary>

--- a/ShapeEngine/Geometry/PointsDef/PointsClosestPoint.cs
+++ b/ShapeEngine/Geometry/PointsDef/PointsClosestPoint.cs
@@ -541,5 +541,29 @@ public partial class Points
             selfIndex,
             otherIndex);
     }
+    
+    /// <summary>
+    /// Finds the closest point on this shapes perimeter to the given <see cref="IShape"/>.
+    /// </summary>
+    /// <param name="shape">The shape to compare against.</param>
+    /// <returns>
+    /// A <see cref="ClosestPointResult"/> containing the closest point information for the shape.
+    /// </returns>
+    public ClosestPointResult GetClosestPoint(IShape shape)
+    {
+        return shape.GetShapeType() switch
+        {
+            ShapeType.Circle => GetClosestPoint(shape.GetCircleShape()),
+            ShapeType.Segment => GetClosestPoint(shape.GetSegmentShape()),
+            ShapeType.Ray => GetClosestPoint(shape.GetRayShape()),
+            ShapeType.Line => GetClosestPoint(shape.GetLineShape()),
+            ShapeType.Triangle => GetClosestPoint(shape.GetTriangleShape()),
+            ShapeType.Rect => GetClosestPoint(shape.GetRectShape()),
+            ShapeType.Quad => GetClosestPoint(shape.GetQuadShape()),
+            ShapeType.Poly => GetClosestPoint(shape.GetPolygonShape()),
+            ShapeType.PolyLine => GetClosestPoint(shape.GetPolylineShape()),
+            _ => new()
+        };
+    }
 
 }

--- a/ShapeEngine/Geometry/PolygonDef/Polygon.cs
+++ b/ShapeEngine/Geometry/PolygonDef/Polygon.cs
@@ -537,7 +537,7 @@ public partial class Polygon : Points, IEquatable<Polygon>
     /// Returns the convex hull of the polygon as a new polygon.
     /// </summary>
     /// <returns>A convex polygon containing all the original points.</returns>
-    public Polygon ToConvex() => Polygon.FindConvexHull(this);
+    public Polygon? ToConvex() => Polygon.FindConvexHull(this);
     #endregion
 
     #region Random

--- a/ShapeEngine/Geometry/PolygonDef/Polygon.cs
+++ b/ShapeEngine/Geometry/PolygonDef/Polygon.cs
@@ -644,7 +644,6 @@ public partial class Polygon : Points, IEquatable<Polygon>
                 return shape.GetPolygonShape().ToPolygon(ref result);
         }
     }
-  
     
     /// <summary>
     /// Adds a compound shape to the polygon by converting the given <see cref="IShape"/> to a polygon and merging it.

--- a/ShapeEngine/Geometry/PolygonDef/Polygon.cs
+++ b/ShapeEngine/Geometry/PolygonDef/Polygon.cs
@@ -5,6 +5,7 @@ using ShapeEngine.Geometry.CircleDef;
 using ShapeEngine.Geometry.CollisionSystem;
 using ShapeEngine.Geometry.PointsDef;
 using ShapeEngine.Geometry.PolylineDef;
+using ShapeEngine.Geometry.QuadDef;
 using ShapeEngine.Geometry.RectDef;
 using ShapeEngine.Geometry.SegmentDef;
 using ShapeEngine.Geometry.SegmentsDef;
@@ -66,6 +67,8 @@ public partial class Polygon : Points, IEquatable<Polygon>
     /// Gets the diameter (maximum distance between any two vertices) of the polygon.
     /// </summary>
     public float Diameter => GetDiameter();
+    
+    private Polygon? compoundHelperPolygon = null;
     
     #region Constructors
     /// <summary>
@@ -611,6 +614,235 @@ public partial class Polygon : Points, IEquatable<Polygon>
         return pa.Lerp(pb, Rng.Instance.RandF());
     }
 
+    
+    #endregion
+    
+    #region Cutout & Compound
+    private bool GetPolygonShape(IShape shape, ref Polygon result)
+    {
+        switch (shape.GetShapeType())
+        {
+            default:
+            case ShapeType.None: 
+            case ShapeType.Ray:
+            case ShapeType.Line:
+            case ShapeType.Segment:
+            case ShapeType.PolyLine:
+                return false;
+            case ShapeType.Circle:
+                return shape.GetCircleShape().ToPolygon(ref result);
+            case ShapeType.Triangle:
+                shape.GetTriangleShape().ToPolygon(ref result);
+                return true;
+            case ShapeType.Quad:
+                shape.GetQuadShape().ToPolygon(ref result);
+                return true;
+            case ShapeType.Rect:
+                shape.GetRectShape().ToPolygon(ref result);
+                return true;
+            case ShapeType.Poly:
+                return shape.GetPolygonShape().ToPolygon(ref result);
+        }
+    }
+  
+    
+    /// <summary>
+    /// Adds a compound shape to the polygon by converting the given <see cref="IShape"/> to a polygon and merging it.
+    /// </summary>
+    /// <param name="shape">The shape to add.</param>
+    /// <returns>True if the shape was successfully merged; otherwise, false.</returns>
+    public bool AddCompoundShape(IShape shape)
+    {
+        compoundHelperPolygon ??= [];
+        var valid = GetPolygonShape(shape, ref compoundHelperPolygon);
+        if (!valid || compoundHelperPolygon.Count <= 2) return false;
+        return MergeShapeSelf(compoundHelperPolygon);
+    
+    }
+    
+    /// <summary>
+    /// Adds a compound shape and its children from a <see cref="ShapeContainer"/> to the polygon.
+    /// </summary>
+    /// <param name="shape">The shape container to add.</param>
+    /// <returns>The number of shapes successfully merged. (Parent Shape + Children Shapes) </returns>
+    public int AddCompoundShape(ShapeContainer shape)
+    {
+        int count = 0;
+        if (AddCompoundShape((IShape)shape)) count++;
+        
+        foreach (var child in shape.GetChildrenCopy())
+        {
+            if(AddCompoundShape((IShape)child))
+            {
+                count++;
+            }
+        }
+    
+        return count;
+    }
+    
+    /// <summary>
+    /// Adds a <see cref="Circle"/> shape to the polygon by converting it to a polygon with the specified number of points.
+    /// </summary>
+    /// <param name="shape">The circle to add.</param>
+    /// <param name="pointCount">The number of points to use for the polygon approximation. Default is 16.</param>
+    /// <returns>True if the shape was successfully merged; otherwise, false.</returns>
+    public bool AddCompoundShape(Circle shape, int pointCount = 16)
+    {
+        compoundHelperPolygon ??= [];
+        shape.ToPolygon(ref compoundHelperPolygon, pointCount);
+        if(compoundHelperPolygon.Count <= 2) return false;
+        return MergeShapeSelf(compoundHelperPolygon);
+    }
+    
+    /// <summary>
+    /// Adds a <see cref="Triangle"/> shape to the polygon by converting it to a polygon.
+    /// </summary>
+    /// <param name="shape">The triangle to add.</param>
+    /// <returns>True if the shape was successfully merged; otherwise, false.</returns>
+    public bool AddCompoundShape(Triangle shape)
+    {
+        compoundHelperPolygon ??= [];
+        shape.ToPolygon(ref compoundHelperPolygon);
+        if(compoundHelperPolygon.Count <= 2) return false;
+        return MergeShapeSelf(compoundHelperPolygon);
+    }
+    
+    /// <summary>
+    /// Adds a <see cref="Quad"/> shape to the polygon by converting it to a polygon.
+    /// </summary>
+    /// <param name="shape">The quad to add.</param>
+    /// <returns>True if the shape was successfully merged; otherwise, false.</returns>
+    public bool AddCompoundShape(Quad shape)
+    {
+        compoundHelperPolygon ??= [];
+        shape.ToPolygon(ref compoundHelperPolygon);
+        if(compoundHelperPolygon.Count <= 2) return false;
+        return MergeShapeSelf(compoundHelperPolygon);
+    }
+    
+    /// <summary>
+    /// Adds a <see cref="Rect"/> shape to the polygon by converting it to a polygon.
+    /// </summary>
+    /// <param name="shape">The rectangle to add.</param>
+    /// <returns>True if the shape was successfully merged; otherwise, false.</returns>
+    public bool AddCompoundShape(Rect shape)
+    {
+        compoundHelperPolygon ??= [];
+        shape.ToPolygon(ref compoundHelperPolygon);
+        if(compoundHelperPolygon.Count <= 2) return false;
+        return MergeShapeSelf(compoundHelperPolygon);
+    }
+    
+    /// <summary>
+    /// Adds another <see cref="Polygon"/> shape to the polygon by merging it.
+    /// </summary>
+    /// <param name="shape">The polygon to add.</param>
+    /// <returns>True if the shape was successfully merged; otherwise, false.</returns>
+    public bool AddCompoundShape(Polygon shape)
+    {
+        if (shape.Count <= 2) return false;
+        return MergeShapeSelf(shape);
+    }
+   
+    
+    /// <summary>
+    /// Cuts out the given <see cref="IShape"/> from the polygon by converting it to a polygon and performing a cut operation.
+    /// </summary>
+    /// <param name="shape">The shape to cut out.</param>
+    /// <returns>True if the cutout was successful; otherwise, false.</returns>
+    public bool AddCutoutShape(IShape shape)
+    {
+        compoundHelperPolygon ??= [];
+        bool valid = GetPolygonShape(shape, ref compoundHelperPolygon);
+        if (!valid || compoundHelperPolygon.Count <= 2) return false;
+        return CutShapeSelf(compoundHelperPolygon);
+    }
+    
+    /// <summary>
+    /// Cuts out the parent and child shapes from a <see cref="ShapeContainer"/> from the polygon.
+    /// </summary>
+    /// <param name="shape">The shape container whose shapes will be cut out.</param>
+    /// <returns>The number of shapes successfully cut out.</returns>
+    public int AddCutoutShape(ShapeContainer shape)
+    {
+        var count = 0;
+        if (AddCutoutShape((IShape)shape)) count++;
+        
+        foreach (var child in shape.GetChildrenCopy())
+        {
+            if(AddCutoutShape((IShape)child))
+            {
+                count++;
+            }
+        }
+    
+        return count;
+    }
+    
+    /// <summary>
+    /// Cuts out a <see cref="Circle"/> shape from the polygon by converting it to a polygon with the specified number of points.
+    /// </summary>
+    /// <param name="shape">The circle to cut out.</param>
+    /// <param name="pointCount">The number of points to use for the polygon approximation. Default is 16.</param>
+    /// <returns>True if the cutout was successful; otherwise, false.</returns>
+    public bool AddCutoutShape(Circle shape, int pointCount = 16)
+    {
+        compoundHelperPolygon ??= [];
+        shape.ToPolygon(ref compoundHelperPolygon, pointCount);
+        if(compoundHelperPolygon.Count <= 2) return false;
+        return CutShapeSelf(compoundHelperPolygon);
+    }
+    
+    /// <summary>
+    /// Cuts out a <see cref="Triangle"/> shape from the polygon by converting it to a polygon.
+    /// </summary>
+    /// <param name="shape">The triangle to cut out.</param>
+    /// <returns>True if the cutout was successful; otherwise, false.</returns>
+    public bool AddCutoutShape(Triangle shape)
+    {
+        compoundHelperPolygon ??= [];
+        shape.ToPolygon(ref compoundHelperPolygon);
+        if(compoundHelperPolygon.Count <= 2) return false;
+        return CutShapeSelf(compoundHelperPolygon);
+    }
+    
+    /// <summary>
+    /// Cuts out a <see cref="Quad"/> shape from the polygon by converting it to a polygon.
+    /// </summary>
+    /// <param name="shape">The quad to cut out.</param>
+    /// <returns>True if the cutout was successful; otherwise, false.</returns>
+    public bool AddCutoutShape(Quad shape)
+    {
+        compoundHelperPolygon ??= [];
+        shape.ToPolygon(ref compoundHelperPolygon);
+        if(compoundHelperPolygon.Count <= 2) return false;
+        return CutShapeSelf(compoundHelperPolygon);
+    }
+    
+    /// <summary>
+    /// Cuts out a <see cref="Rect"/> shape from the polygon by converting it to a polygon.
+    /// </summary>
+    /// <param name="shape">The rectangle to cut out.</param>
+    /// <returns>True if the cutout was successful; otherwise, false.</returns>
+    public bool AddCutoutShape(Rect shape)
+    {
+        compoundHelperPolygon ??= [];
+        shape.ToPolygon(ref compoundHelperPolygon);
+        if(compoundHelperPolygon.Count <= 2) return false;
+        return CutShapeSelf(compoundHelperPolygon);
+    }
+    
+    /// <summary>
+    /// Cuts out another <see cref="Polygon"/> shape from the polygon.
+    /// </summary>
+    /// <param name="shape">The polygon to cut out.</param>
+    /// <returns>True if the cutout was successful; otherwise, false.</returns>
+    public bool AddCutoutShape(Polygon shape)
+    {
+        if (shape.Count <= 2) return false;
+        return CutShapeSelf(shape);
+    }
     
     #endregion
 }

--- a/ShapeEngine/Geometry/PolygonDef/Polygon.cs
+++ b/ShapeEngine/Geometry/PolygonDef/Polygon.cs
@@ -750,6 +750,10 @@ public partial class Polygon : Points, IEquatable<Polygon>
     /// </summary>
     /// <param name="shape">The shape to cut out.</param>
     /// <returns>True if the cutout was successful; otherwise, false.</returns>
+    /// <remarks>
+    /// Does not support cutting out holes.
+    /// If the shape for cutting is completely contained within the polygon, it will not be cut out!
+    /// </remarks>
     public bool AddCutoutShape(IShape shape)
     {
         compoundHelperPolygon ??= [];
@@ -763,6 +767,10 @@ public partial class Polygon : Points, IEquatable<Polygon>
     /// </summary>
     /// <param name="shape">The shape container whose shapes will be cut out.</param>
     /// <returns>The number of shapes successfully cut out.</returns>
+    /// <remarks>
+    /// Does not support cutting out holes.
+    /// If the shape for cutting is completely contained within the polygon, it will not be cut out!
+    /// </remarks>
     public int AddCutoutShape(ShapeContainer shape)
     {
         var count = 0;
@@ -785,6 +793,10 @@ public partial class Polygon : Points, IEquatable<Polygon>
     /// <param name="shape">The circle to cut out.</param>
     /// <param name="pointCount">The number of points to use for the polygon approximation. Default is 16.</param>
     /// <returns>True if the cutout was successful; otherwise, false.</returns>
+    /// <remarks>
+    /// Does not support cutting out holes.
+    /// If the shape for cutting is completely contained within the polygon, it will not be cut out!
+    /// </remarks>
     public bool AddCutoutShape(Circle shape, int pointCount = 16)
     {
         compoundHelperPolygon ??= [];
@@ -798,6 +810,10 @@ public partial class Polygon : Points, IEquatable<Polygon>
     /// </summary>
     /// <param name="shape">The triangle to cut out.</param>
     /// <returns>True if the cutout was successful; otherwise, false.</returns>
+    /// <remarks>
+    /// Does not support cutting out holes.
+    /// If the shape for cutting is completely contained within the polygon, it will not be cut out!
+    /// </remarks>
     public bool AddCutoutShape(Triangle shape)
     {
         compoundHelperPolygon ??= [];
@@ -811,6 +827,10 @@ public partial class Polygon : Points, IEquatable<Polygon>
     /// </summary>
     /// <param name="shape">The quad to cut out.</param>
     /// <returns>True if the cutout was successful; otherwise, false.</returns>
+    /// <remarks>
+    /// Does not support cutting out holes.
+    /// If the shape for cutting is completely contained within the polygon, it will not be cut out!
+    /// </remarks>
     public bool AddCutoutShape(Quad shape)
     {
         compoundHelperPolygon ??= [];
@@ -824,6 +844,10 @@ public partial class Polygon : Points, IEquatable<Polygon>
     /// </summary>
     /// <param name="shape">The rectangle to cut out.</param>
     /// <returns>True if the cutout was successful; otherwise, false.</returns>
+    /// <remarks>
+    /// Does not support cutting out holes.
+    /// If the shape for cutting is completely contained within the polygon, it will not be cut out!
+    /// </remarks>
     public bool AddCutoutShape(Rect shape)
     {
         compoundHelperPolygon ??= [];
@@ -837,6 +861,10 @@ public partial class Polygon : Points, IEquatable<Polygon>
     /// </summary>
     /// <param name="shape">The polygon to cut out.</param>
     /// <returns>True if the cutout was successful; otherwise, false.</returns>
+    /// <remarks>
+    /// Does not support cutting out holes.
+    /// If the shape for cutting is completely contained within the polygon, it will not be cut out!
+    /// </remarks>
     public bool AddCutoutShape(Polygon shape)
     {
         if (shape.Count <= 2) return false;

--- a/ShapeEngine/Geometry/PolygonDef/PolygonClipping.cs
+++ b/ShapeEngine/Geometry/PolygonDef/PolygonClipping.cs
@@ -58,6 +58,23 @@ public partial class Polygon
 
         return false;
     }
+    
+    /// <summary>
+    /// Attempts to merge this polygon with another if they overlap.
+    /// </summary>
+    /// <param name="other">The polygon to merge with.</param>
+    /// <returns>True if a merge was performed; otherwise, false.</returns>
+    public bool MergeShapeSelf(Polygon other)
+    {
+        var overlap = OverlapShape(other);
+        if (overlap)
+        {
+            UnionShapeSelf(other);
+            return true;
+        }
+
+        return false;
+    }
 
     /// <summary>
     /// Subtracts the specified polygon (`cutShape`) from this polygon.
@@ -67,7 +84,7 @@ public partial class Polygon
     /// <param name="cutShape">The polygon to subtract from this polygon.</param>
     /// <param name="keepCutout">If true, keeps only the intersected region; otherwise, subtracts the cutShape.</param>
     /// <returns>True if the difference operation produced a valid polygon; otherwise, false.</returns>
-    public bool CutSelf(Polygon cutShape, bool keepCutout = false)
+    public bool CutShapeSelf(Polygon cutShape, bool keepCutout = false)
     {
         var newShapes = keepCutout ? this.Intersect(cutShape) : this.Difference(cutShape);
         

--- a/ShapeEngine/Geometry/PolygonDef/PolygonClipping.cs
+++ b/ShapeEngine/Geometry/PolygonDef/PolygonClipping.cs
@@ -11,6 +11,7 @@ namespace ShapeEngine.Geometry.PolygonDef;
 
 public partial class Polygon
 {
+    
     /// <summary>
     /// Unions this polygon with another polygon and replaces the current shape with the result.
     /// </summary>
@@ -58,6 +59,52 @@ public partial class Polygon
         return false;
     }
 
+    /// <summary>
+    /// Subtracts the specified polygon (`cutShape`) from this polygon.
+    /// Optionally keeps only the intersected (cut-out) region if `keepCutout` is true.
+    /// Returns true if the operation resulted in a valid polygon; otherwise, false.
+    /// </summary>
+    /// <param name="cutShape">The polygon to subtract from this polygon.</param>
+    /// <param name="keepCutout">If true, keeps only the intersected region; otherwise, subtracts the cutShape.</param>
+    /// <returns>True if the difference operation produced a valid polygon; otherwise, false.</returns>
+    public bool CutSelf(Polygon cutShape, bool keepCutout = false)
+    {
+        var newShapes = keepCutout ? this.Intersect(cutShape) : this.Difference(cutShape);
+        
+        if (newShapes.Count > 0)
+        {
+            var polygons = newShapes.ToPolygons(true);
+            if (polygons.Count > 0)
+            {
+                foreach (var polygon in polygons)
+                {
+                    if(polygon.Count < 3) continue; // Skip invalid polygons
+                    this.Clear();
+
+                    if (polygon.IsClockwise())
+                    {
+                        for (int i = polygon.Count - 1; i >= 0; i--)//reverse order clockwise to counter-clockwise
+                        {
+                            Add(polygon[i]);
+                        }
+                    }
+                    else
+                    {
+                        for (int i = 0; i < polygon.Count; i++)
+                        {
+                            Add(polygon[i]);
+                        }
+                    }
+                    
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+   
+    
     /// <summary>
     /// Attempts to merge this polygon with another and returns the merged result as a new polygon.
     /// </summary>

--- a/ShapeEngine/Geometry/PolygonDef/PolygonClosestPoint.cs
+++ b/ShapeEngine/Geometry/PolygonDef/PolygonClosestPoint.cs
@@ -695,4 +695,28 @@ public partial class Polygon
 
         return new(closestSegment, closest);
     }
+    
+    /// <summary>
+    /// Finds the closest point on this shapes perimeter to the given <see cref="IShape"/>.
+    /// </summary>
+    /// <param name="shape">The shape to compare against.</param>
+    /// <returns>
+    /// A <see cref="ClosestPointResult"/> containing the closest point information for the shape.
+    /// </returns>
+    public new ClosestPointResult GetClosestPoint(IShape shape)
+    {
+        return shape.GetShapeType() switch
+        {
+            ShapeType.Circle => GetClosestPoint(shape.GetCircleShape()),
+            ShapeType.Segment => GetClosestPoint(shape.GetSegmentShape()),
+            ShapeType.Ray => GetClosestPoint(shape.GetRayShape()),
+            ShapeType.Line => GetClosestPoint(shape.GetLineShape()),
+            ShapeType.Triangle => GetClosestPoint(shape.GetTriangleShape()),
+            ShapeType.Rect => GetClosestPoint(shape.GetRectShape()),
+            ShapeType.Quad => GetClosestPoint(shape.GetQuadShape()),
+            ShapeType.Poly => GetClosestPoint(shape.GetPolygonShape()),
+            ShapeType.PolyLine => GetClosestPoint(shape.GetPolylineShape()),
+            _ => new()
+        };
+    }
 }

--- a/ShapeEngine/Geometry/PolygonDef/PolygonClosestPoint.cs
+++ b/ShapeEngine/Geometry/PolygonDef/PolygonClosestPoint.cs
@@ -26,7 +26,7 @@ public partial class Polygon
     public static Vector2 GetClosestPointPolygonPoint(List<Vector2> points, Vector2 p, out float disSquared)
     {
         disSquared = -1;
-        if (points.Count <= 2) return new();
+        if (points.Count < 3) return new(); // Polygon must have at least 3 points
 
         var first = points[0];
         var second = points[1];
@@ -56,7 +56,7 @@ public partial class Polygon
     public new IntersectionPoint GetClosestPoint(Vector2 p, out float disSquared)
     {
         disSquared = -1;
-        if (Count <= 2) return new();
+        if (Count < 3) return new(); // Polygon must have at least 3 points
 
         var first = this[0];
         var second = this[1];
@@ -91,7 +91,7 @@ public partial class Polygon
     {
         disSquared = -1;
         index = -1;
-        if (Count <= 2) return new();
+        if (Count < 3) return new(); // Polygon must have at least 3 points
 
         var first = this[0];
         var second = this[1];

--- a/ShapeEngine/Geometry/PolygonDef/PolygonContains.cs
+++ b/ShapeEngine/Geometry/PolygonDef/PolygonContains.cs
@@ -177,5 +177,25 @@ public partial class Polygon
     {
         return ContainsPoints(this, points);
     }
+    
+    /// <summary>
+    /// Determines whether this shape contains the specified <see cref="IShape"/>.
+    /// </summary>
+    /// <param name="shape">The shape to check.</param>
+    /// <returns><c>true</c> if the shape is inside this shape; otherwise, <c>false</c>.</returns>
+    public bool ContainsShape(IShape shape)
+    {
+        return shape.GetShapeType() switch
+        {
+            ShapeType.Circle => ContainsShape(shape.GetCircleShape()),
+            ShapeType.Segment => ContainsShape(shape.GetSegmentShape()),
+            ShapeType.Triangle => ContainsShape(shape.GetTriangleShape()),
+            ShapeType.Rect => ContainsShape(shape.GetRectShape()),
+            ShapeType.Quad => ContainsShape(shape.GetQuadShape()),
+            ShapeType.Poly => ContainsShape(shape.GetPolygonShape()),
+            ShapeType.PolyLine => ContainsShape(shape.GetPolylineShape()),
+            _ => false
+        };
+    }
 
 }

--- a/ShapeEngine/Geometry/PolygonDef/PolygonContainsStatic.cs
+++ b/ShapeEngine/Geometry/PolygonDef/PolygonContainsStatic.cs
@@ -15,6 +15,7 @@ public partial class Polygon
     /// <returns>True if the point is inside the polygon; otherwise, false.</returns>
     public static bool ContainsPoint(List<Vector2> polygon, Vector2 p)
     {
+        if (polygon.Count < 3) return false; // Polygon must have at least 3 points
         var oddNodes = false;
         int num = polygon.Count;
         int j = num - 1;
@@ -37,6 +38,7 @@ public partial class Polygon
     /// <returns>True if both points are inside the polygon; otherwise, false.</returns>
     public static bool ContainsPoints(List<Vector2> polygon, Vector2 a, Vector2 b)
     {
+        if (polygon.Count < 3) return false; // Polygon must have at least 3 points
         var oddNodesA = false;
         var oddNodesB = false;
         int num = polygon.Count;
@@ -63,6 +65,7 @@ public partial class Polygon
     /// <returns>True if all points are inside the polygon; otherwise, false.</returns>
     public static bool ContainsPoints(List<Vector2> polygon, Vector2 a, Vector2 b, Vector2 c)
     {
+        if (polygon.Count < 3) return false; // Polygon must have at least 3 points
         var oddNodesA = false;
         var oddNodesB = false;
         var oddNodesC = false;
@@ -92,6 +95,7 @@ public partial class Polygon
     /// <returns>True if all points are inside the polygon; otherwise, false.</returns>
     public static bool ContainsPoints(List<Vector2> polygon, Vector2 a, Vector2 b, Vector2 c, Vector2 d)
     {
+        if (polygon.Count < 3) return false; // Polygon must have at least 3 points
         var oddNodesA = false;
         var oddNodesB = false;
         var oddNodesC = false;

--- a/ShapeEngine/Geometry/PolygonDef/PolygonConvexHull.cs
+++ b/ShapeEngine/Geometry/PolygonDef/PolygonConvexHull.cs
@@ -46,9 +46,10 @@ public partial class Polygon
     /// </summary>
     /// <param name="points">The list of points to compute the convex hull for.</param>
     /// <returns>A <see cref="Polygon"/> representing the convex hull.</returns>
-    private static Polygon ConvexHull_JarvisMarch(List<Vector2> points)
+    private static Polygon? ConvexHull_JarvisMarch(List<Vector2> points)
     {
-        var hull = new List<Vector2>();
+        if (points.Count < 3) return null; // Polygon must have at least 3 points
+        var hull = new Polygon();
         foreach (var p in points)
         {
             if (hull.Count == 0)
@@ -75,44 +76,66 @@ public partial class Polygon
             counter++;
         }
 
-        return new Polygon(hull);
+        // return new Polygon(hull);
+        return hull;
     }
     /// <summary>
     /// Finds the convex hull of a list of points.
     /// </summary>
     /// <param name="points">The list of points.</param>
     /// <returns>A <see cref="Polygon"/> representing the convex hull.</returns>
-    public static Polygon FindConvexHull(List<Vector2> points) => ConvexHull_JarvisMarch(points);
+    public static Polygon? FindConvexHull(List<Vector2> points)
+    {
+        if (points.Count < 3) return null; // Polygon must have at least 3 points
+        return ConvexHull_JarvisMarch(points);
+    }
     /// <summary>
     /// Finds the convex hull of a set of points.
     /// </summary>
     /// <param name="points">The points as a <see cref="Points"/> collection.</param>
     /// <returns>A <see cref="Polygon"/> representing the convex hull.</returns>
-    public static Polygon FindConvexHull(Points points) => ConvexHull_JarvisMarch(points);
+    public static Polygon? FindConvexHull(Points points)
+    {
+        if (points.Count < 3) return null; // Polygon must have at least 3 points
+        return ConvexHull_JarvisMarch(points);
+    }
     /// <summary>
     /// Finds the convex hull of a set of points.
     /// </summary>
     /// <param name="points">The points as an array of <see cref="Vector2"/>.</param>
     /// <returns>A <see cref="Polygon"/> representing the convex hull.</returns>
-    public static Polygon FindConvexHull(params Vector2[] points) => ConvexHull_JarvisMarch(points.ToList());
+    public static Polygon? FindConvexHull(params Vector2[] points)
+    {
+        if (points.Length < 3) return null; // Polygon must have at least 3 points
+        return ConvexHull_JarvisMarch(points.ToList());
+    }
     /// <summary>
     /// Finds the convex hull of a polygon's points.
     /// </summary>
     /// <param name="points">The polygon whose points are used.</param>
     /// <returns>A <see cref="Polygon"/> representing the convex hull.</returns>
-    public static Polygon FindConvexHull(Polygon points) => ConvexHull_JarvisMarch(points);
+    public static Polygon? FindConvexHull(Polygon points)
+    {
+        if (points.Count < 3) return null; // Polygon must have at least 3 points
+        return ConvexHull_JarvisMarch(points);
+    }
+
     /// <summary>
     /// Finds the convex hull of multiple polygons by combining all their points.
     /// </summary>
     /// <param name="shapes">The polygons to combine.</param>
     /// <returns>A <see cref="Polygon"/> representing the convex hull of all points.</returns>
-    public static Polygon FindConvexHull(params Polygon[] shapes)
+    public static Polygon? FindConvexHull(params Polygon[] shapes)
     {
-        var allPoints = new List<Vector2>();
+        List<Vector2>? allPoints = null;
         foreach (var shape in shapes)
         {
+            if(shape.Count < 3) continue; // Skip polygons with less than 3 points
+
+            allPoints ??= [];
             allPoints.AddRange(shape);
         }
-        return ConvexHull_JarvisMarch(allPoints);
+
+        return allPoints == null ? null : ConvexHull_JarvisMarch(allPoints);
     }
 }

--- a/ShapeEngine/Geometry/PolygonDef/PolygonDrawing.cs
+++ b/ShapeEngine/Geometry/PolygonDef/PolygonDrawing.cs
@@ -25,7 +25,11 @@ public static class PolygonDrawing
     /// <param name="poly">The polygon to draw.</param>
     /// <param name="color">The fill color.</param>
     /// <param name="clockwise">If true, draws triangles in clockwise order; otherwise, counter-clockwise.</param>
-    public static void DrawPolygonConvex(this Polygon poly, ColorRgba color, bool clockwise = false) { DrawPolygonConvex(poly, poly.GetCentroid(), color, clockwise); }
+    public static void DrawPolygonConvex(this Polygon poly, ColorRgba color, bool clockwise = false)
+    {
+        if (poly.Count < 3) return; // Polygon must have at least 3 points
+        DrawPolygonConvex(poly, poly.GetCentroid(), color, clockwise);
+    }
 
     /// <summary>
     /// Draws a convex polygon filled with the specified color, using a custom center point.
@@ -36,6 +40,7 @@ public static class PolygonDrawing
     /// <param name="clockwise">If true, draws triangles in clockwise order; otherwise, counter-clockwise.</param>
     public static void DrawPolygonConvex(this Polygon poly, Vector2 center, ColorRgba color, bool clockwise = false)
     {
+        if (poly.Count < 3) return; // Polygon must have at least 3 points
         if (clockwise)
         {
             for (var i = 0; i < poly.Count - 1; i++)
@@ -65,6 +70,7 @@ public static class PolygonDrawing
     /// <param name="clockwise">If true, draws triangles in clockwise order; otherwise, counter-clockwise.</param>
     public static void DrawPolygonConvex(this Polygon relativePoly, Vector2 pos, float size, float rotDeg, ColorRgba color, bool clockwise = false)
     {
+        if (relativePoly.Count < 3) return; // Polygon must have at least 3 points
         if (clockwise)
         {
             for (int i = 0; i < relativePoly.Count - 1; i++)

--- a/ShapeEngine/Geometry/PolygonDef/PolygonIntersectShape.cs
+++ b/ShapeEngine/Geometry/PolygonDef/PolygonIntersectShape.cs
@@ -393,5 +393,31 @@ public partial class Polygon
 
         return points;
     }
-
+    
+    
+    /// <summary>
+    /// Computes intersection points between this shape and a shape implementing <see cref="IShape"/>.
+    /// </summary>
+    /// <param name="shape">The shape to test against.</param>
+    /// <returns>
+    /// A <see cref="IntersectionPoints"/> collection of intersection points, or null if none.
+    /// </returns>
+    public IntersectionPoints? IntersectShape(IShape shape)
+    {
+        return shape.GetShapeType() switch
+        {
+            ShapeType.Circle => IntersectShape(shape.GetCircleShape()),
+            ShapeType.Segment => IntersectShape(shape.GetSegmentShape()),
+            ShapeType.Ray => IntersectShape(shape.GetRayShape()),
+            ShapeType.Line => IntersectShape(shape.GetLineShape()),
+            ShapeType.Triangle => IntersectShape(shape.GetTriangleShape()),
+            ShapeType.Rect => IntersectShape(shape.GetRectShape()),
+            ShapeType.Quad => IntersectShape(shape.GetQuadShape()),
+            ShapeType.Poly => IntersectShape(shape.GetPolygonShape()),
+            ShapeType.PolyLine => IntersectShape(shape.GetPolylineShape()),
+            _ => null
+        };
+    }
+    
+    
 }

--- a/ShapeEngine/Geometry/PolygonDef/PolygonIntersectShape2.cs
+++ b/ShapeEngine/Geometry/PolygonDef/PolygonIntersectShape2.cs
@@ -415,5 +415,31 @@ public partial class Polygon
 
         return count;
     }
+    
+    /// <summary>
+    /// Computes the number of intersection points between this shape and a shape implementing <see cref="IShape"/>.
+    /// </summary>
+    /// <param name="shape">The shape to test against.</param>
+    /// <param name="points">A reference to an <see cref="IntersectionPoints"/> collection to store intersection points.</param>
+    /// <param name="returnAfterFirstValid">
+    /// If true, the method returns after finding the first valid intersection point; otherwise, it finds all intersections.
+    /// </param>
+    /// <returns>The number of valid intersection points found.</returns>
+    public int IntersectShape(IShape shape, ref IntersectionPoints points, bool returnAfterFirstValid = false)
+    {
+        return shape.GetShapeType() switch
+        {
+            ShapeType.Circle => IntersectShape(shape.GetCircleShape(), ref points, returnAfterFirstValid),
+            ShapeType.Segment => IntersectShape(shape.GetSegmentShape(), ref points, returnAfterFirstValid),
+            ShapeType.Ray => IntersectShape(shape.GetRayShape(), ref points, returnAfterFirstValid),
+            ShapeType.Line => IntersectShape(shape.GetLineShape(), ref points, returnAfterFirstValid),
+            ShapeType.Triangle => IntersectShape(shape.GetTriangleShape(), ref points, returnAfterFirstValid),
+            ShapeType.Rect => IntersectShape(shape.GetRectShape(), ref points, returnAfterFirstValid),
+            ShapeType.Quad => IntersectShape(shape.GetQuadShape(), ref points, returnAfterFirstValid),
+            ShapeType.Poly => IntersectShape(shape.GetPolygonShape(), ref points, returnAfterFirstValid),
+            ShapeType.PolyLine => IntersectShape(shape.GetPolylineShape(), ref points, returnAfterFirstValid),
+            _ => 0
+        };
+    }
 
 }

--- a/ShapeEngine/Geometry/PolygonDef/PolygonMath.cs
+++ b/ShapeEngine/Geometry/PolygonDef/PolygonMath.cs
@@ -35,16 +35,16 @@ public partial class Polygon
     /// or null if the vector is zero.</returns>
     public Polygon? ProjectShape(Vector2 v)
     {
-        if (v.LengthSquared() <= 0f) return null;
+        if (v.LengthSquared() <= 0f || Count < 3) return null;
 
-        var points = new Points(Count);
+        var points = new Points(Count * 2);
         for (var i = 0; i < Count; i++)
         {
             points.Add(this[i]);
             points.Add(this[i] + v);
         }
 
-        return Polygon.FindConvexHull(points);
+        return FindConvexHull(points);
     }
     /// <summary>
     /// Calculates the centroid (center of mass) of the polygon.

--- a/ShapeEngine/Geometry/PolygonDef/PolygonOverlap.cs
+++ b/ShapeEngine/Geometry/PolygonDef/PolygonOverlap.cs
@@ -320,5 +320,28 @@ public partial class Polygon
 
         return oddNodes;
     }
+    
+    /// <summary>
+    /// Determines whether this shape overlaps with the specified <see cref="IShape"/>.
+    /// </summary>
+    /// <param name="shape">The shape to test for overlap with this shape.
+    /// The shape can be any supported type such as circle, segment, ray, line, triangle, rectangle, quad, polygon, or polyline.</param>
+    /// <returns><c>true</c> if this shape overlaps with the specified shape; otherwise, <c>false</c>.</returns>
+    public bool OverlapShape(IShape shape)
+    {
+        return shape.GetShapeType() switch
+        {
+            ShapeType.Circle => OverlapShape(shape.GetCircleShape()),
+            ShapeType.Segment => OverlapShape(shape.GetSegmentShape()),
+            ShapeType.Ray => OverlapShape(shape.GetRayShape()),
+            ShapeType.Line => OverlapShape(shape.GetLineShape()),
+            ShapeType.Triangle => OverlapShape(shape.GetTriangleShape()),
+            ShapeType.Rect => OverlapShape(shape.GetRectShape()),
+            ShapeType.Quad => OverlapShape(shape.GetQuadShape()),
+            ShapeType.Poly => OverlapShape(shape.GetPolygonShape()),
+            ShapeType.PolyLine => OverlapShape(shape.GetPolylineShape()),
+            _ => false
+        };
+    }
 
 }

--- a/ShapeEngine/Geometry/PolygonDef/PolygonOverlapStatic.cs
+++ b/ShapeEngine/Geometry/PolygonDef/PolygonOverlapStatic.cs
@@ -19,6 +19,7 @@ public partial class Polygon
     /// <returns>True if the segment overlaps the polygon; otherwise, false.</returns>
     public static bool OverlapPolygonSegment(List<Vector2> points, Vector2 segmentStart, Vector2 segmentEnd)
     {
+        if (points.Count < 3) return false; // Polygon must have at least 3 points
         return Segment.OverlapSegmentPolygon(segmentStart, segmentEnd, points);
     }
 
@@ -32,6 +33,7 @@ public partial class Polygon
     /// <remarks>The Line is infinite in both directions.</remarks>
     public static bool OverlapPolygonLine(List<Vector2> points, Vector2 linePoint, Vector2 lineDirection)
     {
+        if (points.Count < 3) return false; // Polygon must have at least 3 points
         return Line.OverlapLinePolygon(linePoint, lineDirection, points);
     }
 
@@ -45,6 +47,7 @@ public partial class Polygon
     /// <remarks>Ray is infinite in one direction from the origin.</remarks>
     public static bool OverlapPolygonRay(List<Vector2> points, Vector2 rayPoint, Vector2 rayDirection)
     {
+        if (points.Count < 3) return false; // Polygon must have at least 3 points
         return Ray.OverlapRayPolygon(rayPoint, rayDirection, points);
     }
 
@@ -57,6 +60,7 @@ public partial class Polygon
     /// <returns>True if the circle overlaps the polygon; otherwise, false.</returns>
     public static bool OverlapPolygonCircle(List<Vector2> points, Vector2 circleCenter, float circleRadius)
     {
+        if (points.Count < 3) return false; // Polygon must have at least 3 points
         return Circle.OverlapCirclePolygon(circleCenter, circleRadius, points);
     }
 
@@ -70,6 +74,7 @@ public partial class Polygon
     /// <returns>True if the triangle overlaps the polygon; otherwise, false.</returns>
     public static bool OverlapPolygonTriangle(List<Vector2> points, Vector2 ta, Vector2 tb, Vector2 tc)
     {
+        if (points.Count < 3) return false; // Polygon must have at least 3 points
         return Triangle.OverlapTrianglePolygon(ta, tb, tc, points);
     }
 
@@ -84,6 +89,7 @@ public partial class Polygon
     /// <returns>True if the quad overlaps the polygon; otherwise, false.</returns>
     public static bool OverlapPolygonQuad(List<Vector2> points, Vector2 qa, Vector2 qb, Vector2 qc, Vector2 qd)
     {
+        if (points.Count < 3) return false; // Polygon must have at least 3 points
         return Quad.OverlapQuadPolygon(qa, qb, qc, qd, points);
     }
 
@@ -103,6 +109,7 @@ public partial class Polygon
    /// </remarks>
     public static bool OverlapPolygonRect(List<Vector2> points, Vector2 ra, Vector2 rb, Vector2 rc, Vector2 rd)
     {
+        if (points.Count < 3) return false; // Polygon must have at least 3 points
         return Quad.OverlapQuadPolygon(ra, rb, rc, rd, points);
     }
 

--- a/ShapeEngine/Geometry/PolygonDef/PolygonShape.cs
+++ b/ShapeEngine/Geometry/PolygonDef/PolygonShape.cs
@@ -29,6 +29,7 @@ public class PolygonShape : ShapeContainer
     /// <param name="relativePoints">The points that define the polygon in local space.</param>
     public PolygonShape(Transform2D offset, Points relativePoints)
     {
+        if (relativePoints.Count < 3) throw new ArgumentException("A polygon must have at least 3 points.");
         Offset = offset;
         RelativeShape = relativePoints.ToPolygon();
         shape = new(RelativeShape.Count);
@@ -40,6 +41,7 @@ public class PolygonShape : ShapeContainer
     /// <param name="relativePoints">The polygon defined in local space.</param>
     public PolygonShape(Transform2D offset, Polygon relativePoints)
     {
+        if (relativePoints.Count < 3) throw new ArgumentException("A polygon must have at least 3 points.");
         Offset = offset;
         RelativeShape = relativePoints;
         shape = new(RelativeShape.Count);

--- a/ShapeEngine/Geometry/PolylineDef/PolylineClosestPoint.cs
+++ b/ShapeEngine/Geometry/PolylineDef/PolylineClosestPoint.cs
@@ -799,5 +799,29 @@ public partial class Polyline
 
         return new(closestSegment, closest);
     }
+    
+    /// <summary>
+    /// Finds the closest point on this shapes perimeter to the given <see cref="IShape"/>.
+    /// </summary>
+    /// <param name="shape">The shape to compare against.</param>
+    /// <returns>
+    /// A <see cref="ClosestPointResult"/> containing the closest point information for the shape.
+    /// </returns>
+    public new ClosestPointResult GetClosestPoint(IShape shape)
+    {
+        return shape.GetShapeType() switch
+        {
+            ShapeType.Circle => GetClosestPoint(shape.GetCircleShape()),
+            ShapeType.Segment => GetClosestPoint(shape.GetSegmentShape()),
+            ShapeType.Ray => GetClosestPoint(shape.GetRayShape()),
+            ShapeType.Line => GetClosestPoint(shape.GetLineShape()),
+            ShapeType.Triangle => GetClosestPoint(shape.GetTriangleShape()),
+            ShapeType.Rect => GetClosestPoint(shape.GetRectShape()),
+            ShapeType.Quad => GetClosestPoint(shape.GetQuadShape()),
+            ShapeType.Poly => GetClosestPoint(shape.GetPolygonShape()),
+            ShapeType.PolyLine => GetClosestPoint(shape.GetPolylineShape()),
+            _ => new()
+        };
+    }
 
 }

--- a/ShapeEngine/Geometry/PolylineDef/PolylineIntersectShape.cs
+++ b/ShapeEngine/Geometry/PolylineDef/PolylineIntersectShape.cs
@@ -433,7 +433,7 @@ public partial class Polyline
         return points;
     }
     
-        /// <summary>
+    /// <summary>
     /// Computes intersection points between this shape and a shape implementing <see cref="IShape"/>.
     /// </summary>
     /// <param name="shape">The shape to test against.</param>

--- a/ShapeEngine/Geometry/PolylineDef/PolylineIntersectShape.cs
+++ b/ShapeEngine/Geometry/PolylineDef/PolylineIntersectShape.cs
@@ -23,6 +23,7 @@ public partial class Polyline
     /// </returns>
     public Dictionary<Collider, IntersectionPoints>? Intersect(CollisionObject collisionObject)
     {
+        if (Count < 2) return null;
         if (!collisionObject.HasColliders) return null;
 
         Dictionary<Collider, IntersectionPoints>? intersections = null;

--- a/ShapeEngine/Geometry/PolylineDef/PolylineIntersectShape.cs
+++ b/ShapeEngine/Geometry/PolylineDef/PolylineIntersectShape.cs
@@ -432,5 +432,31 @@ public partial class Polyline
 
         return points;
     }
+    
+        /// <summary>
+    /// Computes intersection points between this shape and a shape implementing <see cref="IShape"/>.
+    /// </summary>
+    /// <param name="shape">The shape to test against.</param>
+    /// <returns>
+    /// A <see cref="IntersectionPoints"/> collection of intersection points, or null if none.
+    /// </returns>
+    public IntersectionPoints? IntersectShape(IShape shape)
+    {
+        return shape.GetShapeType() switch
+        {
+            ShapeType.Circle => IntersectShape(shape.GetCircleShape()),
+            ShapeType.Segment => IntersectShape(shape.GetSegmentShape()),
+            ShapeType.Ray => IntersectShape(shape.GetRayShape()),
+            ShapeType.Line => IntersectShape(shape.GetLineShape()),
+            ShapeType.Triangle => IntersectShape(shape.GetTriangleShape()),
+            ShapeType.Rect => IntersectShape(shape.GetRectShape()),
+            ShapeType.Quad => IntersectShape(shape.GetQuadShape()),
+            ShapeType.Poly => IntersectShape(shape.GetPolygonShape()),
+            ShapeType.PolyLine => IntersectShape(shape.GetPolylineShape()),
+            _ => null
+        };
+    }
+    
+
 
 }

--- a/ShapeEngine/Geometry/PolylineDef/PolylineIntersectShape2.cs
+++ b/ShapeEngine/Geometry/PolylineDef/PolylineIntersectShape2.cs
@@ -467,5 +467,31 @@ public partial class Polyline
 
         return count;
     }
+    
+    /// <summary>
+    /// Computes the number of intersection points between this shape and a shape implementing <see cref="IShape"/>.
+    /// </summary>
+    /// <param name="shape">The shape to test against.</param>
+    /// <param name="points">A reference to an <see cref="IntersectionPoints"/> collection to store intersection points.</param>
+    /// <param name="returnAfterFirstValid">
+    /// If true, the method returns after finding the first valid intersection point; otherwise, it finds all intersections.
+    /// </param>
+    /// <returns>The number of valid intersection points found.</returns>
+    public int IntersectShape(IShape shape, ref IntersectionPoints points, bool returnAfterFirstValid = false)
+    {
+        return shape.GetShapeType() switch
+        {
+            ShapeType.Circle => IntersectShape(shape.GetCircleShape(), ref points, returnAfterFirstValid),
+            ShapeType.Segment => IntersectShape(shape.GetSegmentShape(), ref points, returnAfterFirstValid),
+            ShapeType.Ray => IntersectShape(shape.GetRayShape(), ref points, returnAfterFirstValid),
+            ShapeType.Line => IntersectShape(shape.GetLineShape(), ref points, returnAfterFirstValid),
+            ShapeType.Triangle => IntersectShape(shape.GetTriangleShape(), ref points, returnAfterFirstValid),
+            ShapeType.Rect => IntersectShape(shape.GetRectShape(), ref points, returnAfterFirstValid),
+            ShapeType.Quad => IntersectShape(shape.GetQuadShape(), ref points, returnAfterFirstValid),
+            ShapeType.Poly => IntersectShape(shape.GetPolygonShape(), ref points, returnAfterFirstValid),
+            ShapeType.PolyLine => IntersectShape(shape.GetPolylineShape(), ref points, returnAfterFirstValid),
+            _ => 0
+        };
+    }
 
 }

--- a/ShapeEngine/Geometry/PolylineDef/PolylineMath.cs
+++ b/ShapeEngine/Geometry/PolylineDef/PolylineMath.cs
@@ -43,9 +43,9 @@ public partial class Polyline
     /// </returns>
     public Polygon? ProjectShape(Vector2 v)
     {
-        if (v.LengthSquared() <= 0f) return null;
-
-        var points = new Points(Count);
+        if (v.LengthSquared() <= 0f || Count < 2) return null;
+        
+        var points = new Points(Count * 2);
         for (var i = 0; i < Count; i++)
         {
             points.Add(this[i]);

--- a/ShapeEngine/Geometry/PolylineDef/PolylineOverlap.cs
+++ b/ShapeEngine/Geometry/PolylineDef/PolylineOverlap.cs
@@ -96,7 +96,11 @@ public partial class Polyline
     /// </summary>
     /// <param name="points">The vertices of the polygon.</param>
     /// <returns><c>true</c> if the polyline overlaps the polygon; otherwise, <c>false</c>.</returns>
-    public bool OverlapPolygon(List<Vector2> points) => OverlapPolylinePolygon(this, points);
+    public bool OverlapPolygon(List<Vector2> points)
+    {
+        if (points.Count < 3) return false;
+        return OverlapPolylinePolygon(this, points);
+    }
 
     /// <summary>
     /// Determines whether the polyline overlaps another polyline.

--- a/ShapeEngine/Geometry/PolylineDef/PolylineOverlap.cs
+++ b/ShapeEngine/Geometry/PolylineDef/PolylineOverlap.cs
@@ -274,5 +274,28 @@ public partial class Polyline
 
         return false;
     }
+    
+    /// <summary>
+    /// Determines whether this shape overlaps with the specified <see cref="IShape"/>.
+    /// </summary>
+    /// <param name="shape">The shape to test for overlap with this shape.
+    /// The shape can be any supported type such as circle, segment, ray, line, triangle, rectangle, quad, polygon, or polyline.</param>
+    /// <returns><c>true</c> if this shape overlaps with the specified shape; otherwise, <c>false</c>.</returns>
+    public bool OverlapShape(IShape shape)
+    {
+        return shape.GetShapeType() switch
+        {
+            ShapeType.Circle => OverlapShape(shape.GetCircleShape()),
+            ShapeType.Segment => OverlapShape(shape.GetSegmentShape()),
+            ShapeType.Ray => OverlapShape(shape.GetRayShape()),
+            ShapeType.Line => OverlapShape(shape.GetLineShape()),
+            ShapeType.Triangle => OverlapShape(shape.GetTriangleShape()),
+            ShapeType.Rect => OverlapShape(shape.GetRectShape()),
+            ShapeType.Quad => OverlapShape(shape.GetQuadShape()),
+            ShapeType.Poly => OverlapShape(shape.GetPolygonShape()),
+            ShapeType.PolyLine => OverlapShape(shape.GetPolylineShape()),
+            _ => false
+        };
+    }
 
 }

--- a/ShapeEngine/Geometry/PolylineDef/PolylineOverlapStatic.cs
+++ b/ShapeEngine/Geometry/PolylineDef/PolylineOverlapStatic.cs
@@ -23,7 +23,7 @@ public partial class Polyline
     /// </remarks>
     public static bool OverlapPolylineSegment(List<Vector2> points, Vector2 segmentStart, Vector2 segmentEnd)
     {
-        return Segment.OverlapSegmentPolyline(segmentStart, segmentEnd, points);
+        return points.Count >= 2 && Segment.OverlapSegmentPolyline(segmentStart, segmentEnd, points);
     }
 
     /// <summary>
@@ -38,7 +38,7 @@ public partial class Polyline
     /// </remarks>
     public static bool OverlapPolylineLine(List<Vector2> points, Vector2 linePoint, Vector2 lineDirection)
     {
-        return Line.OverlapLinePolyline(linePoint, lineDirection, points);
+        return points.Count >= 2 && Line.OverlapLinePolyline(linePoint, lineDirection, points);
     }
 
     /// <summary>
@@ -53,7 +53,7 @@ public partial class Polyline
     /// </remarks>
     public static bool OverlapPolylineRay(List<Vector2> points, Vector2 rayPoint, Vector2 rayDirection)
     {
-        return Ray.OverlapRayPolyline(rayPoint, rayDirection, points);
+        return points.Count >= 2 && Ray.OverlapRayPolyline(rayPoint, rayDirection, points);
     }
 
     /// <summary>
@@ -68,7 +68,7 @@ public partial class Polyline
     /// </remarks>
     public static bool OverlapPolylineCircle(List<Vector2> points, Vector2 circleCenter, float circleRadius)
     {
-        return Circle.OverlapCirclePolyline(circleCenter, circleRadius, points);
+        return points.Count >= 2 && Circle.OverlapCirclePolyline(circleCenter, circleRadius, points);
     }
 
     /// <summary>
@@ -84,7 +84,7 @@ public partial class Polyline
     /// </remarks>
     public static bool OverlapPolylineTriangle(List<Vector2> points, Vector2 ta, Vector2 tb, Vector2 tc)
     {
-        return Triangle.OverlapTrianglePolyline(ta, tb, tc, points);
+        return points.Count >= 2 && Triangle.OverlapTrianglePolyline(ta, tb, tc, points);
     }
 
     /// <summary>
@@ -101,7 +101,7 @@ public partial class Polyline
     /// </remarks>
     public static bool OverlapPolylineQuad(List<Vector2> points, Vector2 qa, Vector2 qb, Vector2 qc, Vector2 qd)
     {
-        return Quad.OverlapQuadPolyline(qa, qb, qc, qd, points);
+        return points.Count >= 2 && Quad.OverlapQuadPolyline(qa, qb, qc, qd, points);
     }
 
     /// <summary>
@@ -119,7 +119,7 @@ public partial class Polyline
     /// </remarks>
     public static bool OverlapPolylineRect(List<Vector2> points, Vector2 ra, Vector2 rb, Vector2 rc, Vector2 rd)
     {
-        return Quad.OverlapQuadPolyline(ra, rb, rc, rd, points);
+        return points.Count >= 2 && Quad.OverlapQuadPolyline(ra, rb, rc, rd, points);
     }
 
     /// <summary>
@@ -133,6 +133,7 @@ public partial class Polyline
     /// </remarks>
     public static bool OverlapPolylinePolygon(List<Vector2> points1, List<Vector2> points2)
     {
+        if (points1.Count < 2 || points2.Count < 3) return false;
         return Polygon.OverlapPolygonPolyline(points2, points1);
     }
 

--- a/ShapeEngine/Geometry/PolylineDef/PolylineShape.cs
+++ b/ShapeEngine/Geometry/PolylineDef/PolylineShape.cs
@@ -28,6 +28,7 @@ public class PolylineShape : ShapeContainer
     /// <param name="relativePoints">The points that define the polyline in local space.</param>
     public PolylineShape(Transform2D offset, Points relativePoints)
     {
+        if (relativePoints.Count < 2) throw new ArgumentException("A polyline must have at least 2 points.");
         Offset = offset;
         RelativeShape = relativePoints.ToPolyline();
         shape = new(RelativeShape.Count);
@@ -39,6 +40,7 @@ public class PolylineShape : ShapeContainer
     /// <param name="relativePoints">The polyline defined in local space.</param>
     public PolylineShape(Transform2D offset, Polyline relativePoints)
     {
+        if (relativePoints.Count < 2) throw new ArgumentException("A polyline must have at least 2 points.");
         Offset = offset;
         RelativeShape = relativePoints;
         shape = new(RelativeShape.Count);

--- a/ShapeEngine/Geometry/QuadDef/Quad.cs
+++ b/ShapeEngine/Geometry/QuadDef/Quad.cs
@@ -225,6 +225,21 @@ public readonly partial struct Quad : IEquatable<Quad>
     /// </summary>
     /// <returns>A <see cref="Polygon"/> representing the quad.</returns>
     public Polygon ToPolygon() => [A, B, C, D];
+    
+
+    /// <summary>
+    /// Converts the quad to a polygon and stores the result in the provided <see cref="Polygon"/> reference.
+    /// </summary>
+    /// <param name="result">A reference to a <see cref="Polygon"/> that will be populated with the quad's vertices.</param>
+    public void ToPolygon(ref Polygon result)
+    {
+        if(result.Count > 0) result.Clear();
+        result.Add(A);
+        result.Add(B);
+        result.Add(C);
+        result.Add(D);
+    }
+    
     /// <summary>
     /// Converts the quad to a set of points.
     /// </summary>

--- a/ShapeEngine/Geometry/QuadDef/QuadClosestPoint.cs
+++ b/ShapeEngine/Geometry/QuadDef/QuadClosestPoint.cs
@@ -1180,6 +1180,30 @@ public readonly partial struct Quad
 
         return furthest;
     }
+    
+    /// <summary>
+    /// Finds the closest point on this shapes perimeter to the given <see cref="IShape"/>.
+    /// </summary>
+    /// <param name="shape">The shape to compare against.</param>
+    /// <returns>
+    /// A <see cref="ClosestPointResult"/> containing the closest point information for the shape.
+    /// </returns>
+    public ClosestPointResult GetClosestPoint(IShape shape)
+    {
+        return shape.GetShapeType() switch
+        {
+            ShapeType.Circle => GetClosestPoint(shape.GetCircleShape()),
+            ShapeType.Segment => GetClosestPoint(shape.GetSegmentShape()),
+            ShapeType.Ray => GetClosestPoint(shape.GetRayShape()),
+            ShapeType.Line => GetClosestPoint(shape.GetLineShape()),
+            ShapeType.Triangle => GetClosestPoint(shape.GetTriangleShape()),
+            ShapeType.Rect => GetClosestPoint(shape.GetRectShape()),
+            ShapeType.Quad => GetClosestPoint(shape.GetQuadShape()),
+            ShapeType.Poly => GetClosestPoint(shape.GetPolygonShape()),
+            ShapeType.PolyLine => GetClosestPoint(shape.GetPolylineShape()),
+            _ => new()
+        };
+    }
 
 }
 

--- a/ShapeEngine/Geometry/QuadDef/QuadContains.cs
+++ b/ShapeEngine/Geometry/QuadDef/QuadContains.cs
@@ -158,5 +158,23 @@ public readonly partial struct Quad
     {
         return ContainsQuadPoints(A, B, C, D, points);
     }
-
+    /// <summary>
+    /// Determines whether this shape contains the specified <see cref="IShape"/>.
+    /// </summary>
+    /// <param name="shape">The shape to check.</param>
+    /// <returns><c>true</c> if the shape is inside this shape; otherwise, <c>false</c>.</returns>
+    public bool ContainsShape(IShape shape)
+    {
+        return shape.GetShapeType() switch
+        {
+            ShapeType.Circle => ContainsShape(shape.GetCircleShape()),
+            ShapeType.Segment => ContainsShape(shape.GetSegmentShape()),
+            ShapeType.Triangle => ContainsShape(shape.GetTriangleShape()),
+            ShapeType.Rect => ContainsShape(shape.GetRectShape()),
+            ShapeType.Quad => ContainsShape(shape.GetQuadShape()),
+            ShapeType.Poly => ContainsShape(shape.GetPolygonShape()),
+            ShapeType.PolyLine => ContainsShape(shape.GetPolylineShape()),
+            _ => false
+        };
+    }
 }

--- a/ShapeEngine/Geometry/QuadDef/QuadContainsStatic.cs
+++ b/ShapeEngine/Geometry/QuadDef/QuadContainsStatic.cs
@@ -213,7 +213,7 @@ public readonly partial struct Quad
     /// <returns><c>true</c> if the polyline is inside the quad; otherwise, <c>false</c>.</returns>
     public static bool ContainsQuadPolyline(Vector2 qA, Vector2 qB, Vector2 qC, Vector2 qD, List<Vector2> polyline)
     {
-        return ContainsQuadPoints(qA, qB, qC, qD, polyline);
+        return polyline.Count >= 2 && ContainsQuadPoints(qA, qB, qC, qD, polyline);
     }
 
     /// <summary>

--- a/ShapeEngine/Geometry/QuadDef/QuadIntersectShape.cs
+++ b/ShapeEngine/Geometry/QuadDef/QuadIntersectShape.cs
@@ -712,6 +712,31 @@ public readonly partial struct Quad
 
         return points;
     }
+    
+    /// <summary>
+    /// Computes intersection points between this shape and a shape implementing <see cref="IShape"/>.
+    /// </summary>
+    /// <param name="shape">The shape to test against.</param>
+    /// <returns>
+    /// A <see cref="IntersectionPoints"/> collection of intersection points, or null if none.
+    /// </returns>
+    public IntersectionPoints? IntersectShape(IShape shape)
+    {
+        return shape.GetShapeType() switch
+        {
+            ShapeType.Circle => IntersectShape(shape.GetCircleShape()),
+            ShapeType.Segment => IntersectShape(shape.GetSegmentShape()),
+            ShapeType.Ray => IntersectShape(shape.GetRayShape()),
+            ShapeType.Line => IntersectShape(shape.GetLineShape()),
+            ShapeType.Triangle => IntersectShape(shape.GetTriangleShape()),
+            ShapeType.Rect => IntersectShape(shape.GetRectShape()),
+            ShapeType.Quad => IntersectShape(shape.GetQuadShape()),
+            ShapeType.Poly => IntersectShape(shape.GetPolygonShape()),
+            ShapeType.PolyLine => IntersectShape(shape.GetPolylineShape()),
+            _ => null
+        };
+    }
+    
     /// <summary>
     /// Computes intersection points between this quad and a collider, adding results to an existing <see cref="IntersectionPoints"/> collection.
     /// </summary>
@@ -1512,6 +1537,34 @@ public readonly partial struct Quad
         }
 
         return count;
+    }
+    
+
+    
+    /// <summary>
+    /// Computes the number of intersection points between this shape and a shape implementing <see cref="IShape"/>.
+    /// </summary>
+    /// <param name="shape">The shape to test against.</param>
+    /// <param name="points">A reference to an <see cref="IntersectionPoints"/> collection to store intersection points.</param>
+    /// <param name="returnAfterFirstValid">
+    /// If true, the method returns after finding the first valid intersection point; otherwise, it finds all intersections.
+    /// </param>
+    /// <returns>The number of valid intersection points found.</returns>
+    public int IntersectShape(IShape shape, ref IntersectionPoints points, bool returnAfterFirstValid = false)
+    {
+        return shape.GetShapeType() switch
+        {
+            ShapeType.Circle => IntersectShape(shape.GetCircleShape(), ref points, returnAfterFirstValid),
+            ShapeType.Segment => IntersectShape(shape.GetSegmentShape(), ref points, returnAfterFirstValid),
+            ShapeType.Ray => IntersectShape(shape.GetRayShape(), ref points, returnAfterFirstValid),
+            ShapeType.Line => IntersectShape(shape.GetLineShape(), ref points, returnAfterFirstValid),
+            ShapeType.Triangle => IntersectShape(shape.GetTriangleShape(), ref points, returnAfterFirstValid),
+            ShapeType.Rect => IntersectShape(shape.GetRectShape(), ref points, returnAfterFirstValid),
+            ShapeType.Quad => IntersectShape(shape.GetQuadShape(), ref points, returnAfterFirstValid),
+            ShapeType.Poly => IntersectShape(shape.GetPolygonShape(), ref points, returnAfterFirstValid),
+            ShapeType.PolyLine => IntersectShape(shape.GetPolylineShape(), ref points, returnAfterFirstValid),
+            _ => 0
+        };
     }
 
 }

--- a/ShapeEngine/Geometry/QuadDef/QuadOverlap.cs
+++ b/ShapeEngine/Geometry/QuadDef/QuadOverlap.cs
@@ -334,5 +334,28 @@ public readonly partial struct Quad
 
         return false;
     }
+    
+    /// <summary>
+    /// Determines whether this shape overlaps with the specified <see cref="IShape"/>.
+    /// </summary>
+    /// <param name="shape">The shape to test for overlap with this shape.
+    /// The shape can be any supported type such as circle, segment, ray, line, triangle, rectangle, quad, polygon, or polyline.</param>
+    /// <returns><c>true</c> if this shape overlaps with the specified shape; otherwise, <c>false</c>.</returns>
+    public bool OverlapShape(IShape shape)
+    {
+        return shape.GetShapeType() switch
+        {
+            ShapeType.Circle => OverlapShape(shape.GetCircleShape()),
+            ShapeType.Segment => OverlapShape(shape.GetSegmentShape()),
+            ShapeType.Ray => OverlapShape(shape.GetRayShape()),
+            ShapeType.Line => OverlapShape(shape.GetLineShape()),
+            ShapeType.Triangle => OverlapShape(shape.GetTriangleShape()),
+            ShapeType.Rect => OverlapShape(shape.GetRectShape()),
+            ShapeType.Quad => OverlapShape(shape.GetQuadShape()),
+            ShapeType.Poly => OverlapShape(shape.GetPolygonShape()),
+            ShapeType.PolyLine => OverlapShape(shape.GetPolylineShape()),
+            _ => false
+        };
+    }
 
 }

--- a/ShapeEngine/Geometry/RayDef/RayClosestPoint.cs
+++ b/ShapeEngine/Geometry/RayDef/RayClosestPoint.cs
@@ -501,4 +501,28 @@ public readonly partial struct Ray
 
         return closestResult.SetOtherSegmentIndex(otherIndex);
     }
+    
+    /// <summary>
+    /// Finds the closest point on this shapes perimeter to the given <see cref="IShape"/>.
+    /// </summary>
+    /// <param name="shape">The shape to compare against.</param>
+    /// <returns>
+    /// A <see cref="ClosestPointResult"/> containing the closest point information for the shape.
+    /// </returns>
+    public ClosestPointResult GetClosestPoint(IShape shape)
+    {
+        return shape.GetShapeType() switch
+        {
+            ShapeType.Circle => GetClosestPoint(shape.GetCircleShape()),
+            ShapeType.Segment => GetClosestPoint(shape.GetSegmentShape()),
+            ShapeType.Ray => GetClosestPoint(shape.GetRayShape()),
+            ShapeType.Line => GetClosestPoint(shape.GetLineShape()),
+            ShapeType.Triangle => GetClosestPoint(shape.GetTriangleShape()),
+            ShapeType.Rect => GetClosestPoint(shape.GetRectShape()),
+            ShapeType.Quad => GetClosestPoint(shape.GetQuadShape()),
+            ShapeType.Poly => GetClosestPoint(shape.GetPolygonShape()),
+            ShapeType.PolyLine => GetClosestPoint(shape.GetPolylineShape()),
+            _ => new()
+        };
+    }
 }

--- a/ShapeEngine/Geometry/RayDef/RayIntersectShape.cs
+++ b/ShapeEngine/Geometry/RayDef/RayIntersectShape.cs
@@ -267,7 +267,11 @@ public readonly partial struct Ray
     /// <remarks>
     /// The method uses the ray-polygon intersection algorithm, which may return multiple intersection points depending on the polygon's shape and the ray's direction.
     /// </remarks>
-    public IntersectionPoints? IntersectShape(Polygon p, int maxCollisionPoints = -1) => IntersectRayPolygon(Point, Direction, p, maxCollisionPoints);
+    public IntersectionPoints? IntersectShape(Polygon p, int maxCollisionPoints = -1)
+    {
+        return p.Count < 3 ? null : IntersectRayPolygon(Point, Direction, p, maxCollisionPoints);
+    }
+
     /// <summary>
     /// Computes all intersection points between this ray and a polyline.
     /// </summary>
@@ -277,7 +281,10 @@ public readonly partial struct Ray
     /// <remarks>
     /// The method uses the ray-polyline intersection algorithm, which may return multiple intersection points depending on the polyline's shape and the ray's direction.
     /// </remarks>
-    public IntersectionPoints? IntersectShape(Polyline pl, int maxCollisionPoints = -1) => IntersectRayPolyline(Point, Direction, pl, maxCollisionPoints);
+    public IntersectionPoints? IntersectShape(Polyline pl, int maxCollisionPoints = -1)
+    {
+        return pl.Count < 2 ? null : IntersectRayPolyline(Point, Direction, pl, maxCollisionPoints);
+    }
 
     /// <summary>
     /// Computes all intersection points between this ray and a set of segments.

--- a/ShapeEngine/Geometry/RayDef/RayIntersectShape.cs
+++ b/ShapeEngine/Geometry/RayDef/RayIntersectShape.cs
@@ -671,5 +671,55 @@ public readonly partial struct Ray
 
         return count;
     }
+    
+        /// <summary>
+    /// Computes intersection points between this shape and a shape implementing <see cref="IShape"/>.
+    /// </summary>
+    /// <param name="shape">The shape to test against.</param>
+    /// <returns>
+    /// A <see cref="IntersectionPoints"/> collection of intersection points, or null if none.
+    /// </returns>
+    public IntersectionPoints? IntersectShape(IShape shape)
+    {
+        return shape.GetShapeType() switch
+        {
+            ShapeType.Circle => IntersectShape(shape.GetCircleShape()),
+            ShapeType.Segment => IntersectShape(shape.GetSegmentShape()),
+            ShapeType.Ray => IntersectShape(shape.GetRayShape()),
+            ShapeType.Line => IntersectShape(shape.GetLineShape()),
+            ShapeType.Triangle => IntersectShape(shape.GetTriangleShape()),
+            ShapeType.Rect => IntersectShape(shape.GetRectShape()),
+            ShapeType.Quad => IntersectShape(shape.GetQuadShape()),
+            ShapeType.Poly => IntersectShape(shape.GetPolygonShape()),
+            ShapeType.PolyLine => IntersectShape(shape.GetPolylineShape()),
+            _ => null
+        };
+    }
+    
+    /// <summary>
+    /// Computes the number of intersection points between this shape and a shape implementing <see cref="IShape"/>.
+    /// </summary>
+    /// <param name="shape">The shape to test against.</param>
+    /// <param name="points">A reference to an <see cref="IntersectionPoints"/> collection to store intersection points.</param>
+    /// <param name="returnAfterFirstValid">
+    /// If true, the method returns after finding the first valid intersection point; otherwise, it finds all intersections.
+    /// </param>
+    /// <returns>The number of valid intersection points found.</returns>
+    public int IntersectShape(IShape shape, ref IntersectionPoints points, bool returnAfterFirstValid = false)
+    {
+        return shape.GetShapeType() switch
+        {
+            ShapeType.Circle => IntersectShape(shape.GetCircleShape(), ref points, returnAfterFirstValid),
+            ShapeType.Segment => IntersectShape(shape.GetSegmentShape(), ref points),
+            ShapeType.Ray => IntersectShape(shape.GetRayShape(), ref points),
+            ShapeType.Line => IntersectShape(shape.GetLineShape(), ref points),
+            ShapeType.Triangle => IntersectShape(shape.GetTriangleShape(), ref points, returnAfterFirstValid),
+            ShapeType.Rect => IntersectShape(shape.GetRectShape(), ref points, returnAfterFirstValid),
+            ShapeType.Quad => IntersectShape(shape.GetQuadShape(), ref points, returnAfterFirstValid),
+            ShapeType.Poly => IntersectShape(shape.GetPolygonShape(), ref points, returnAfterFirstValid),
+            ShapeType.PolyLine => IntersectShape(shape.GetPolylineShape(), ref points, returnAfterFirstValid),
+            _ => 0
+        };
+    }
 
 }

--- a/ShapeEngine/Geometry/RayDef/RayOverlap.cs
+++ b/ShapeEngine/Geometry/RayDef/RayOverlap.cs
@@ -80,13 +80,19 @@ public readonly partial struct Ray
     /// </summary>
     /// <param name="points">The list of points defining the polygon.</param>
     /// <returns>True if the ray overlaps the polygon; otherwise, false.</returns>
-    public bool OverlapPolygon(List<Vector2> points) => OverlapRayPolygon(Point, Direction, points);
+    public bool OverlapPolygon(List<Vector2> points)
+    {
+        return points.Count >= 3 && OverlapRayPolygon(Point, Direction, points);
+    }
     /// <summary>
     /// Determines whether this ray overlaps the specified polyline.
     /// </summary>
     /// <param name="points">The list of points defining the polyline.</param>
     /// <returns>True if the ray overlaps the polyline; otherwise, false.</returns>
-    public bool OverlapPolyline(List<Vector2> points) => OverlapRayPolyline(Point, Direction, points);
+    public bool OverlapPolyline(List<Vector2> points)
+    {
+        return points.Count >= 2 && OverlapRayPolyline(Point, Direction, points);
+    }
     /// <summary>
     /// Determines whether this ray overlaps the specified list of segments.
     /// </summary>

--- a/ShapeEngine/Geometry/RayDef/RayOverlap.cs
+++ b/ShapeEngine/Geometry/RayDef/RayOverlap.cs
@@ -214,5 +214,28 @@ public readonly partial struct Ray
     /// <param name="segments">The set of segments to check for overlap.</param>
     /// <returns>True if the ray overlaps any of the segments; otherwise, false.</returns>
     public bool OverlapShape(Segments segments) => OverlapRaySegments(Point, Direction, segments);
+    
+    /// <summary>
+    /// Determines whether this shape overlaps with the specified <see cref="IShape"/>.
+    /// </summary>
+    /// <param name="shape">The shape to test for overlap with this shape.
+    /// The shape can be any supported type such as circle, segment, ray, line, triangle, rectangle, quad, polygon, or polyline.</param>
+    /// <returns><c>true</c> if this shape overlaps with the specified shape; otherwise, <c>false</c>.</returns>
+    public bool OverlapShape(IShape shape)
+    {
+        return shape.GetShapeType() switch
+        {
+            ShapeType.Circle => OverlapShape(shape.GetCircleShape()),
+            ShapeType.Segment => OverlapShape(shape.GetSegmentShape()),
+            ShapeType.Ray => OverlapShape(shape.GetRayShape()),
+            ShapeType.Line => OverlapShape(shape.GetLineShape()),
+            ShapeType.Triangle => OverlapShape(shape.GetTriangleShape()),
+            ShapeType.Rect => OverlapShape(shape.GetRectShape()),
+            ShapeType.Quad => OverlapShape(shape.GetQuadShape()),
+            ShapeType.Poly => OverlapShape(shape.GetPolygonShape()),
+            ShapeType.PolyLine => OverlapShape(shape.GetPolylineShape()),
+            _ => false
+        };
+    }
 
 }

--- a/ShapeEngine/Geometry/RayDef/RayOverlapStatic.cs
+++ b/ShapeEngine/Geometry/RayDef/RayOverlapStatic.cs
@@ -255,7 +255,7 @@ public readonly partial struct Ray
     /// </remarks>
     public static bool OverlapRayPolyline(Vector2 rayPoint, Vector2 rayDirection, List<Vector2> points)
     {
-        if (points.Count < 3) return false;
+        if (points.Count < 2) return false;
         for (var i = 0; i < points.Count - 1; i++)
         {
             var colPoint = IntersectRaySegment(rayPoint, rayDirection, points[i], points[i + 1]);

--- a/ShapeEngine/Geometry/RectDef/Rect.cs
+++ b/ShapeEngine/Geometry/RectDef/Rect.cs
@@ -310,6 +310,21 @@ public readonly partial struct Rect : IEquatable<Rect>
     /// </summary>
     /// <returns>A <see cref="Polygon"/> object representing the rectangle.</returns>
     public Polygon ToPolygon() { return [TopLeft, BottomLeft, BottomRight, TopRight]; }
+    
+    /// <summary>
+    /// Converts the rectangle to a polygon by adding its corners to the provided <see cref="Polygon"/> reference.
+    /// The corners are added in counter-clockwise order: top-left, bottom-left, bottom-right, top-right.
+    /// </summary>
+    /// <param name="result">A reference to a <see cref="Polygon"/> that will be populated with the rectangle's corners.</param>
+    public void ToPolygon(ref Polygon result)
+    {
+        if(result.Count > 0) result.Clear();
+        result.Add(A);
+        result.Add(B);
+        result.Add(C);
+        result.Add(D);
+    }
+    
     /// <summary>
     /// Converts the rectangle to a polyline representing its outline.
     /// </summary>

--- a/ShapeEngine/Geometry/RectDef/RectClosestPoint.cs
+++ b/ShapeEngine/Geometry/RectDef/RectClosestPoint.cs
@@ -1163,4 +1163,28 @@ public readonly partial struct Rect
 
         return furthest;
     }
+    
+    /// <summary>
+    /// Finds the closest point on this shapes perimeter to the given <see cref="IShape"/>.
+    /// </summary>
+    /// <param name="shape">The shape to compare against.</param>
+    /// <returns>
+    /// A <see cref="ClosestPointResult"/> containing the closest point information for the shape.
+    /// </returns>
+    public ClosestPointResult GetClosestPoint(IShape shape)
+    {
+        return shape.GetShapeType() switch
+        {
+            ShapeType.Circle => GetClosestPoint(shape.GetCircleShape()),
+            ShapeType.Segment => GetClosestPoint(shape.GetSegmentShape()),
+            ShapeType.Ray => GetClosestPoint(shape.GetRayShape()),
+            ShapeType.Line => GetClosestPoint(shape.GetLineShape()),
+            ShapeType.Triangle => GetClosestPoint(shape.GetTriangleShape()),
+            ShapeType.Rect => GetClosestPoint(shape.GetRectShape()),
+            ShapeType.Quad => GetClosestPoint(shape.GetQuadShape()),
+            ShapeType.Poly => GetClosestPoint(shape.GetPolygonShape()),
+            ShapeType.PolyLine => GetClosestPoint(shape.GetPolylineShape()),
+            _ => new()
+        };
+    }
 }

--- a/ShapeEngine/Geometry/RectDef/RectContains.cs
+++ b/ShapeEngine/Geometry/RectDef/RectContains.cs
@@ -215,4 +215,23 @@ public readonly partial struct Rect
     {
         return ContainsRectPoints(TopLeft, BottomRight, points);
     }
+    /// <summary>
+    /// Determines whether this shape contains the specified <see cref="IShape"/>.
+    /// </summary>
+    /// <param name="shape">The shape to check.</param>
+    /// <returns><c>true</c> if the shape is inside this shape; otherwise, <c>false</c>.</returns>
+    public bool ContainsShape(IShape shape)
+    {
+        return shape.GetShapeType() switch
+        {
+            ShapeType.Circle => ContainsShape(shape.GetCircleShape()),
+            ShapeType.Segment => ContainsShape(shape.GetSegmentShape()),
+            ShapeType.Triangle => ContainsShape(shape.GetTriangleShape()),
+            ShapeType.Rect => ContainsShape(shape.GetRectShape()),
+            ShapeType.Quad => ContainsShape(shape.GetQuadShape()),
+            ShapeType.Poly => ContainsShape(shape.GetPolygonShape()),
+            ShapeType.PolyLine => ContainsShape(shape.GetPolylineShape()),
+            _ => false
+        };
+    }
 }

--- a/ShapeEngine/Geometry/RectDef/RectIntersectShape.cs
+++ b/ShapeEngine/Geometry/RectDef/RectIntersectShape.cs
@@ -833,4 +833,30 @@ public readonly partial struct Rect
 
         return points;
     }
+    
+        /// <summary>
+    /// Computes intersection points between this shape and a shape implementing <see cref="IShape"/>.
+    /// </summary>
+    /// <param name="shape">The shape to test against.</param>
+    /// <returns>
+    /// A <see cref="IntersectionPoints"/> collection of intersection points, or null if none.
+    /// </returns>
+    public IntersectionPoints? IntersectShape(IShape shape)
+    {
+        return shape.GetShapeType() switch
+        {
+            ShapeType.Circle => IntersectShape(shape.GetCircleShape()),
+            ShapeType.Segment => IntersectShape(shape.GetSegmentShape()),
+            ShapeType.Ray => IntersectShape(shape.GetRayShape()),
+            ShapeType.Line => IntersectShape(shape.GetLineShape()),
+            ShapeType.Triangle => IntersectShape(shape.GetTriangleShape()),
+            ShapeType.Rect => IntersectShape(shape.GetRectShape()),
+            ShapeType.Quad => IntersectShape(shape.GetQuadShape()),
+            ShapeType.Poly => IntersectShape(shape.GetPolygonShape()),
+            ShapeType.PolyLine => IntersectShape(shape.GetPolylineShape()),
+            _ => null
+        };
+    }
+    
+
 }

--- a/ShapeEngine/Geometry/RectDef/RectIntersectShape2.cs
+++ b/ShapeEngine/Geometry/RectDef/RectIntersectShape2.cs
@@ -911,4 +911,30 @@ public readonly partial struct Rect
 
         return count;
     }
+    
+    /// <summary>
+    /// Computes the number of intersection points between this shape and a shape implementing <see cref="IShape"/>.
+    /// </summary>
+    /// <param name="shape">The shape to test against.</param>
+    /// <param name="points">A reference to an <see cref="IntersectionPoints"/> collection to store intersection points.</param>
+    /// <param name="returnAfterFirstValid">
+    /// If true, the method returns after finding the first valid intersection point; otherwise, it finds all intersections.
+    /// </param>
+    /// <returns>The number of valid intersection points found.</returns>
+    public int IntersectShape(IShape shape, ref IntersectionPoints points, bool returnAfterFirstValid = false)
+    {
+        return shape.GetShapeType() switch
+        {
+            ShapeType.Circle => IntersectShape(shape.GetCircleShape(), ref points, returnAfterFirstValid),
+            ShapeType.Segment => IntersectShape(shape.GetSegmentShape(), ref points, returnAfterFirstValid),
+            ShapeType.Ray => IntersectShape(shape.GetRayShape(), ref points, returnAfterFirstValid),
+            ShapeType.Line => IntersectShape(shape.GetLineShape(), ref points, returnAfterFirstValid),
+            ShapeType.Triangle => IntersectShape(shape.GetTriangleShape(), ref points, returnAfterFirstValid),
+            ShapeType.Rect => IntersectShape(shape.GetRectShape(), ref points, returnAfterFirstValid),
+            ShapeType.Quad => IntersectShape(shape.GetQuadShape(), ref points, returnAfterFirstValid),
+            ShapeType.Poly => IntersectShape(shape.GetPolygonShape(), ref points, returnAfterFirstValid),
+            ShapeType.PolyLine => IntersectShape(shape.GetPolylineShape(), ref points, returnAfterFirstValid),
+            _ => 0
+        };
+    }
 }

--- a/ShapeEngine/Geometry/RectDef/RectOverlap.cs
+++ b/ShapeEngine/Geometry/RectDef/RectOverlap.cs
@@ -82,14 +82,20 @@ public readonly partial struct Rect
     /// </summary>
     /// <param name="points">The list of polygon points.</param>
     /// <returns>True if the polygon overlaps the rectangle; otherwise, false.</returns>
-    public bool OverlapPolygon(List<Vector2> points) => OverlapRectPolygon(A, B, C, D, points);
+    public bool OverlapPolygon(List<Vector2> points)
+    {
+        return points.Count >= 3 && OverlapRectPolygon(A, B, C, D, points);
+    }
 
     /// <summary>
     /// Checks if the rectangle overlaps with the given polyline.
     /// </summary>
     /// <param name="points">The list of polyline points.</param>
     /// <returns>True if the polyline overlaps the rectangle; otherwise, false.</returns>
-    public bool OverlapPolyline(List<Vector2> points) => OverlapRectPolyline(A, B, C, D, points);
+    public bool OverlapPolyline(List<Vector2> points)
+    {
+        return points.Count >= 2 && OverlapRectPolyline(A, B, C, D, points);
+    }
 
     /// <summary>
     /// Checks if the rectangle overlaps with the given list of segments.

--- a/ShapeEngine/Geometry/RectDef/RectOverlap.cs
+++ b/ShapeEngine/Geometry/RectDef/RectOverlap.cs
@@ -318,4 +318,27 @@ public readonly partial struct Rect
 
         return dp1 * dp2 <= 0.0f || dp2 * dp3 <= 0.0f || dp3 * dp4 <= 0.0f;
     }
+    
+    /// <summary>
+    /// Determines whether this shape overlaps with the specified <see cref="IShape"/>.
+    /// </summary>
+    /// <param name="shape">The shape to test for overlap with this shape.
+    /// The shape can be any supported type such as circle, segment, ray, line, triangle, rectangle, quad, polygon, or polyline.</param>
+    /// <returns><c>true</c> if this shape overlaps with the specified shape; otherwise, <c>false</c>.</returns>
+    public bool OverlapShape(IShape shape)
+    {
+        return shape.GetShapeType() switch
+        {
+            ShapeType.Circle => OverlapShape(shape.GetCircleShape()),
+            ShapeType.Segment => OverlapShape(shape.GetSegmentShape()),
+            ShapeType.Ray => OverlapShape(shape.GetRayShape()),
+            ShapeType.Line => OverlapShape(shape.GetLineShape()),
+            ShapeType.Triangle => OverlapShape(shape.GetTriangleShape()),
+            ShapeType.Rect => OverlapShape(shape.GetRectShape()),
+            ShapeType.Quad => OverlapShape(shape.GetQuadShape()),
+            ShapeType.Poly => OverlapShape(shape.GetPolygonShape()),
+            ShapeType.PolyLine => OverlapShape(shape.GetPolylineShape()),
+            _ => false
+        };
+    }
 }

--- a/ShapeEngine/Geometry/RectDef/RectOverlapStatic.cs
+++ b/ShapeEngine/Geometry/RectDef/RectOverlapStatic.cs
@@ -155,7 +155,7 @@ public readonly partial struct Rect
     /// </remarks>
     public static bool OverlapRectPolygon(Vector2 a, Vector2 b, Vector2 c, Vector2 d, List<Vector2> points)
     {
-        return Quad.OverlapQuadPolygon(a, b, c, d, points);
+        return points.Count >= 3 && Quad.OverlapQuadPolygon(a, b, c, d, points);
     }
 
     /// <summary>
@@ -172,7 +172,7 @@ public readonly partial struct Rect
     /// </remarks>
     public static bool OverlapRectPolyline(Vector2 a, Vector2 b, Vector2 c, Vector2 d, List<Vector2> points)
     {
-        return Quad.OverlapQuadPolyline(a, b, c, d, points);
+        return points.Count >= 2 && Quad.OverlapQuadPolyline(a, b, c, d, points);
     }
 
     /// <summary>

--- a/ShapeEngine/Geometry/SegmentDef/SegmentClosestPoint.cs
+++ b/ShapeEngine/Geometry/SegmentDef/SegmentClosestPoint.cs
@@ -15,7 +15,7 @@ namespace ShapeEngine.Geometry.SegmentDef;
 
 public readonly partial struct Segment
 {
-        /// <summary>
+    /// <summary>
     /// Finds the closest point on the segment to any collider in the given collision object.
     /// </summary>
     /// <param name="collisionObject">The collision object containing one or more colliders to compare against.</param>
@@ -540,6 +540,30 @@ public readonly partial struct Segment
 
         disSquared = disSqB;
         return End;
+    }
+    
+    /// <summary>
+    /// Finds the closest point on this shapes perimeter to the given <see cref="IShape"/>.
+    /// </summary>
+    /// <param name="shape">The shape to compare against.</param>
+    /// <returns>
+    /// A <see cref="ClosestPointResult"/> containing the closest point information for the shape.
+    /// </returns>
+    public ClosestPointResult GetClosestPoint(IShape shape)
+    {
+        return shape.GetShapeType() switch
+        {
+            ShapeType.Circle => GetClosestPoint(shape.GetCircleShape()),
+            ShapeType.Segment => GetClosestPoint(shape.GetSegmentShape()),
+            ShapeType.Ray => GetClosestPoint(shape.GetRayShape()),
+            ShapeType.Line => GetClosestPoint(shape.GetLineShape()),
+            ShapeType.Triangle => GetClosestPoint(shape.GetTriangleShape()),
+            ShapeType.Rect => GetClosestPoint(shape.GetRectShape()),
+            ShapeType.Quad => GetClosestPoint(shape.GetQuadShape()),
+            ShapeType.Poly => GetClosestPoint(shape.GetPolygonShape()),
+            ShapeType.PolyLine => GetClosestPoint(shape.GetPolylineShape()),
+            _ => new()
+        };
     }
 
 }

--- a/ShapeEngine/Geometry/SegmentDef/SegmentIntersectShape.cs
+++ b/ShapeEngine/Geometry/SegmentDef/SegmentIntersectShape.cs
@@ -771,5 +771,55 @@ public readonly partial struct Segment
 
         return count;
     }
+    
+        /// <summary>
+    /// Computes intersection points between this shape and a shape implementing <see cref="IShape"/>.
+    /// </summary>
+    /// <param name="shape">The shape to test against.</param>
+    /// <returns>
+    /// A <see cref="IntersectionPoints"/> collection of intersection points, or null if none.
+    /// </returns>
+    public IntersectionPoints? IntersectShape(IShape shape)
+    {
+        return shape.GetShapeType() switch
+        {
+            ShapeType.Circle => IntersectShape(shape.GetCircleShape()),
+            ShapeType.Segment => IntersectShape(shape.GetSegmentShape()),
+            ShapeType.Ray => IntersectShape(shape.GetRayShape()),
+            ShapeType.Line => IntersectShape(shape.GetLineShape()),
+            ShapeType.Triangle => IntersectShape(shape.GetTriangleShape()),
+            ShapeType.Rect => IntersectShape(shape.GetRectShape()),
+            ShapeType.Quad => IntersectShape(shape.GetQuadShape()),
+            ShapeType.Poly => IntersectShape(shape.GetPolygonShape()),
+            ShapeType.PolyLine => IntersectShape(shape.GetPolylineShape()),
+            _ => null
+        };
+    }
+    
+    /// <summary>
+    /// Computes the number of intersection points between this shape and a shape implementing <see cref="IShape"/>.
+    /// </summary>
+    /// <param name="shape">The shape to test against.</param>
+    /// <param name="points">A reference to an <see cref="IntersectionPoints"/> collection to store intersection points.</param>
+    /// <param name="returnAfterFirstValid">
+    /// If true, the method returns after finding the first valid intersection point; otherwise, it finds all intersections.
+    /// </param>
+    /// <returns>The number of valid intersection points found.</returns>
+    public int IntersectShape(IShape shape, ref IntersectionPoints points, bool returnAfterFirstValid = false)
+    {
+        return shape.GetShapeType() switch
+        {
+            ShapeType.Circle => IntersectShape(shape.GetCircleShape(), ref points, returnAfterFirstValid),
+            ShapeType.Segment => IntersectShape(shape.GetSegmentShape(), ref points),
+            ShapeType.Ray => IntersectShape(shape.GetRayShape(), ref points),
+            ShapeType.Line => IntersectShape(shape.GetLineShape(), ref points),
+            ShapeType.Triangle => IntersectShape(shape.GetTriangleShape(), ref points, returnAfterFirstValid),
+            ShapeType.Rect => IntersectShape(shape.GetRectShape(), ref points, returnAfterFirstValid),
+            ShapeType.Quad => IntersectShape(shape.GetQuadShape(), ref points, returnAfterFirstValid),
+            ShapeType.Poly => IntersectShape(shape.GetPolygonShape(), ref points, returnAfterFirstValid),
+            ShapeType.PolyLine => IntersectShape(shape.GetPolylineShape(), ref points, returnAfterFirstValid),
+            _ => 0
+        };
+    }
 
 }

--- a/ShapeEngine/Geometry/SegmentDef/SegmentIntersectionStatic.cs
+++ b/ShapeEngine/Geometry/SegmentDef/SegmentIntersectionStatic.cs
@@ -608,7 +608,7 @@ public readonly partial struct Segment
     /// <returns>A <see cref="IntersectionPoints"/> collection, or null if there are no intersections.</returns>
     public static IntersectionPoints? IntersectSegmentPolyline(Vector2 segmentStart, Vector2 segmentEnd, List<Vector2> points, int maxCollisionPoints = -1)
     {
-        if (points.Count < 3) return null;
+        if (points.Count < 2) return null;
         if (maxCollisionPoints == 0) return null;
         IntersectionPoints? result = null;
         for (var i = 0; i < points.Count - 1; i++)

--- a/ShapeEngine/Geometry/SegmentDef/SegmentOverlap.cs
+++ b/ShapeEngine/Geometry/SegmentDef/SegmentOverlap.cs
@@ -317,5 +317,28 @@ public readonly partial struct Segment
 
         return false;
     }
+    
+    /// <summary>
+    /// Determines whether this shape overlaps with the specified <see cref="IShape"/>.
+    /// </summary>
+    /// <param name="shape">The shape to test for overlap with this shape.
+    /// The shape can be any supported type such as circle, segment, ray, line, triangle, rectangle, quad, polygon, or polyline.</param>
+    /// <returns><c>true</c> if this shape overlaps with the specified shape; otherwise, <c>false</c>.</returns>
+    public bool OverlapShape(IShape shape)
+    {
+        return shape.GetShapeType() switch
+        {
+            ShapeType.Circle => OverlapShape(shape.GetCircleShape()),
+            ShapeType.Segment => OverlapShape(shape.GetSegmentShape()),
+            ShapeType.Ray => OverlapShape(shape.GetRayShape()),
+            ShapeType.Line => OverlapShape(shape.GetLineShape()),
+            ShapeType.Triangle => OverlapShape(shape.GetTriangleShape()),
+            ShapeType.Rect => OverlapShape(shape.GetRectShape()),
+            ShapeType.Quad => OverlapShape(shape.GetQuadShape()),
+            ShapeType.Poly => OverlapShape(shape.GetPolygonShape()),
+            ShapeType.PolyLine => OverlapShape(shape.GetPolylineShape()),
+            _ => false
+        };
+    }
 
 }

--- a/ShapeEngine/Geometry/SegmentDef/SegmentOverlapStatic.cs
+++ b/ShapeEngine/Geometry/SegmentDef/SegmentOverlapStatic.cs
@@ -189,7 +189,6 @@ public readonly partial struct Segment
     public static bool OverlapSegmentPolygon(Vector2 segStart, Vector2 segEnd, List<Vector2> points)
     {
         if (points.Count < 3) return false;
-        // if (Polygon.ContainsPoints(points, segStart)) return true;
         var oddNodes = false;
         for (var i = 0; i < points.Count; i++)
         {
@@ -214,7 +213,7 @@ public readonly partial struct Segment
     /// </remarks>
     public static bool OverlapSegmentPolyline(Vector2 segStart, Vector2 segEnd, List<Vector2> points)
     {
-        if (points.Count < 3) return false;
+        if (points.Count < 2) return false;
         for (var i = 0; i < points.Count - 1; i++)
         {
             if (OverlapSegmentSegment(segStart, segEnd, points[i], points[i + 1])) return true;

--- a/ShapeEngine/Geometry/SegmentsDef/SegmentsClosestPoint.cs
+++ b/ShapeEngine/Geometry/SegmentsDef/SegmentsClosestPoint.cs
@@ -736,5 +736,29 @@ public partial class Segments
 
         return new(closestSegment, new(closest, closestSegment.Normal));
     }
+    
+    /// <summary>
+    /// Finds the closest point on this shapes perimeter to the given <see cref="IShape"/>.
+    /// </summary>
+    /// <param name="shape">The shape to compare against.</param>
+    /// <returns>
+    /// A <see cref="ClosestPointResult"/> containing the closest point information for the shape.
+    /// </returns>
+    public ClosestPointResult GetClosestPoint(IShape shape)
+    {
+        return shape.GetShapeType() switch
+        {
+            ShapeType.Circle => GetClosestPoint(shape.GetCircleShape()),
+            ShapeType.Segment => GetClosestPoint(shape.GetSegmentShape()),
+            ShapeType.Ray => GetClosestPoint(shape.GetRayShape()),
+            ShapeType.Line => GetClosestPoint(shape.GetLineShape()),
+            ShapeType.Triangle => GetClosestPoint(shape.GetTriangleShape()),
+            ShapeType.Rect => GetClosestPoint(shape.GetRectShape()),
+            ShapeType.Quad => GetClosestPoint(shape.GetQuadShape()),
+            ShapeType.Poly => GetClosestPoint(shape.GetPolygonShape()),
+            ShapeType.PolyLine => GetClosestPoint(shape.GetPolylineShape()),
+            _ => new()
+        };
+    }
 
 }

--- a/ShapeEngine/Geometry/SegmentsDef/SegmentsIntersectShape.cs
+++ b/ShapeEngine/Geometry/SegmentsDef/SegmentsIntersectShape.cs
@@ -300,6 +300,30 @@ public partial class Segments
     }
     
     /// <summary>
+    /// Computes intersection points between this shape and a shape implementing <see cref="IShape"/>.
+    /// </summary>
+    /// <param name="shape">The shape to test against.</param>
+    /// <returns>
+    /// A <see cref="IntersectionPoints"/> collection of intersection points, or null if none.
+    /// </returns>
+    public IntersectionPoints? IntersectShape(IShape shape)
+    {
+        return shape.GetShapeType() switch
+        {
+            ShapeType.Circle => IntersectShape(shape.GetCircleShape()),
+            ShapeType.Segment => IntersectShape(shape.GetSegmentShape()),
+            ShapeType.Ray => IntersectShape(shape.GetRayShape()),
+            ShapeType.Line => IntersectShape(shape.GetLineShape()),
+            ShapeType.Triangle => IntersectShape(shape.GetTriangleShape()),
+            ShapeType.Rect => IntersectShape(shape.GetRectShape()),
+            ShapeType.Quad => IntersectShape(shape.GetQuadShape()),
+            ShapeType.Poly => IntersectShape(shape.GetPolygonShape()),
+            ShapeType.PolyLine => IntersectShape(shape.GetPolylineShape()),
+            _ => null
+        };
+    }
+    
+    /// <summary>
     /// Intersects a set of segments with the segments.
     /// </summary>
     /// <param name="shape">The segments to intersect with.</param>
@@ -462,6 +486,190 @@ public partial class Segments
         }
 
         return count;
+    }
+    /// <summary>
+    /// Computes all intersection points between this segments and a triangle.
+    /// </summary>
+    /// <param name="shape">The triangle to test against.</param>
+    /// <param name="points">A reference to an <see cref="IntersectionPoints"/> collection to store intersection points.</param>
+    /// <param name="returnAfterFirstValid">
+    /// If true, the method returns after finding the first valid intersection point; otherwise, it finds all intersections.
+    /// </param>
+    /// <returns>The number of valid intersection points found.</returns>
+    public int IntersectShape(Triangle shape, ref IntersectionPoints points, bool returnAfterFirstValid = false)
+    {
+        if(Count <= 0) return 0;
+        var count = 0;
+        foreach (var segment in this)
+        {
+            var result = Segment.IntersectSegmentTriangle(segment.Start, segment.End, shape.A, shape.B, shape.C);
+            if (result.a.Valid || result.b.Valid)
+            {
+                if (result.a.Valid)
+                {
+                    points.Add(result.a);
+                    if(returnAfterFirstValid) return 1;
+                    count++;
+                }
+
+                if (result.b.Valid)
+                {
+                    points.Add(result.b);
+                    count++;
+                }
+            }
+        }
+        return count;
+    }
+    /// <summary>
+    /// Computes all intersection points between this segments and a rectangle.
+    /// </summary>
+    /// <param name="shape">The rectangle to test against.</param>
+    /// <param name="points">A reference to an <see cref="IntersectionPoints"/> collection to store intersection points.</param>
+    /// <param name="returnAfterFirstValid">
+    /// If true, the method returns after finding the first valid intersection point; otherwise, it finds all intersections.
+    /// </param>
+    /// <returns>The number of valid intersection points found.</returns>
+    public int IntersectShape(Rect shape, ref IntersectionPoints points, bool returnAfterFirstValid = false)
+    {
+        if(Count <= 0) return 0;
+        var count = 0;
+        foreach (var segment in this)
+        {
+            var result = Segment.IntersectSegmentRect(segment.Start, segment.End, shape.A, shape.B, shape.C, shape.D);
+            if (result.a.Valid || result.b.Valid)
+            {
+                if (result.a.Valid)
+                {
+                    points.Add(result.a);
+                    if(returnAfterFirstValid) return 1;
+                    count++;
+                }
+
+                if (result.b.Valid)
+                {
+                    points.Add(result.b);
+                    count++;
+                }
+            }
+        }
+        return count;
+    }
+    /// <summary>
+    /// Computes all intersection points between this segments and a quadrilateral.
+    /// </summary>
+    /// <param name="shape">The quadrilateral to test against.</param>
+    /// <param name="points">A reference to an <see cref="IntersectionPoints"/> collection to store intersection points.</param>
+    /// <param name="returnAfterFirstValid">
+    /// If true, the method returns after finding the first valid intersection point; otherwise, it finds all intersections.
+    /// </param>
+    /// <returns>The number of valid intersection points found.</returns>
+    public int IntersectShape(Quad shape, ref IntersectionPoints points, bool returnAfterFirstValid = false)
+    {
+        if(Count <= 0) return 0;
+        var count = 0;
+        foreach (var segment in this)
+        {
+            var result = Segment.IntersectSegmentQuad(segment.Start, segment.End, shape.A, shape.B, shape.C, shape.D);
+            if (result.a.Valid || result.b.Valid)
+            {
+                if (result.a.Valid)
+                {
+                    points.Add(result.a);
+                    if(returnAfterFirstValid) return 1;
+                    count++;
+                }
+
+                if (result.b.Valid)
+                {
+                    points.Add(result.b);
+                    count++;
+                }
+            }
+        }
+        return count;
+    }
+    /// <summary>
+    /// Computes all intersection points between this segments and a polygon.
+    /// </summary>
+    /// <param name="shape">The polygon to test against. Must have at least 3 vertices.</param>
+    /// <param name="points">A reference to an <see cref="IntersectionPoints"/> collection to store intersection points.</param>
+    /// <param name="returnAfterFirstValid">
+    /// If true, the method returns after finding the first valid intersection point; otherwise, it finds all intersections.
+    /// </param>
+    /// <returns>The number of valid intersection points found.</returns>
+    public int IntersectShape(Polygon shape, ref IntersectionPoints points, bool returnAfterFirstValid = false)
+    {
+        if (Count <= 0 || shape.Count < 3) return 0;
+        var count = 0;
+        foreach (var segment in this)
+        {
+            for (var i = 0; i < shape.Count; i++)
+            {
+                var colPoint = Segment.IntersectSegmentSegment(segment.Start, segment.End, shape[i], shape[(i + 1) % shape.Count]);
+                if (colPoint.Valid)
+                {
+                    points.Add(colPoint);
+                    if (returnAfterFirstValid) return 1;
+                    count++;
+                }
+            }
+        }
+        return count;
+    }
+    /// <summary>
+    /// Computes all intersection points between this segments and a polyline.
+    /// </summary>
+    /// <param name="shape">The polyline to test against. Must have at least 2 vertices.</param>
+    /// <param name="points">A reference to an <see cref="IntersectionPoints"/> collection to store intersection points.</param>
+    /// <param name="returnAfterFirstValid">
+    /// If true, the method returns after finding the first valid intersection point; otherwise, it finds all intersections.
+    /// </param>
+    /// <returns>The number of valid intersection points found.</returns>
+    public int IntersectShape(Polyline shape, ref IntersectionPoints points, bool returnAfterFirstValid = false)
+    {
+        if (Count <= 0 || shape.Count < 3) return 0;
+        var count = 0;
+        foreach (var segment in this)
+        {
+            for (var i = 0; i < shape.Count - 1; i++)
+            {
+                var colPoint = Segment.IntersectSegmentSegment(segment.Start, segment.End, shape[i], shape[i + 1]);
+                if (colPoint.Valid)
+                {
+                    points.Add(colPoint);
+                    if (returnAfterFirstValid) return 1;
+                    count++;
+                }
+            }
+        }
+        return count;
+    }
+    
+    /// <summary>
+    /// Computes the number of intersection points between this shape and a shape implementing <see cref="IShape"/>.
+    /// </summary>
+    /// <param name="shape">The shape to test against.</param>
+    /// <param name="points">A reference to an <see cref="IntersectionPoints"/> collection to store intersection points.</param>
+    /// <param name="returnAfterFirstValid">
+    /// If true, the method returns after finding the first valid intersection point; otherwise, it finds all intersections.
+    /// </param>
+    /// <returns>The number of valid intersection points found.</returns>
+    public int IntersectShape(IShape shape, ref IntersectionPoints points, bool returnAfterFirstValid = false)
+    {
+        return shape.GetShapeType() switch
+        {
+            ShapeType.Circle => IntersectShape(shape.GetCircleShape(), ref points, returnAfterFirstValid),
+            ShapeType.Segment => IntersectShape(shape.GetSegmentShape(), ref points, returnAfterFirstValid),
+            ShapeType.Ray => IntersectShape(shape.GetRayShape(), ref points, returnAfterFirstValid),
+            ShapeType.Line => IntersectShape(shape.GetLineShape(), ref points, returnAfterFirstValid),
+            ShapeType.Triangle => IntersectShape(shape.GetTriangleShape(), ref points, returnAfterFirstValid),
+            ShapeType.Rect => IntersectShape(shape.GetRectShape(), ref points, returnAfterFirstValid),
+            ShapeType.Quad => IntersectShape(shape.GetQuadShape(), ref points, returnAfterFirstValid),
+            ShapeType.Poly => IntersectShape(shape.GetPolygonShape(), ref points, returnAfterFirstValid),
+            ShapeType.PolyLine => IntersectShape(shape.GetPolylineShape(), ref points, returnAfterFirstValid),
+            _ => 0
+        };
     }
 
 }

--- a/ShapeEngine/Geometry/SegmentsDef/SegmentsIntersectShape.cs
+++ b/ShapeEngine/Geometry/SegmentsDef/SegmentsIntersectShape.cs
@@ -628,7 +628,7 @@ public partial class Segments
     /// <returns>The number of valid intersection points found.</returns>
     public int IntersectShape(Polyline shape, ref IntersectionPoints points, bool returnAfterFirstValid = false)
     {
-        if (Count <= 0 || shape.Count < 3) return 0;
+        if (Count <= 0 || shape.Count < 2) return 0;
         var count = 0;
         foreach (var segment in this)
         {

--- a/ShapeEngine/Geometry/SegmentsDef/SegmentsOverlap.cs
+++ b/ShapeEngine/Geometry/SegmentsDef/SegmentsOverlap.cs
@@ -239,5 +239,28 @@ public partial class Segments
     /// <param name="p">The polygon to check for overlap with.</param>
     /// <returns>True if the segments overlap with the polygon, false otherwise.</returns>
     public bool OverlapShape(Polygon p) => p.OverlapShape(this);
+    
+    /// <summary>
+    /// Determines whether this shape overlaps with the specified <see cref="IShape"/>.
+    /// </summary>
+    /// <param name="shape">The shape to test for overlap with this shape.
+    /// The shape can be any supported type such as circle, segment, ray, line, triangle, rectangle, quad, polygon, or polyline.</param>
+    /// <returns><c>true</c> if this shape overlaps with the specified shape; otherwise, <c>false</c>.</returns>
+    public bool OverlapShape(IShape shape)
+    {
+        return shape.GetShapeType() switch
+        {
+            ShapeType.Circle => OverlapShape(shape.GetCircleShape()),
+            ShapeType.Segment => OverlapShape(shape.GetSegmentShape()),
+            ShapeType.Ray => OverlapShape(shape.GetRayShape()),
+            ShapeType.Line => OverlapShape(shape.GetLineShape()),
+            ShapeType.Triangle => OverlapShape(shape.GetTriangleShape()),
+            ShapeType.Rect => OverlapShape(shape.GetRectShape()),
+            ShapeType.Quad => OverlapShape(shape.GetQuadShape()),
+            ShapeType.Poly => OverlapShape(shape.GetPolygonShape()),
+            ShapeType.PolyLine => OverlapShape(shape.GetPolylineShape()),
+            _ => false
+        };
+    }
 
 }

--- a/ShapeEngine/Geometry/SegmentsDef/SegmentsOverlapStatic.cs
+++ b/ShapeEngine/Geometry/SegmentsDef/SegmentsOverlapStatic.cs
@@ -117,7 +117,7 @@ public partial class Segments
     /// <remarks>This is a convenience method that calls Polygon.OverlapPolygonSegments.</remarks>
     public static bool OverlapSegmentsPolygon(List<Segment> segments, List<Vector2> points)
     {
-        return Polygon.OverlapPolygonSegments(points, segments);
+        return points.Count >= 3 && Polygon.OverlapPolygonSegments(points, segments);
     }
 
     /// <summary>
@@ -129,7 +129,7 @@ public partial class Segments
     /// <remarks>This is a convenience method that calls Polyline.OverlapPolylineSegments.</remarks>
     public static bool OverlapSegmentsPolyline(List<Segment> segments, List<Vector2> points)
     {
-        return Polyline.OverlapPolylineSegments(points, segments);
+        return points.Count >= 2 && Polyline.OverlapPolylineSegments(points, segments);
     }
 
     /// <summary>

--- a/ShapeEngine/Geometry/Shape.cs
+++ b/ShapeEngine/Geometry/Shape.cs
@@ -174,10 +174,10 @@ public abstract class Shape : IShape
     public virtual Rect GetRectShape() => new();
 
     /// <inheritdoc/>
-    public virtual Polygon GetPolygonShape() => new();
+    public virtual Polygon GetPolygonShape() => [];
 
     /// <inheritdoc/>
-    public virtual Polyline GetPolylineShape() => new();
+    public virtual Polyline GetPolylineShape() => [];
     
     /// <summary>
     /// Determines whether this shape overlaps with the specified shape.

--- a/ShapeEngine/Geometry/Shape.cs
+++ b/ShapeEngine/Geometry/Shape.cs
@@ -1,6 +1,7 @@
 using System.Numerics;
 using ShapeEngine.Core.Structs;
 using ShapeEngine.Geometry.CircleDef;
+using ShapeEngine.Geometry.CollisionSystem;
 using ShapeEngine.Geometry.LineDef;
 using ShapeEngine.Geometry.PolygonDef;
 using ShapeEngine.Geometry.PolylineDef;
@@ -177,4 +178,112 @@ public abstract class Shape : IShape
 
     /// <inheritdoc/>
     public virtual Polyline GetPolylineShape() => new();
+    
+    /// <summary>
+    /// Determines whether this shape overlaps with the specified shape.
+    /// </summary>
+    /// <param name="shape">The other shape to check for overlap.</param>
+    /// <returns><c>true</c> if the shapes overlap; otherwise, <c>false</c>.</returns>
+    public bool OverlapShape(IShape shape)
+    {
+        return GetShapeType() switch
+        {
+            ShapeType.Circle => GetCircleShape().OverlapShape(shape),
+            ShapeType.Segment => GetSegmentShape().OverlapShape(shape),
+            ShapeType.Ray => GetRayShape().OverlapShape(shape),
+            ShapeType.Line => GetLineShape().OverlapShape(shape),
+            ShapeType.Triangle => GetTriangleShape().OverlapShape(shape),
+            ShapeType.Rect => GetRectShape().OverlapShape(shape),
+            ShapeType.Quad => GetQuadShape().OverlapShape(shape),
+            ShapeType.Poly => GetPolygonShape().OverlapShape(shape),
+            ShapeType.PolyLine => GetPolylineShape().OverlapShape(shape),
+            _ => false
+        };
+    }
+    /// <summary>
+    /// Calculates the intersection points between this shape and another shape.
+    /// </summary>
+    /// <param name="shape">The other shape to check for intersection.</param>
+    /// <returns>
+    /// An <see cref="IntersectionPoints"/> object containing the intersection points if any exist; otherwise, <c>null</c>.
+    /// </returns>
+    public IntersectionPoints? IntersectShape(IShape shape)
+    {
+        return GetShapeType() switch
+        {
+            ShapeType.Circle => GetCircleShape().IntersectShape(shape),
+            ShapeType.Segment => GetSegmentShape().IntersectShape(shape),
+            ShapeType.Ray => GetRayShape().IntersectShape(shape),
+            ShapeType.Line => GetLineShape().IntersectShape(shape),
+            ShapeType.Triangle => GetTriangleShape().IntersectShape(shape),
+            ShapeType.Rect => GetRectShape().IntersectShape(shape),
+            ShapeType.Quad => GetQuadShape().IntersectShape(shape),
+            ShapeType.Poly => GetPolygonShape().IntersectShape(shape),
+            ShapeType.PolyLine => GetPolylineShape().IntersectShape(shape),
+            _ => null
+        };
+    }
+    /// <summary>
+    /// Calculates the number of intersection points between this shape and another shape.
+    /// </summary>
+    /// <param name="shape">The other shape to check for intersection.</param>
+    /// <param name="points">A reference to an <see cref="IntersectionPoints"/> object to store the intersection points.</param>
+    /// <param name="returnAfterFirstValid">If <c>true</c>, returns after finding the first valid intersection; otherwise, finds all intersections.</param>
+    /// <returns>The number of intersection points found.</returns>
+    public int IntersectShape(IShape shape, ref IntersectionPoints points, bool returnAfterFirstValid = false)
+    {
+        return GetShapeType() switch
+        {
+            ShapeType.Circle => GetCircleShape().IntersectShape(shape, ref points, returnAfterFirstValid),
+            ShapeType.Segment => GetSegmentShape().IntersectShape(shape, ref points, returnAfterFirstValid),
+            ShapeType.Ray => GetRayShape().IntersectShape(shape, ref points, returnAfterFirstValid),
+            ShapeType.Line => GetLineShape().IntersectShape(shape, ref points, returnAfterFirstValid),
+            ShapeType.Triangle => GetTriangleShape().IntersectShape(shape, ref points, returnAfterFirstValid),
+            ShapeType.Rect => GetRectShape().IntersectShape(shape, ref points, returnAfterFirstValid),
+            ShapeType.Quad => GetQuadShape().IntersectShape(shape, ref points, returnAfterFirstValid),
+            ShapeType.Poly => GetPolygonShape().IntersectShape(shape, ref points, returnAfterFirstValid),
+            ShapeType.PolyLine => GetPolylineShape().IntersectShape(shape, ref points, returnAfterFirstValid),
+            _ => 0
+        };
+    }
+    /// <summary>
+    /// Finds the closest point on this shape to the specified <paramref name="shape"/>.
+    /// </summary>
+    /// <param name="shape">The other shape to which the closest point is calculated.</param>
+    /// <returns>
+    /// A <see cref="ClosestPointResult"/> containing information about the closest point found.
+    /// </returns>
+    public ClosestPointResult GetClosestPoint(IShape shape)
+    {
+        return GetShapeType() switch
+        {
+            ShapeType.Circle => GetCircleShape().GetClosestPoint(shape),
+            ShapeType.Segment => GetSegmentShape().GetClosestPoint(shape),
+            ShapeType.Ray => GetRayShape().GetClosestPoint(shape),
+            ShapeType.Line => GetLineShape().GetClosestPoint(shape),
+            ShapeType.Triangle => GetTriangleShape().GetClosestPoint(shape),
+            ShapeType.Rect => GetRectShape().GetClosestPoint(shape),
+            ShapeType.Quad => GetQuadShape().GetClosestPoint(shape),
+            ShapeType.Poly => GetPolygonShape().GetClosestPoint(shape),
+            ShapeType.PolyLine => GetPolylineShape().GetClosestPoint(shape),
+            _ => new()
+        };
+    }
+    /// <summary>
+    /// Determines whether this shape completely contains the specified <paramref name="shape"/>.
+    /// </summary>
+    /// <param name="shape">The other shape to check for containment.</param>
+    /// <returns><c>true</c> if this shape contains the specified shape; otherwise, <c>false</c>.</returns>
+    public bool ContainsShape(IShape shape)
+    {
+        return GetShapeType() switch
+        {
+            ShapeType.Circle => GetCircleShape().ContainsShape(shape),
+            ShapeType.Triangle => GetTriangleShape().ContainsShape(shape),
+            ShapeType.Rect => GetRectShape().ContainsShape(shape),
+            ShapeType.Quad => GetQuadShape().ContainsShape(shape),
+            ShapeType.Poly => GetPolygonShape().ContainsShape(shape),
+            _ => false
+        };
+    }
 }

--- a/ShapeEngine/Geometry/ShapeContainer.cs
+++ b/ShapeEngine/Geometry/ShapeContainer.cs
@@ -20,7 +20,7 @@ public abstract class ShapeContainer : Shape
     
     // List of child shape containers. Not exposed publicly.
     private List<ShapeContainer> children { get; set; } = [];
-    
+    public List<ShapeContainer> GetChildrenCopy() => [..children];
     #endregion
     
     #region Public Functions

--- a/ShapeEngine/Geometry/TriangleDef/Triangle.cs
+++ b/ShapeEngine/Geometry/TriangleDef/Triangle.cs
@@ -192,6 +192,18 @@ public readonly partial struct Triangle : IEquatable<Triangle>
     public Polygon ToPolygon() => new() {A, B, C};
     
     /// <summary>
+    /// Converts this triangle to a polygon by adding its vertices to the provided <paramref name="result"/> polygon.
+    /// </summary>
+    /// <param name="result">A reference to a <see cref="Polygon"/> that will be cleared and filled with the triangle's vertices.</param>
+    public void ToPolygon(ref Polygon result)
+    {
+        if(result.Count > 0) result.Clear();
+        result.Add(A);
+        result.Add(B);
+        result.Add(C);
+    }
+    
+    /// <summary>
     /// Converts the triangle to a polyline representation.
     /// </summary>
     /// <returns>A polyline containing the three vertices of the triangle.</returns>

--- a/ShapeEngine/Geometry/TriangleDef/TriangleClosestPoint.cs
+++ b/ShapeEngine/Geometry/TriangleDef/TriangleClosestPoint.cs
@@ -985,5 +985,29 @@ public readonly partial struct Triangle
 
         return furthest;
     }
+    
+    /// <summary>
+    /// Finds the closest point on this shapes perimeter to the given <see cref="IShape"/>.
+    /// </summary>
+    /// <param name="shape">The shape to compare against.</param>
+    /// <returns>
+    /// A <see cref="ClosestPointResult"/> containing the closest point information for the shape.
+    /// </returns>
+    public ClosestPointResult GetClosestPoint(IShape shape)
+    {
+        return shape.GetShapeType() switch
+        {
+            ShapeType.Circle => GetClosestPoint(shape.GetCircleShape()),
+            ShapeType.Segment => GetClosestPoint(shape.GetSegmentShape()),
+            ShapeType.Ray => GetClosestPoint(shape.GetRayShape()),
+            ShapeType.Line => GetClosestPoint(shape.GetLineShape()),
+            ShapeType.Triangle => GetClosestPoint(shape.GetTriangleShape()),
+            ShapeType.Rect => GetClosestPoint(shape.GetRectShape()),
+            ShapeType.Quad => GetClosestPoint(shape.GetQuadShape()),
+            ShapeType.Poly => GetClosestPoint(shape.GetPolygonShape()),
+            ShapeType.PolyLine => GetClosestPoint(shape.GetPolylineShape()),
+            _ => new()
+        };
+    }
 
 }

--- a/ShapeEngine/Geometry/TriangleDef/TriangleContains.cs
+++ b/ShapeEngine/Geometry/TriangleDef/TriangleContains.cs
@@ -209,7 +209,7 @@ public readonly partial struct Triangle
     /// </remarks>
     public bool ContainsShape(Polygon polygon)
     {
-        return ContainsTrianglePoints(A, B, C, polygon);
+        return polygon.Count >= 3 && ContainsTrianglePoints(A, B, C, polygon);
     }
 
     /// <summary>

--- a/ShapeEngine/Geometry/TriangleDef/TriangleContains.cs
+++ b/ShapeEngine/Geometry/TriangleDef/TriangleContains.cs
@@ -225,5 +225,23 @@ public readonly partial struct Triangle
     {
         return ContainsTrianglePoints(A, B, C, points);
     }
-
+    /// <summary>
+    /// Determines whether this shape contains the specified <see cref="IShape"/>.
+    /// </summary>
+    /// <param name="shape">The shape to check.</param>
+    /// <returns><c>true</c> if the shape is inside this shape; otherwise, <c>false</c>.</returns>
+    public bool ContainsShape(IShape shape)
+    {
+        return shape.GetShapeType() switch
+        {
+            ShapeType.Circle => ContainsShape(shape.GetCircleShape()),
+            ShapeType.Segment => ContainsShape(shape.GetSegmentShape()),
+            ShapeType.Triangle => ContainsShape(shape.GetTriangleShape()),
+            ShapeType.Rect => ContainsShape(shape.GetRectShape()),
+            ShapeType.Quad => ContainsShape(shape.GetQuadShape()),
+            ShapeType.Poly => ContainsShape(shape.GetPolygonShape()),
+            ShapeType.PolyLine => ContainsShape(shape.GetPolylineShape()),
+            _ => false
+        };
+    }
 }

--- a/ShapeEngine/Geometry/TriangleDef/TriangleContainsStatic.cs
+++ b/ShapeEngine/Geometry/TriangleDef/TriangleContainsStatic.cs
@@ -236,7 +236,7 @@ public readonly partial struct Triangle
     /// </remarks>
     public static bool ContainsTrianglePolyline(Vector2 tA, Vector2 tB, Vector2 tC, List<Vector2> polyline)
     {
-        return ContainsTrianglePoints(tA, tB, tC, polyline);
+        return polyline.Count >= 2 && ContainsTrianglePoints(tA, tB, tC, polyline);
     }
 
     /// <summary>
@@ -253,6 +253,8 @@ public readonly partial struct Triangle
     /// </remarks>
     public static bool ContainsTrianglePolygon(Vector2 tA, Vector2 tB, Vector2 tC, List<Vector2> polygon)
     {
+        if (polygon == null || polygon.Count < 3)
+            return false;
         return ContainsTrianglePoints(tA, tB, tC, polygon);
     }
 

--- a/ShapeEngine/Geometry/TriangleDef/TriangleIntersectShape.cs
+++ b/ShapeEngine/Geometry/TriangleDef/TriangleIntersectShape.cs
@@ -635,6 +635,30 @@ public readonly partial struct Triangle
 
         return points;
     }
+    
+    /// <summary>
+    /// Computes intersection points between this shape and a shape implementing <see cref="IShape"/>.
+    /// </summary>
+    /// <param name="shape">The shape to test against.</param>
+    /// <returns>
+    /// A <see cref="IntersectionPoints"/> collection of intersection points, or null if none.
+    /// </returns>
+    public IntersectionPoints? IntersectShape(IShape shape)
+    {
+        return shape.GetShapeType() switch
+        {
+            ShapeType.Circle => IntersectShape(shape.GetCircleShape()),
+            ShapeType.Segment => IntersectShape(shape.GetSegmentShape()),
+            ShapeType.Ray => IntersectShape(shape.GetRayShape()),
+            ShapeType.Line => IntersectShape(shape.GetLineShape()),
+            ShapeType.Triangle => IntersectShape(shape.GetTriangleShape()),
+            ShapeType.Rect => IntersectShape(shape.GetRectShape()),
+            ShapeType.Quad => IntersectShape(shape.GetQuadShape()),
+            ShapeType.Poly => IntersectShape(shape.GetPolygonShape()),
+            ShapeType.PolyLine => IntersectShape(shape.GetPolylineShape()),
+            _ => null
+        };
+    }
 
     /// <summary>
     /// Tests for intersection between this triangle and a collider, adding intersection points to an existing collection.
@@ -1321,6 +1345,34 @@ public readonly partial struct Triangle
         }
 
         return count;
+    }
+    
+
+    
+    /// <summary>
+    /// Computes the number of intersection points between this shape and a shape implementing <see cref="IShape"/>.
+    /// </summary>
+    /// <param name="shape">The shape to test against.</param>
+    /// <param name="points">A reference to an <see cref="IntersectionPoints"/> collection to store intersection points.</param>
+    /// <param name="returnAfterFirstValid">
+    /// If true, the method returns after finding the first valid intersection point; otherwise, it finds all intersections.
+    /// </param>
+    /// <returns>The number of valid intersection points found.</returns>
+    public int IntersectShape(IShape shape, ref IntersectionPoints points, bool returnAfterFirstValid = false)
+    {
+        return shape.GetShapeType() switch
+        {
+            ShapeType.Circle => IntersectShape(shape.GetCircleShape(), ref points, returnAfterFirstValid),
+            ShapeType.Segment => IntersectShape(shape.GetSegmentShape(), ref points, returnAfterFirstValid),
+            ShapeType.Ray => IntersectShape(shape.GetRayShape(), ref points, returnAfterFirstValid),
+            ShapeType.Line => IntersectShape(shape.GetLineShape(), ref points, returnAfterFirstValid),
+            ShapeType.Triangle => IntersectShape(shape.GetTriangleShape(), ref points, returnAfterFirstValid),
+            ShapeType.Rect => IntersectShape(shape.GetRectShape(), ref points, returnAfterFirstValid),
+            ShapeType.Quad => IntersectShape(shape.GetQuadShape(), ref points, returnAfterFirstValid),
+            ShapeType.Poly => IntersectShape(shape.GetPolygonShape(), ref points, returnAfterFirstValid),
+            ShapeType.PolyLine => IntersectShape(shape.GetPolylineShape(), ref points, returnAfterFirstValid),
+            _ => 0
+        };
     }
     
 }

--- a/ShapeEngine/Geometry/TriangleDef/TriangleOverlap.cs
+++ b/ShapeEngine/Geometry/TriangleDef/TriangleOverlap.cs
@@ -414,5 +414,28 @@ public readonly partial struct Triangle
 
         return false;
     }
+    
+    /// <summary>
+    /// Determines whether this shape overlaps with the specified <see cref="IShape"/>.
+    /// </summary>
+    /// <param name="shape">The shape to test for overlap with this shape.
+    /// The shape can be any supported type such as circle, segment, ray, line, triangle, rectangle, quad, polygon, or polyline.</param>
+    /// <returns><c>true</c> if this shape overlaps with the specified shape; otherwise, <c>false</c>.</returns>
+    public bool OverlapShape(IShape shape)
+    {
+        return shape.GetShapeType() switch
+        {
+            ShapeType.Circle => OverlapShape(shape.GetCircleShape()),
+            ShapeType.Segment => OverlapShape(shape.GetSegmentShape()),
+            ShapeType.Ray => OverlapShape(shape.GetRayShape()),
+            ShapeType.Line => OverlapShape(shape.GetLineShape()),
+            ShapeType.Triangle => OverlapShape(shape.GetTriangleShape()),
+            ShapeType.Rect => OverlapShape(shape.GetRectShape()),
+            ShapeType.Quad => OverlapShape(shape.GetQuadShape()),
+            ShapeType.Poly => OverlapShape(shape.GetPolygonShape()),
+            ShapeType.PolyLine => OverlapShape(shape.GetPolylineShape()),
+            _ => false
+        };
+    }
 
 }

--- a/ShapeEngine/Geometry/TriangulationDef/TriangulationClosestPoint.cs
+++ b/ShapeEngine/Geometry/TriangulationDef/TriangulationClosestPoint.cs
@@ -619,6 +619,32 @@ public partial class Triangulation
         var segment = triangle.GetSegment(segmentIndex);
         return (segment, closestResult);
     }
+    
+    /// <summary>
+    /// Finds the closest point in the triangulation to the specified shape.
+    /// </summary>
+    /// <param name="shape">The shape to find the closest point to.</param>
+    /// <param name="triangleIndex">The index of the triangle in the triangulation that is closest to the shape.</param>
+    /// <returns>
+    /// A <see cref="ClosestPointResult"/> containing the closest point information for the shape.
+    /// </returns>
+    public ClosestPointResult GetClosestPoint(IShape shape, out int triangleIndex)
+    {
+        triangleIndex = -1;
+        return shape.GetShapeType() switch
+        {
+            ShapeType.Circle => GetClosestPoint(shape.GetCircleShape(), out triangleIndex),
+            ShapeType.Segment => GetClosestPoint(shape.GetSegmentShape(), out triangleIndex),
+            ShapeType.Ray => GetClosestPoint(shape.GetRayShape(), out triangleIndex),
+            ShapeType.Line => GetClosestPoint(shape.GetLineShape(), out triangleIndex),
+            ShapeType.Triangle => GetClosestPoint(shape.GetTriangleShape(), out triangleIndex),
+            ShapeType.Rect => GetClosestPoint(shape.GetRectShape(), out triangleIndex),
+            ShapeType.Quad => GetClosestPoint(shape.GetQuadShape(), out triangleIndex),
+            ShapeType.Poly => GetClosestPoint(shape.GetPolygonShape(), out triangleIndex),
+            ShapeType.PolyLine => GetClosestPoint(shape.GetPolylineShape(), out triangleIndex),
+            _ => new()
+        };
+    }
 
 }
 

--- a/ShapeEngine/Geometry/TriangulationDef/TriangulationContainsPoint.cs
+++ b/ShapeEngine/Geometry/TriangulationDef/TriangulationContainsPoint.cs
@@ -287,4 +287,26 @@ public partial class Triangulation
         return false;
     }
     
+    /// <summary>
+    /// Determines whether the specified shape is contained within any triangle of this triangulation.
+    /// </summary>
+    /// <param name="shape">The shape to check for containment.</param>
+    /// <param name="triangleIndex">The index of the triangle that contains the shape, or -1 if not found.</param>
+    /// <returns>True if the shape is contained in a triangle, false otherwise.</returns>
+    public bool ContainsShape(IShape shape, out int triangleIndex)
+    {
+        triangleIndex = -1;
+        
+        return shape.GetShapeType() switch
+        {
+            ShapeType.Circle => ContainsShape(shape.GetCircleShape(), out triangleIndex),
+            ShapeType.Segment => ContainsShape(shape.GetSegmentShape(), out triangleIndex),
+            ShapeType.Triangle => ContainsShape(shape.GetTriangleShape(), out triangleIndex),
+            ShapeType.Rect => ContainsShape(shape.GetRectShape(), out triangleIndex),
+            ShapeType.Quad => ContainsShape(shape.GetQuadShape(), out triangleIndex),
+            ShapeType.Poly => ContainsShape(shape.GetPolygonShape(), out triangleIndex),
+            ShapeType.PolyLine => ContainsShape(shape.GetPolylineShape(), out triangleIndex),
+            _ => false
+        };
+    }
 }

--- a/ShapeEngine/Geometry/TriangulationDef/TriangulationIntersectShape.cs
+++ b/ShapeEngine/Geometry/TriangulationDef/TriangulationIntersectShape.cs
@@ -230,6 +230,7 @@ public partial class Triangulation
     /// <remarks>Only triangles with valid intersections are included in the result.</remarks>
     public Dictionary<int, IntersectionPoints>? IntersectShape(Polygon shape)
     {
+        if (shape.Count < 3) return null;
         Dictionary<int, IntersectionPoints>? result = null;
         for (int i = 0; i < Count; i++)
         {
@@ -241,7 +242,6 @@ public partial class Triangulation
                 result.Add(i, intersection);
             }
         }
-
         return result;
     }
 
@@ -253,6 +253,7 @@ public partial class Triangulation
     /// <remarks>Only triangles with valid intersections are included in the result.</remarks>
     public Dictionary<int, IntersectionPoints>? IntersectShape(Polyline shape)
     {
+        if (shape.Count < 2) return null;
         Dictionary<int, IntersectionPoints>? result = null;
         for (int i = 0; i < Count; i++)
         {

--- a/ShapeEngine/Geometry/TriangulationDef/TriangulationIntersectShape.cs
+++ b/ShapeEngine/Geometry/TriangulationDef/TriangulationIntersectShape.cs
@@ -291,4 +291,29 @@ public partial class Triangulation
         return result;
     }
 
+    /// <summary>
+    /// Checks for intersections between the triangles in this triangulation and the specified shape implementing <see cref="IShape"/>.
+    /// </summary>
+    /// <param name="shape">The shape to check for intersections.</param>
+    /// <returns>
+    /// A dictionary mapping the index of each intersecting triangle to the resulting <see cref="IntersectionPoints"/>.
+    /// Returns <c>null</c> if no intersections are found or the shape type is not supported.
+    /// </returns>
+    public Dictionary<int, IntersectionPoints>? IntersectShape(IShape shape)
+    {
+        return shape.GetShapeType() switch
+        {
+            ShapeType.Circle => IntersectShape(shape.GetCircleShape()),
+            ShapeType.Segment => IntersectShape(shape.GetSegmentShape()),
+            ShapeType.Ray => IntersectShape(shape.GetRayShape()),
+            ShapeType.Line => IntersectShape(shape.GetLineShape()),
+            ShapeType.Triangle => IntersectShape(shape.GetTriangleShape()),
+            ShapeType.Rect => IntersectShape(shape.GetRectShape()),
+            ShapeType.Quad => IntersectShape(shape.GetQuadShape()),
+            ShapeType.Poly => IntersectShape(shape.GetPolygonShape()),
+            ShapeType.PolyLine => IntersectShape(shape.GetPolylineShape()),
+            _ => null
+        };
+    }
+
 }

--- a/ShapeEngine/Geometry/TriangulationDef/TriangulationOverlap.cs
+++ b/ShapeEngine/Geometry/TriangulationDef/TriangulationOverlap.cs
@@ -431,5 +431,28 @@ public partial class Triangulation
 
         return triangleIndices != null && triangleIndices.Count > 0;
     }
+    
+    /// <summary>
+    /// Determines whether this shape overlaps with the specified <see cref="IShape"/>.
+    /// </summary>
+    /// <param name="shape">The shape to test for overlap with this shape.
+    /// The shape can be any supported type such as circle, segment, ray, line, triangle, rectangle, quad, polygon, or polyline.</param>
+    /// <returns><c>true</c> if this shape overlaps with the specified shape; otherwise, <c>false</c>.</returns>
+    public bool OverlapShape(IShape shape)
+    {
+        return shape.GetShapeType() switch
+        {
+            ShapeType.Circle => OverlapShape(shape.GetCircleShape()),
+            ShapeType.Segment => OverlapShape(shape.GetSegmentShape()),
+            ShapeType.Ray => OverlapShape(shape.GetRayShape()),
+            ShapeType.Line => OverlapShape(shape.GetLineShape()),
+            ShapeType.Triangle => OverlapShape(shape.GetTriangleShape()),
+            ShapeType.Rect => OverlapShape(shape.GetRectShape()),
+            ShapeType.Quad => OverlapShape(shape.GetQuadShape()),
+            ShapeType.Poly => OverlapShape(shape.GetPolygonShape()),
+            ShapeType.PolyLine => OverlapShape(shape.GetPolylineShape()),
+            _ => false
+        };
+    }
 
 }

--- a/ShapeEngine/Geometry/TriangulationDef/TriangulationOverlap.cs
+++ b/ShapeEngine/Geometry/TriangulationDef/TriangulationOverlap.cs
@@ -169,12 +169,12 @@ public partial class Triangulation
     /// <remarks>Returns as soon as an overlapping triangle is found.</remarks>
     public bool OverlapShape(Polygon shape)
     {
+        if (shape.Count < 3) return false;
         for (int i = 0; i < Count; i++)
         {
             var tri = this[i];
             if (tri.OverlapShape(shape)) return true;
         }
-
         return false;
     }
 
@@ -186,6 +186,7 @@ public partial class Triangulation
     /// <remarks>Returns as soon as an overlapping triangle is found.</remarks>
     public bool OverlapShape(Polyline shape)
     {
+        if (shape.Count < 2) return false;
         for (int i = 0; i < Count; i++)
         {
             var tri = this[i];


### PR DESCRIPTION
## Polygon
- Added `AddCompoundShape` methods for adding shapes to the polygon (boolean merge)
- Added `AddCutoutShape` methods for removing shapes from the polygon (cutting out/ boolean difference/intersection)

>This functions change the shape of the polygon permanently.

## General
- Added `IntersectShape, OverlapShape, ContainsShape, and ClosestPoint` functions using `IShape` parameter to `IShape` interface.
- Added `IntersectShape, OverlapShape, ContainsShape, and ClosestPoint` method overloads using an `IShape` parameter to all shapes (line, ray, segment, circle, triangle, quad, rect, polygon, polyline)
- Added `IntersectShape, OverlapShape, ContainsShape, and ClosestPoint` functions using `Shape` parameter to `Shape` class.

## CutoutShape / CompoundShape
Originally, I wanted to add a new `CutoutShape/CompoundShape` classes. The `CutoutShape` would support holes and the `CompoundShape` would allow you to combine many shapes into one. But ultimately I did not find a good way to implement those 2 things without completely changing large portions of the shape system. So I decided agains it. The `CollisionObject` already allows for compound colliders via adding multiple colliders to a collision system and holes are not supported anywhere in the engine anyway.