### PR TITLE
Simple Savegame Slot & Savegame Backup System

### DIFF
--- a/ShapeEngine/Core/GameDef/Game.cs
+++ b/ShapeEngine/Core/GameDef/Game.cs
@@ -61,11 +61,31 @@ public partial class Game
     /// </summary>
     public readonly string ApplicationName;
     
+    //NOTE:
+    // - SaveDirectory -> Local/ApplicationName
+    // - SavegameDirectory -> SaveDirectory/Savegames
+    //  - Slot -> SaveDirectory/Savegames/Slot{number}
+    // - BackupDirectory -> SaveDirectory/Backups
+    //  - Backup 1 -> BackupDirectory/Backup1 -> backup of SavegameDirectory
+    //  - Backup 2 -> BackupDirectory/Backup2 -> backup of SavegameDirectory
+    //  - Backup 3 -> BackupDirectory/Backup2 -> backup of SavegameDirectory
     
-    //TODO: Add savegame slot system
-    // - update backup system to use slots as well
-    // - add max savegame slots to GameSettings
-    // - save, load, GetBackupPath just get a current save slot parameter
+    //!!!
+    // - Only use 1 backup number that increments for each backup created
+    // - Only have 1 function that creates a backup of the entire savegame folder (with all slots, and extra files)
+    // - Have 1 function that can restore a backup by overwriting the entire savegame folder with the backup folder
+    // - save functions do NOT create backups
+    
+    //NOTE:
+    // - Save -> saves single text file with relative path
+    // - SaveToSlot -> saves single text file with relative path to a numbered slot
+    // - Load -> loads single text file with relative path
+    // - LoadFromSlot -> loads single text file with relative path from a numbered slot
+    // - CreateBackup -> creates a backup of the entire savegame folder (with all slots, and extra files) - increments backup number
+    // - ApplyLastBackup -> loads most recent backup file with relative path
+    // - ApplyBackup(int number)
+    
+
     
     /// <summary>
     /// The directory where game data is saved.
@@ -74,29 +94,29 @@ public partial class Game
     /// </summary>
     public readonly DirectoryInfo SaveDirectory;
     /// <summary>
-    /// The directory where backup copies of savegame data are stored.
-    /// Points to a "Backups" subdirectory within <see cref="SaveDirectory"/>.
-    /// Will be empty if the backup directory could not be created, or if no save directory is set, or if <see cref="MaxSavegameBackups"/> is less or equal to zero.
-    /// </summary>
-    public readonly DirectoryInfo SaveBackupDirectory;
-    /// <summary>
     /// Gets the full path of the save directory as a string.
     /// </summary>
     public string SaveDirectoryPath => SaveDirectory.FullName;
-    /// <summary>
-    /// Gets the full path of the save backup directory as a string.
-    /// </summary>
-    public string SaveBackupDirectoryPath => SaveBackupDirectory.FullName;
-    
     /// <summary>
     /// Indicates whether the save directory is valid (exists and has a non-empty path).
     /// </summary>
     public bool IsSaveDirectoryValid => SaveDirectory is { Exists: true, FullName.Length: > 0 };
     
+    
+    /// <summary>
+    /// The directory where backup copies of savegame data are stored.
+    /// Resolves to "<see cref="SaveDirectoryPath"/>/Backups".
+    /// Will be empty if the backup directory could not be created, or if no save directory is set, or if <see cref="MaxSavegameBackups"/> is less or equal to zero.
+    /// </summary>
+    public readonly DirectoryInfo SavegameBackupDirectory;
+    /// <summary>
+    /// Gets the full path of the save backup directory as a string.
+    /// </summary>
+    public string SavegameBackupDirectoryPath => SavegameBackupDirectory.FullName;
     /// <summary>
     /// Indicates whether the save backup directory is valid (exists and has a non-empty path).
     /// </summary>
-    public bool IsSaveBackupDirectoryValid => SaveBackupDirectory is { Exists: true, FullName.Length: > 0 };
+    public bool IsSavegameBackupDirectoryValid => SavegameBackupDirectory is { Exists: true, FullName.Length: > 0 };
 
     /// <summary>
     /// The maximum number of savegame backup files to keep. Is set with <see cref="GameSettings.MaxSavegameBackups"/> in the constructor.
@@ -104,10 +124,23 @@ public partial class Game
     /// </summary>
     public readonly int MaxSavegameBackups;
 
-    public readonly Dictionary<string, int> CurrentSavegameBackupCount = new();
+    public int CurrentSavegameBackup { get; private set; } = 0;
+
+    /// <summary>
+    /// The directory where savegame files are stored.
+    /// This points to "<see cref="SaveDirectoryPath"/>/Savegames".
+    /// </summary>
+    public readonly DirectoryInfo SavegameDirectory;
     
-    public readonly Dictionary<string, string> LastSavegameBackupPath = new();
+    /// <summary>
+    /// Gets the full path of the savegame directory as a string.
+    /// </summary>
+    public string SavegameDirectoryPath => SavegameDirectory.FullName;
     
+    /// <summary>
+    /// Indicates whether the savegame directory is valid (exists and has a non-empty path).
+    /// </summary>
+    public bool IsSavegameDirectoryValid => SavegameDirectory is { Exists: true, FullName.Length: > 0 };
     
     
     
@@ -432,32 +465,44 @@ public partial class Game
                 Logger.LogInfo($"Save directory set to: {SaveDirectoryPath}.");
                 if (MaxSavegameBackups <= 0)
                 {
-                    SaveBackupDirectory = new DirectoryInfo(string.Empty);
-                    Logger.LogInfo("MaxSavegameBackups is set to 0 or less. No save backups will be created. SaveBackupDirectory will be empty.");
+                    Logger.LogInfo("MaxSavegameBackups is set to 0 or less. No save backups will be created.");
                 }
-                else
+                
+                
+                var savegameDirPath = Path.Combine(dir.FullName, "Savegames");
+                var savegameDir = ShapeFileManager.CreateDirectory(savegameDirPath, false);
+                if (savegameDir != null)
                 {
+                    SavegameDirectory = savegameDir;
+                    Logger.LogInfo($"Savegame directory set to: {SavegameDirectory}.");
                     var backupDirPath = Path.Combine(dir.FullName, "Backups");
                     var backupDir = ShapeFileManager.CreateDirectory(backupDirPath, false);
                     if (backupDir != null)
                     {
-                        SaveBackupDirectory = backupDir;
-                        Logger.LogInfo($"Save backup directory set to: {SaveBackupDirectoryPath} with MaxSavegameBackups = {MaxSavegameBackups}.");
+                        SavegameBackupDirectory = backupDir;
+                        Logger.LogInfo($"Savegame backup directory set to: {SavegameBackupDirectoryPath} with MaxSavegameBackups = {MaxSavegameBackups}.");
                     }
                     else
                     {
-                        SaveBackupDirectory = new DirectoryInfo(string.Empty);
+                        SavegameBackupDirectory = new (string.Empty);
                         Logger.LogWarning("Failed to create save backup directory! SaveBackupDirectory will be empty and MaxSavegameBackups will be set to 0.");
                         MaxSavegameBackups = 0;
                     } 
                 }
-                
+                else
+                {
+                    SavegameDirectory = new(string.Empty);
+                    SavegameBackupDirectory = new(string.Empty);
+                    MaxSavegameBackups = 0;
+                    Logger.LogWarning("Failed to create SavegameDirectory. SavegameDirectory and SaveBackupDirectory will be empty and MaxSavegameBackups will be set to 0.");
+                } 
                 
             }
             else
             {
                 SaveDirectory = new(string.Empty);
-                SaveBackupDirectory = new(string.Empty);
+                SavegameDirectory = new(string.Empty);
+                SavegameBackupDirectory = new(string.Empty);
                 Logger = new Logger(LoggerSettings.Default);
                 if (ReleaseMode)
                 {
@@ -468,13 +513,15 @@ public partial class Game
                     Logger.LogInfo("Logger initialized in debug mode. No log file will be created.");
                 }
                 
-                Logger.LogWarning("No save directory set! SaveDirectory will be empty. SaveBackupDirectory will be empty.");
+                Logger.LogWarning("No save directory set! SaveDirectory will be empty. ");
+                Logger.LogWarning("SavegameDirectory and SavegameBackupDirectory will be empty.");
             }
         }
         else
         {
             SaveDirectory = new(string.Empty);
-            SaveBackupDirectory = new(string.Empty);
+            SavegameDirectory = new(string.Empty);
+            SavegameBackupDirectory = new(string.Empty);
             MaxSavegameBackups = 0;
             Logger = new Logger(LoggerSettings.Default);
             if (ReleaseMode)
@@ -485,7 +532,8 @@ public partial class Game
             {
                 Logger.LogInfo("Logger initialized in debug mode. No log file will be created.");
             }
-            Logger.LogWarning("No save directory set! SaveDirectory will be empty. SaveBackupDirectory will be empty and MaxSavegameBackups will be set to 0.");
+            Logger.LogWarning("No save directory set! SaveDirectory will be empty.");
+            Logger.LogWarning("SavegameDirectory and SavegameBackupDirectory will be empty and MaxSavegameBackups will be set to 0.");
         }
         
         // this.DevelopmentDimensions = gameSettings.DevelopmentDimensions;
@@ -921,75 +969,89 @@ public partial class Game
     }
     #endregion
     
-    #region Savegame Backup System
+    #region Savegame System
     
     public bool Save(string relativeFilePath, string content)
     {
         if (SaveDirectoryPath == string.Empty) return false;
-        if (relativeFilePath == string.Empty) return false;
+        if (!Path.HasExtension(relativeFilePath)) return false;
         
         string path = Path.Combine(SaveDirectoryPath, relativeFilePath);
-        if (!ShapeFileManager.SaveText(content, path)) return false;
-        if (SaveBackupDirectoryPath == string.Empty || MaxSavegameBackups <= 0) return true;
-        var fileName = Path.GetFileName(relativeFilePath);
-        if (GetNextSavegameBackupPath(fileName, out string backupPath))
-        {
-            ShapeFileManager.SaveText(content, backupPath);
-        }
-        return true;
+        return ShapeFileManager.SaveText(content, path);
     }
-    
     public bool Load(string relativeFilePath, out string content)
     {
         content = string.Empty;
         
         if (SaveDirectoryPath == string.Empty) return false;
-        if (relativeFilePath == string.Empty) return false;
+        if (!Path.HasExtension(relativeFilePath)) return false;
         
         string path = Path.Combine(SaveDirectoryPath, relativeFilePath);
         content = ShapeFileManager.LoadText(path);
         
         return true;
     }
-    public bool LoadLastBackup(string fileName, out string content)
+    public bool SaveToSlot(string relativeFilePath, string content, int slotNumber)
     {
+        string slotPath = GetSlotPath(relativeFilePath, slotNumber);
+        return slotPath != string.Empty && Save(slotPath, content);
+    }
+    public bool LoadFromSlot(string relativeFilePath, int slotNumber, out string content)
+    {
+        string slotPath = GetSlotPath(relativeFilePath, slotNumber);
         content = string.Empty;
-        if (!LastSavegameBackupPath.TryGetValue(fileName, out string? path)) return false;
-        content = ShapeFileManager.LoadText(path);
-        return true;
+        return slotPath != string.Empty && Load(slotPath, out content);
+    }
+    public string GetSlotPath(int slotNumber)
+    {
+        return !IsSavegameDirectoryValid ? string.Empty : Path.Combine(SavegameDirectoryPath, $"Slot-{slotNumber:D2}");
+    }
+    public string GetSlotPath(string relativeFilePath, int slotNumber)
+    {
+        if(relativeFilePath == string.Empty || !Path.HasExtension(relativeFilePath) || !IsSavegameDirectoryValid) return string.Empty;
+        string slotDir = Path.Combine(SavegameDirectoryPath, $"Slot-{slotNumber:D2}");
+        return Path.Combine(slotDir, relativeFilePath);
+    }
+    #endregion
+    
+    #region Savegame Backup System
+    
+    public bool CreateBackup()
+    {
+        
+    }
 
+    public bool CreateBackup(int slotNumber)
+    {
+        
+    }
+
+    public bool ApplyLastBackup()
+    {
+        
+    }
+
+    public bool ApplyBackup(int backupNumber)
+    {
+        
     }
     
-    public bool GetNextSavegameBackupPath(string fileName, out string backupFilePath)
+    public string GetBackupPath(int backupNumber)
     {
-        backupFilePath = string.Empty;
-        if (MaxSavegameBackups <= 0) return false;
-        if (SaveBackupDirectory.FullName.Length == 0) return false;
-        if (!Path.HasExtension(fileName)) return false;
-        
-        string extension = Path.GetExtension(fileName);
-        string nameWithoutExt = Path.GetFileNameWithoutExtension(fileName);
-
-        int currentSavegameBackupCount = 0;
-        if (CurrentSavegameBackupCount.TryGetValue(fileName, out int value))
-        {
-            currentSavegameBackupCount = value;
-            
-        }
-        else
-        {
-            CurrentSavegameBackupCount.Add(fileName, 0);
-        }
-        
-        var backupFileName = $"{nameWithoutExt}-backup{currentSavegameBackupCount}{extension}";
-        backupFilePath = Path.Combine(SaveBackupDirectory.FullName, backupFileName);
-
-        LastSavegameBackupPath[fileName] = backupFilePath;
-        
-        currentSavegameBackupCount++;
-        if (currentSavegameBackupCount >= MaxSavegameBackups) currentSavegameBackupCount = 0;
-        CurrentSavegameBackupCount[fileName] = currentSavegameBackupCount;
-        return true;
+        return !IsSavegameBackupDirectoryValid ? string.Empty : Path.Combine(SavegameBackupDirectoryPath, $"Backup-{backupNumber:D2}");
+    }
+    
+    public int IncrementBackupNumber()
+    {
+        CurrentSavegameBackup++;
+        if (CurrentSavegameBackup >= MaxSavegameBackups) CurrentSavegameBackup = 0;
+        return CurrentSavegameBackup;
+    }
+    public int GetPreviousBackupNumber()
+    {
+        var prev = CurrentSavegameBackup--;
+        if(prev < 0) prev = MaxSavegameBackups - 1;
+        return prev;
     }
     
     #endregion

--- a/ShapeEngine/Core/GameDef/Game.cs
+++ b/ShapeEngine/Core/GameDef/Game.cs
@@ -123,9 +123,18 @@ public partial class Game
     /// If set to 0 or less, no backups will be created.
     /// </summary>
     public readonly int MaxSavegameBackups;
-
-    public int CurrentSavegameBackup { get; private set; } = 0;
-    public int CreatedSavegameBackups { get; private set; } = 0;
+    /// <summary>
+    /// Gets the current backup number for savegame backups.
+    /// This value is incremented each time a new backup is created with <see cref="CreateBackup()"/> and wraps around based on <see cref="MaxSavegameBackups"/>.
+    /// If <see cref="MaxSavegameBackups"/> is 0 or less, this value will always be 0 and no backups will be created.
+    /// </summary>
+    public int CurrentSavegameBackup { get; private set; }
+    
+    /// <summary>
+    /// Gets the total number of savegame backups that have been created so far.
+    /// This value is incremented each time a new backup is created, up to the maximum allowed by <see cref="MaxSavegameBackups"/>.
+    /// </summary>
+    public int CreatedSavegameBackups { get; private set; }
     /// <summary>
     /// The directory where savegame files are stored.
     /// This points to "<see cref="SaveDirectoryPath"/>/Savegames".
@@ -439,6 +448,8 @@ public partial class Game
 
         ApplicationName = gameSettings.ApplicationName;
         MaxSavegameBackups = gameSettings.MaxSavegameBackups;
+        CurrentSavegameBackup = 0;
+        CreatedSavegameBackups = 0;
         if (gameSettings.SaveDirectory != null && ApplicationName.Length > 0)
         {
             var folderPath = Environment.GetFolderPath((Environment.SpecialFolder)gameSettings.SaveDirectory);
@@ -480,6 +491,16 @@ public partial class Game
                     if (backupDir != null)
                     {
                         SavegameBackupDirectory = backupDir;
+                        if (LoadBackupInformation(out int currentBackup, out int createdBackups))
+                        {
+                            CurrentSavegameBackup = currentBackup;
+                            CreatedSavegameBackups = createdBackups;
+                            Logger.LogInfo($"Loaded savegame backup information. CurrentSavegameBackup = {CurrentSavegameBackup}, CreatedSavegameBackups = {CreatedSavegameBackups}.");
+                        }
+                        else
+                        {
+                            Logger.LogInfo($"No existing savegame backup information found. Starting with CurrentSavegameBackup = {CurrentSavegameBackup}, CreatedSavegameBackups = {CreatedSavegameBackups}. " );
+                        }
                         Logger.LogInfo($"Savegame backup directory set to: {SavegameBackupDirectoryPath} with MaxSavegameBackups = {MaxSavegameBackups}.");
                     }
                     else

--- a/ShapeEngine/Core/GameDef/GameSavegameSystem.cs
+++ b/ShapeEngine/Core/GameDef/GameSavegameSystem.cs
@@ -1,0 +1,278 @@
+using ShapeEngine.Core.Structs;
+using ShapeEngine.StaticLib;
+
+namespace ShapeEngine.Core.GameDef;
+
+
+
+public partial class Game
+{
+    #region Public Members
+
+    /// <summary>
+    /// The directory where game data is saved.
+    /// Points to <see cref="GameSettings.SaveDirectory"/>/<see cref="GameSettings.ApplicationName"/>.
+    /// Will be empty if no save directory is set in <see cref="GameSettings"/>.
+    /// </summary>
+    public readonly DirectoryInfo SaveDirectory;
+
+    /// <summary>
+    /// Gets the full path of the save directory as a string.
+    /// </summary>
+    public string SaveDirectoryPath => SaveDirectory.FullName;
+
+    /// <summary>
+    /// Indicates whether the save directory is valid (exists and has a non-empty path).
+    /// </summary>
+    public bool IsSaveDirectoryValid => SaveDirectory is { Exists: true, FullName.Length: > 0 };
+
+    /// <summary>
+    /// The directory where backup copies of savegame data are stored.
+    /// Resolves to "<see cref="SaveDirectoryPath"/>/Backups".
+    /// Will be empty if the backup directory could not be created.
+    /// </summary>
+    public readonly DirectoryInfo SavegameBackupDirectory;
+
+    /// <summary>
+    /// Gets the full path of the save backup directory as a string.
+    /// </summary>
+    public string SavegameBackupDirectoryPath => SavegameBackupDirectory.FullName;
+
+    /// <summary>
+    /// Indicates whether the save backup directory is valid (exists and has a non-empty path).
+    /// </summary>
+    public bool IsSavegameBackupDirectoryValid => SavegameBackupDirectory is { Exists: true, FullName.Length: > 0 };
+
+    /// <summary>
+    /// The directory where savegame files are stored.
+    /// This points to "<see cref="SaveDirectoryPath"/>/Savegames".
+    /// </summary>
+    public readonly DirectoryInfo SavegameDirectory;
+
+    /// <summary>
+    /// Gets the full path of the savegame directory as a string.
+    /// </summary>
+    public string SavegameDirectoryPath => SavegameDirectory.FullName;
+
+    /// <summary>
+    /// Indicates whether the savegame directory is valid (exists and has a non-empty path).
+    /// </summary>
+    public bool IsSavegameDirectoryValid => SavegameDirectory is { Exists: true, FullName.Length: > 0 };
+
+    #endregion
+
+    #region Savegame System
+
+    public bool SaveSavegameSlotInformation(int currentActiveSlot, int usedSlots, int maxSlots)
+    {
+        if (!IsSavegameDirectoryValid) return false;
+        if (currentActiveSlot < 0 || usedSlots < 0) return false;
+
+        string path = Path.Combine(SavegameDirectoryPath, "CurrentSavegameSlot.txt");
+        var content = $"{currentActiveSlot},{usedSlots},{maxSlots}";
+        return ShapeFileManager.SaveText(content, path);
+    }
+
+    public bool LoadSavegameSlotInformation(out int activeSlot, out int usedSlots, out int maxSlots)
+    {
+        activeSlot = -1;
+        usedSlots = -1;
+        maxSlots = -1;
+        if (!IsSavegameDirectoryValid) return false;
+
+        string path = Path.Combine(SavegameDirectoryPath, "CurrentSavegameSlot.txt");
+        string content = ShapeFileManager.LoadText(path);
+        if (content.Length == 0) return false;
+
+        var parts = content.Split(',');
+        if (parts.Length != 3) return false;
+
+        if (int.TryParse(parts[0], out activeSlot) && int.TryParse(parts[1], out usedSlots) && int.TryParse(parts[2], out maxSlots))
+        {
+            if (activeSlot >= 0 && usedSlots >= 0 && maxSlots >= 0) return true;
+        }
+
+        activeSlot = -1;
+        usedSlots = -1;
+        maxSlots = -1;
+        return false;
+    }
+
+    public bool Save(string relativeFilePath, string content)
+    {
+        if (SaveDirectoryPath == string.Empty) return false;
+        if (!Path.HasExtension(relativeFilePath)) return false;
+
+        string path = Path.Combine(SaveDirectoryPath, relativeFilePath);
+        return ShapeFileManager.SaveText(content, path);
+    }
+
+    public bool Load(string relativeFilePath, out string content)
+    {
+        content = string.Empty;
+
+        if (SaveDirectoryPath == string.Empty) return false;
+        if (!Path.HasExtension(relativeFilePath)) return false;
+
+        string path = Path.Combine(SaveDirectoryPath, relativeFilePath);
+        content = ShapeFileManager.LoadText(path);
+
+        return true;
+    }
+
+    public bool SaveToSlot(string relativeFilePath, string content, int slotNumber)
+    {
+        string slotPath = GetSlotPath(relativeFilePath, slotNumber);
+        return slotPath != string.Empty && Save(slotPath, content);
+    }
+
+    public bool LoadFromSlot(string relativeFilePath, int slotNumber, out string content)
+    {
+        string slotPath = GetSlotPath(relativeFilePath, slotNumber);
+        content = string.Empty;
+        return slotPath != string.Empty && Load(slotPath, out content);
+    }
+
+    public string GetSlotPath(int slotNumber)
+    {
+        return !IsSavegameDirectoryValid ? string.Empty : Path.Combine(SavegameDirectoryPath, $"Slot-{slotNumber:D2}");
+    }
+
+    public string GetSlotPath(string relativeFilePath, int slotNumber)
+    {
+        if (relativeFilePath == string.Empty || !Path.HasExtension(relativeFilePath) || !IsSavegameDirectoryValid) return string.Empty;
+        string slotDir = Path.Combine(SavegameDirectoryPath, $"Slot-{slotNumber:D2}");
+        return Path.Combine(slotDir, relativeFilePath);
+    }
+
+    #endregion
+
+    #region Savegame Backup System
+
+    public bool SaveBackupInformation(int currentBackupNumber, int createdBackups, int maxBackups)
+    {
+        if (!IsSavegameBackupDirectoryValid) return false;
+        string backupInfoPath = Path.Combine(SavegameBackupDirectoryPath, "BackupInfo.txt");
+        var content = $"{currentBackupNumber},{createdBackups},{maxBackups}";
+        return ShapeFileManager.SaveText(content, backupInfoPath);
+    }
+
+    public bool LoadBackupInformation(out int currentBackupNumber, out int createdBackups, out int maxBackups)
+    {
+        currentBackupNumber = -1;
+        createdBackups = -1;
+        maxBackups = -1;
+        if (!IsSavegameBackupDirectoryValid) return false;
+
+        string backupInfoPath = Path.Combine(SavegameBackupDirectoryPath, "BackupInfo.txt");
+        string content = ShapeFileManager.LoadText(backupInfoPath);
+        if (string.IsNullOrEmpty(content)) return false;
+
+        var parts = content.Split(',');
+        if (parts.Length != 2) return false;
+
+        if (int.TryParse(parts[0], out currentBackupNumber) && int.TryParse(parts[1], out createdBackups) && int.TryParse(parts[2], out maxBackups))
+        {
+            if (currentBackupNumber >= 0 && createdBackups >= 0) return true;
+        }
+
+        currentBackupNumber = -1;
+        createdBackups = -1;
+        maxBackups = -1;
+        return false;
+    }
+
+    public (bool success, int newBackupNumber, int createdBackups) CreateBackup(int currentBackupNumber, int createdBackups, int maxBackups)
+    {
+        if (!IsSavegameDirectoryValid || !IsSavegameBackupDirectoryValid) return (false, currentBackupNumber, createdBackups);
+        var nextBackup = currentBackupNumber;
+        if (maxBackups <= 0)
+        {
+            nextBackup++;
+        }
+        else nextBackup = IncrementBackup(nextBackup, maxBackups);
+
+        string sourcePath = SavegameDirectoryPath;
+        string destinationPath = GetBackupPath(nextBackup);
+
+        try
+        {
+            bool success = ShapeFileManager.CopyDirectory(sourcePath, destinationPath, true);
+            return success ? (true, nextBackup, createdBackups + 1) : (false, currentBackupNumber, createdBackups);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError($"Failed to create backup{currentBackupNumber}: {ex.Message}");
+            return (false, currentBackupNumber, createdBackups);
+        }
+    }
+
+    public bool CreateBackup(int backupNumber)
+    {
+        if (!IsSavegameDirectoryValid || !IsSavegameBackupDirectoryValid) return false;
+
+        string sourcePath = SavegameDirectoryPath;
+        string destinationPath = GetBackupPath(backupNumber);
+
+        try
+        {
+            return ShapeFileManager.CopyDirectory(sourcePath, destinationPath, true);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError($"Failed to create backup{backupNumber}: {ex.Message}");
+            return false;
+        }
+    }
+
+    public bool ApplyBackup(int currentBackupNumber, int createdBackups, int maxBackups)
+    {
+        if (currentBackupNumber < 0 || createdBackups <= 0) return false;
+        if (maxBackups <= 0)
+        {
+            return currentBackupNumber == 0 ? ApplyBackup(0) : ApplyBackup(currentBackupNumber - 1);
+        }
+
+        int prevBackup = GetPreviousBackup(currentBackupNumber, maxBackups);
+        return ApplyBackup(prevBackup);
+    }
+
+    public bool ApplyBackup(int backupNumber)
+    {
+        if (!IsSavegameDirectoryValid || !IsSavegameBackupDirectoryValid) return false;
+
+        string sourcePath = GetBackupPath(backupNumber);
+        string destinationPath = SavegameDirectoryPath;
+
+        try
+        {
+            return ShapeFileManager.CopyDirectory(sourcePath, destinationPath, true);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError($"Failed to apply backup: {ex.Message}");
+            return false;
+        }
+    }
+
+    public string GetBackupPath(int backupNumber)
+    {
+        return !IsSavegameBackupDirectoryValid ? string.Empty : Path.Combine(SavegameBackupDirectoryPath, $"Backup-{backupNumber:D2}");
+    }
+
+    public int IncrementBackup(int currentBackup, int maxBackups)
+    {
+        var cur = currentBackup + 1;
+        if (cur >= maxBackups) cur = 0;
+        return cur;
+    }
+
+    public int GetPreviousBackup(int currentBackup, int maxBackups)
+    {
+        var prev = currentBackup - 1;
+        if (prev < 0) prev = maxBackups - 1;
+        return prev;
+    }
+
+    #endregion
+}

--- a/ShapeEngine/Core/Structs/GameSettings.cs
+++ b/ShapeEngine/Core/Structs/GameSettings.cs
@@ -1,5 +1,4 @@
 using Raylib_cs;
-using ShapeEngine.Core.Logging;
 using ShapeEngine.Screen;
 
 namespace ShapeEngine.Core.Structs;
@@ -17,14 +16,11 @@ public readonly struct GameSettings
     /// <param name="applicationName">The name of the application. Will also be used for savegame folder name.</param>
     /// <param name="saveDirectory">The directory for saving game data. If set to null, no directory will be created.
     /// Savegame location: saveDirectory/applicationName.</param>
-    /// <param name="maxSavegameBackups">The maximum number of savegame backup files to keep.
-    /// If set to 0 or less, no backups will be created.
-    /// Savegame Backup location: saveDirectory/applicationName/Backups.</param>
     public static GameSettings StretchMode(string applicationName = "ShapeEngineGame", 
-        Environment.SpecialFolder? saveDirectory = Environment.SpecialFolder.LocalApplicationData, int maxSavegameBackups = 3)
+        Environment.SpecialFolder? saveDirectory = Environment.SpecialFolder.LocalApplicationData)
     {
         return new GameSettings(-1, TextureFilter.Bilinear, ShaderSupportType.Multi, 
-            applicationName, saveDirectory, maxSavegameBackups);
+            applicationName, saveDirectory);
     }
 
     /// <summary>
@@ -33,14 +29,11 @@ public readonly struct GameSettings
     /// <param name="applicationName">The name of the application. Will also be used for savegame folder name.</param>
     /// <param name="saveDirectory">The directory for saving game data. If set to null, no directory will be created.
     /// Savegame location: saveDirectory/applicationName.</param>
-    /// <param name="maxSavegameBackups">The maximum number of savegame backup files to keep.
-    /// If set to 0 or less, no backups will be created.
-    /// Savegame Backup location: saveDirectory/applicationName/Backups.</param>
     public static GameSettings FixedMode(string applicationName = "ShapeEngineGame", 
-        Environment.SpecialFolder? saveDirectory = Environment.SpecialFolder.LocalApplicationData, int maxSavegameBackups = 3)
+        Environment.SpecialFolder? saveDirectory = Environment.SpecialFolder.LocalApplicationData)
     {
         return new GameSettings(new Dimensions(320, 180), -1, TextureFilter.Point, ShaderSupportType.Multi, false, 
-            applicationName, saveDirectory, maxSavegameBackups);
+            applicationName, saveDirectory);
     }
 
     /// <summary>
@@ -49,14 +42,12 @@ public readonly struct GameSettings
     /// <param name="applicationName">The name of the application. Will also be used for savegame folder name.</param>
     /// <param name="saveDirectory">The directory for saving game data. If set to null, no directory will be created.
     /// Savegame location: saveDirectory/applicationName.</param>
-    /// <param name="maxSavegameBackups">The maximum number of savegame backup files to keep.
-    /// If set to 0 or less, no backups will be created.
-    /// Savegame Backup location: saveDirectory/applicationName/Backups.</param>
+
     public static GameSettings FixedNearestMode(string applicationName = "ShapeEngineGame", 
-        Environment.SpecialFolder? saveDirectory = Environment.SpecialFolder.LocalApplicationData, int maxSavegameBackups = 3)
+        Environment.SpecialFolder? saveDirectory = Environment.SpecialFolder.LocalApplicationData)
     {
         return new GameSettings(new Dimensions(320, 180), -1, TextureFilter.Point, ShaderSupportType.Multi, true, 
-            applicationName, saveDirectory, maxSavegameBackups);
+            applicationName, saveDirectory);
     }
 
     /// <summary>
@@ -65,14 +56,11 @@ public readonly struct GameSettings
     /// <param name="applicationName">The name of the application. Will also be used for savegame folder name.</param>
     /// <param name="saveDirectory">The directory for saving game data. If set to null, no directory will be created.
     /// Savegame location: saveDirectory/applicationName.</param>
-    /// <param name="maxSavegameBackups">The maximum number of savegame backup files to keep.
-    /// If set to 0 or less, no backups will be created.
-    /// Savegame Backup location: saveDirectory/applicationName/Backups.</param>
     public static GameSettings PixelationMode(string applicationName = "ShapeEngineGame", 
-        Environment.SpecialFolder? saveDirectory = Environment.SpecialFolder.LocalApplicationData, int maxSavegameBackups = 3)
+        Environment.SpecialFolder? saveDirectory = Environment.SpecialFolder.LocalApplicationData)
     {
         return new GameSettings(0.25f, -1, TextureFilter.Point, ShaderSupportType.Multi, 
-            applicationName, saveDirectory, maxSavegameBackups);
+            applicationName, saveDirectory);
     }
 
     #endregion
@@ -88,11 +76,8 @@ public readonly struct GameSettings
     /// <param name="applicationName">The name of the application. Will also be used for savegame folder name.</param>
     /// <param name="saveDirectory">The directory for saving game data. If set to null, no directory will be created.
     /// Savegame location: saveDirectory/applicationName.</param>
-    /// <param name="maxSavegameBackups">The maximum number of savegame backup files to keep.
-    /// If set to 0 or less, no backups will be created.
-    /// Savegame Backup location: saveDirectory/applicationName/Backups.</param>
     public GameSettings (int fixedFramerate, TextureFilter textureFilter, ShaderSupportType shaderSupportType, 
-        string applicationName = "ShapeEngineGame", Environment.SpecialFolder? saveDirectory = Environment.SpecialFolder.LocalApplicationData, int maxSavegameBackups = 3)
+        string applicationName = "ShapeEngineGame", Environment.SpecialFolder? saveDirectory = Environment.SpecialFolder.LocalApplicationData)
     {
         FixedFramerate = fixedFramerate;
         TextureFilter = textureFilter;
@@ -102,8 +87,6 @@ public readonly struct GameSettings
         ScreenTextureMode = ScreenTextureMode.Stretch;
         ApplicationName = applicationName;
         SaveDirectory = saveDirectory;
-        MaxSavegameBackups = maxSavegameBackups;
-        if (MaxSavegameBackups <= 0) MaxSavegameBackups = 0;
     }
 
     /// <summary>
@@ -117,11 +100,8 @@ public readonly struct GameSettings
     /// <param name="applicationName">The name of the application. Will also be used for savegame folder name.</param>
     /// <param name="saveDirectory">The directory for saving game data. If set to null, no directory will be created.
     /// Savegame location: saveDirectory/applicationName.</param>
-    /// <param name="maxSavegameBackups">The maximum number of savegame backup files to keep.
-    /// If set to 0 or less, no backups will be created.
-    /// Savegame Backup location: saveDirectory/applicationName/Backups.</param>
     public GameSettings(Dimensions fixedDimensions, int fixedFramerate, TextureFilter textureFilter, ShaderSupportType shaderSupportType, 
-        bool nearestScaling = false, string applicationName = "ShapeEngineGame", Environment.SpecialFolder? saveDirectory = Environment.SpecialFolder.LocalApplicationData, int maxSavegameBackups = 3)
+        bool nearestScaling = false, string applicationName = "ShapeEngineGame", Environment.SpecialFolder? saveDirectory = Environment.SpecialFolder.LocalApplicationData)
     {
         FixedFramerate = fixedFramerate;
         TextureFilter = textureFilter;
@@ -148,8 +128,6 @@ public readonly struct GameSettings
         }
         ApplicationName = applicationName;
         SaveDirectory = saveDirectory;
-        MaxSavegameBackups = maxSavegameBackups;
-        if (MaxSavegameBackups <= 0) MaxSavegameBackups = 0;
     }
 
     /// <summary>
@@ -162,11 +140,8 @@ public readonly struct GameSettings
     /// <param name="applicationName">The name of the application. Will also be used for savegame folder name.</param>
     /// <param name="saveDirectory">The directory for saving game data. If set to null, no directory will be created.
     /// Savegame location: saveDirectory/applicationName.</param>
-    /// <param name="maxSavegameBackups">The maximum number of savegame backup files to keep.
-    /// If set to 0 or less, no backups will be created.
-    /// Savegame Backup location: saveDirectory/applicationName/Backups.</param>
     public GameSettings(float pixelationFactor, int fixedFramerate, TextureFilter textureFilter, ShaderSupportType shaderSupportType, 
-        string applicationName = "ShapeEngineGame", Environment.SpecialFolder? saveDirectory = Environment.SpecialFolder.LocalApplicationData, int maxSavegameBackups = 3)
+        string applicationName = "ShapeEngineGame", Environment.SpecialFolder? saveDirectory = Environment.SpecialFolder.LocalApplicationData)
     {
         FixedFramerate = fixedFramerate;
         TextureFilter = textureFilter;
@@ -185,8 +160,6 @@ public readonly struct GameSettings
         }
         ApplicationName = applicationName;
         SaveDirectory = saveDirectory;
-        MaxSavegameBackups = maxSavegameBackups;
-        if (MaxSavegameBackups <= 0) MaxSavegameBackups = 0;
     }
     
     #endregion
@@ -249,13 +222,13 @@ public readonly struct GameSettings
     /// </remarks>
     public readonly Environment.SpecialFolder? SaveDirectory = Environment.SpecialFolder.LocalApplicationData;
 
-    /// <summary>
-    /// Gets the maximum number of savegame backup files to keep.
-    /// </summary>
-    /// <remarks>
-    /// If set to 0 or less, no backups will be created and no backup directory will be created.
-    /// </remarks>
-    public readonly int MaxSavegameBackups = 3;
+    // /// <summary>
+    // /// Gets the maximum number of savegame backup files to keep.
+    // /// </summary>
+    // /// <remarks>
+    // /// If set to 0 or less, no backups will be created and no backup directory will be created.
+    // /// </remarks>
+    // public readonly int MaxSavegameBackups = 3;
 
     #endregion
 }

--- a/ShapeEngine/Core/Structs/GameSettings.cs
+++ b/ShapeEngine/Core/Structs/GameSettings.cs
@@ -15,52 +15,64 @@ public readonly struct GameSettings
     /// Creates a new GameSettings instance with stretch mode.
     /// </summary>
     /// <param name="applicationName">The name of the application. Will also be used for savegame folder name.</param>
-    /// <param name="saveGameDirectory">The directory for saving game data.
-    /// If set to null, no directory will be created.
-    /// Savegame location: saveGameDirectory/applicationName</param>
+    /// <param name="saveDirectory">The directory for saving game data. If set to null, no directory will be created.
+    /// Savegame location: saveDirectory/applicationName.</param>
+    /// <param name="maxSavegameBackups">The maximum number of savegame backup files to keep.
+    /// If set to 0 or less, no backups will be created.
+    /// Savegame Backup location: saveDirectory/applicationName/Backups.</param>
     public static GameSettings StretchMode(string applicationName = "ShapeEngineGame", 
-        Environment.SpecialFolder? saveGameDirectory = Environment.SpecialFolder.LocalApplicationData)
+        Environment.SpecialFolder? saveDirectory = Environment.SpecialFolder.LocalApplicationData, int maxSavegameBackups = 3)
     {
-        return new GameSettings(-1, TextureFilter.Bilinear, ShaderSupportType.Multi, applicationName, saveGameDirectory);
+        return new GameSettings(-1, TextureFilter.Bilinear, ShaderSupportType.Multi, 
+            applicationName, saveDirectory, maxSavegameBackups);
     }
 
     /// <summary>
     /// Creates a new GameSettings instance with fixed dimensions and the nearest scaling disabled.
     /// </summary>
     /// <param name="applicationName">The name of the application. Will also be used for savegame folder name.</param>
-    /// <param name="saveGameDirectory">The directory for saving game data.
-    /// If set to null, no directory will be created.
-    /// Savegame location: saveGameDirectory/applicationName</param>
+    /// <param name="saveDirectory">The directory for saving game data. If set to null, no directory will be created.
+    /// Savegame location: saveDirectory/applicationName.</param>
+    /// <param name="maxSavegameBackups">The maximum number of savegame backup files to keep.
+    /// If set to 0 or less, no backups will be created.
+    /// Savegame Backup location: saveDirectory/applicationName/Backups.</param>
     public static GameSettings FixedMode(string applicationName = "ShapeEngineGame", 
-        Environment.SpecialFolder? saveGameDirectory = Environment.SpecialFolder.LocalApplicationData)
+        Environment.SpecialFolder? saveDirectory = Environment.SpecialFolder.LocalApplicationData, int maxSavegameBackups = 3)
     {
-        return new GameSettings(new Dimensions(320, 180), -1, TextureFilter.Point, ShaderSupportType.Multi, false, applicationName, saveGameDirectory);
+        return new GameSettings(new Dimensions(320, 180), -1, TextureFilter.Point, ShaderSupportType.Multi, false, 
+            applicationName, saveDirectory, maxSavegameBackups);
     }
 
     /// <summary>
     /// Creates a new GameSettings instance with fixed dimensions and the nearest scaling enabled.
     /// </summary>
     /// <param name="applicationName">The name of the application. Will also be used for savegame folder name.</param>
-    /// <param name="saveGameDirectory">The directory for saving game data.
-    /// If set to null, no directory will be created.
-    /// Savegame location: saveGameDirectory/applicationName</param>
+    /// <param name="saveDirectory">The directory for saving game data. If set to null, no directory will be created.
+    /// Savegame location: saveDirectory/applicationName.</param>
+    /// <param name="maxSavegameBackups">The maximum number of savegame backup files to keep.
+    /// If set to 0 or less, no backups will be created.
+    /// Savegame Backup location: saveDirectory/applicationName/Backups.</param>
     public static GameSettings FixedNearestMode(string applicationName = "ShapeEngineGame", 
-        Environment.SpecialFolder? saveGameDirectory = Environment.SpecialFolder.LocalApplicationData)
+        Environment.SpecialFolder? saveDirectory = Environment.SpecialFolder.LocalApplicationData, int maxSavegameBackups = 3)
     {
-        return new GameSettings(new Dimensions(320, 180), -1, TextureFilter.Point, ShaderSupportType.Multi, true, applicationName, saveGameDirectory);
+        return new GameSettings(new Dimensions(320, 180), -1, TextureFilter.Point, ShaderSupportType.Multi, true, 
+            applicationName, saveDirectory, maxSavegameBackups);
     }
 
     /// <summary>
     /// Creates a new GameSettings instance with pixelation mode.
     /// </summary>
     /// <param name="applicationName">The name of the application. Will also be used for savegame folder name.</param>
-    /// <param name="saveGameDirectory">The directory for saving game data.
-    /// If set to null, no directory will be created.
-    /// Savegame location: saveGameDirectory/applicationName</param>
+    /// <param name="saveDirectory">The directory for saving game data. If set to null, no directory will be created.
+    /// Savegame location: saveDirectory/applicationName.</param>
+    /// <param name="maxSavegameBackups">The maximum number of savegame backup files to keep.
+    /// If set to 0 or less, no backups will be created.
+    /// Savegame Backup location: saveDirectory/applicationName/Backups.</param>
     public static GameSettings PixelationMode(string applicationName = "ShapeEngineGame", 
-        Environment.SpecialFolder? saveGameDirectory = Environment.SpecialFolder.LocalApplicationData)
+        Environment.SpecialFolder? saveDirectory = Environment.SpecialFolder.LocalApplicationData, int maxSavegameBackups = 3)
     {
-        return new GameSettings(0.25f, -1, TextureFilter.Point, ShaderSupportType.Multi, applicationName, saveGameDirectory);
+        return new GameSettings(0.25f, -1, TextureFilter.Point, ShaderSupportType.Multi, 
+            applicationName, saveDirectory, maxSavegameBackups);
     }
 
     #endregion
@@ -74,9 +86,13 @@ public readonly struct GameSettings
     /// <param name="textureFilter">The texture filter to be used.</param>
     /// <param name="shaderSupportType">The shader support type.</param>
     /// <param name="applicationName">The name of the application. Will also be used for savegame folder name.</param>
-    /// <param name="saveDirectory">The directory for saving game data. If set to null, no directory will be created. Savegame location: saveGameDirectory/applicationName</param>
+    /// <param name="saveDirectory">The directory for saving game data. If set to null, no directory will be created.
+    /// Savegame location: saveDirectory/applicationName.</param>
+    /// <param name="maxSavegameBackups">The maximum number of savegame backup files to keep.
+    /// If set to 0 or less, no backups will be created.
+    /// Savegame Backup location: saveDirectory/applicationName/Backups.</param>
     public GameSettings (int fixedFramerate, TextureFilter textureFilter, ShaderSupportType shaderSupportType, 
-        string applicationName = "ShapeEngineGame", Environment.SpecialFolder? saveDirectory = Environment.SpecialFolder.LocalApplicationData)
+        string applicationName = "ShapeEngineGame", Environment.SpecialFolder? saveDirectory = Environment.SpecialFolder.LocalApplicationData, int maxSavegameBackups = 3)
     {
         FixedFramerate = fixedFramerate;
         TextureFilter = textureFilter;
@@ -86,6 +102,8 @@ public readonly struct GameSettings
         ScreenTextureMode = ScreenTextureMode.Stretch;
         ApplicationName = applicationName;
         SaveDirectory = saveDirectory;
+        MaxSavegameBackups = maxSavegameBackups;
+        if (MaxSavegameBackups <= 0) MaxSavegameBackups = 0;
     }
 
     /// <summary>
@@ -97,9 +115,13 @@ public readonly struct GameSettings
     /// <param name="shaderSupportType">The shader support type.</param>
     /// <param name="nearestScaling">A value indicating whether the nearest scaling should be used.</param>
     /// <param name="applicationName">The name of the application. Will also be used for savegame folder name.</param>
-    /// <param name="saveDirectory">The directory for saving game data. If set to null, no directory will be created. Savegame location: saveGameDirectory/applicationName</param>
+    /// <param name="saveDirectory">The directory for saving game data. If set to null, no directory will be created.
+    /// Savegame location: saveDirectory/applicationName.</param>
+    /// <param name="maxSavegameBackups">The maximum number of savegame backup files to keep.
+    /// If set to 0 or less, no backups will be created.
+    /// Savegame Backup location: saveDirectory/applicationName/Backups.</param>
     public GameSettings(Dimensions fixedDimensions, int fixedFramerate, TextureFilter textureFilter, ShaderSupportType shaderSupportType, 
-        bool nearestScaling = false, string applicationName = "ShapeEngineGame", Environment.SpecialFolder? saveDirectory = Environment.SpecialFolder.LocalApplicationData)
+        bool nearestScaling = false, string applicationName = "ShapeEngineGame", Environment.SpecialFolder? saveDirectory = Environment.SpecialFolder.LocalApplicationData, int maxSavegameBackups = 3)
     {
         FixedFramerate = fixedFramerate;
         TextureFilter = textureFilter;
@@ -126,6 +148,8 @@ public readonly struct GameSettings
         }
         ApplicationName = applicationName;
         SaveDirectory = saveDirectory;
+        MaxSavegameBackups = maxSavegameBackups;
+        if (MaxSavegameBackups <= 0) MaxSavegameBackups = 0;
     }
 
     /// <summary>
@@ -136,9 +160,13 @@ public readonly struct GameSettings
     /// <param name="textureFilter">The texture filter to be used.</param>
     /// <param name="shaderSupportType">The shader support type.</param>
     /// <param name="applicationName">The name of the application. Will also be used for savegame folder name.</param>
-    /// <param name="saveDirectory">The directory for saving game data. If set to null, no directory will be created. Savegame location: saveGameDirectory/applicationName</param>
+    /// <param name="saveDirectory">The directory for saving game data. If set to null, no directory will be created.
+    /// Savegame location: saveDirectory/applicationName.</param>
+    /// <param name="maxSavegameBackups">The maximum number of savegame backup files to keep.
+    /// If set to 0 or less, no backups will be created.
+    /// Savegame Backup location: saveDirectory/applicationName/Backups.</param>
     public GameSettings(float pixelationFactor, int fixedFramerate, TextureFilter textureFilter, ShaderSupportType shaderSupportType, 
-        string applicationName = "ShapeEngineGame", Environment.SpecialFolder? saveDirectory = Environment.SpecialFolder.LocalApplicationData)
+        string applicationName = "ShapeEngineGame", Environment.SpecialFolder? saveDirectory = Environment.SpecialFolder.LocalApplicationData, int maxSavegameBackups = 3)
     {
         FixedFramerate = fixedFramerate;
         TextureFilter = textureFilter;
@@ -157,6 +185,8 @@ public readonly struct GameSettings
         }
         ApplicationName = applicationName;
         SaveDirectory = saveDirectory;
+        MaxSavegameBackups = maxSavegameBackups;
+        if (MaxSavegameBackups <= 0) MaxSavegameBackups = 0;
     }
     
     #endregion
@@ -218,6 +248,14 @@ public readonly struct GameSettings
     /// Choose based on your application's requirements and platform conventions.
     /// </remarks>
     public readonly Environment.SpecialFolder? SaveDirectory = Environment.SpecialFolder.LocalApplicationData;
+
+    /// <summary>
+    /// Gets the maximum number of savegame backup files to keep.
+    /// </summary>
+    /// <remarks>
+    /// If set to 0 or less, no backups will be created and no backup directory will be created.
+    /// </remarks>
+    public readonly int MaxSavegameBackups = 3;
 
     #endregion
 }

--- a/ShapeEngine/StaticLib/ShapeFileManager.cs
+++ b/ShapeEngine/StaticLib/ShapeFileManager.cs
@@ -4,6 +4,44 @@ using ShapeEngine.Core.GameDef;
 
 namespace ShapeEngine.StaticLib;
 
+
+
+/// <summary>
+/// Interface for objects that can be serialized to and deserialized from CSV format.
+/// </summary>
+public interface ICsvSerializable
+{
+    /// <summary>
+    /// Serializes the object to a CSV string.
+    /// All values should be in a comma-separated list like: value1,value2,value3.
+    /// </summary>
+    /// <returns>A CSV-formatted string representing the object.</returns>
+    /// <example>
+    /// <code>
+    /// public string ToCsv()
+    /// {
+    ///    return $"{Property1},{Property2},{Property3}";
+    /// }
+    /// public void FromCsv(string[] values)
+    /// {
+    ///     Name = values[0];
+    ///     Age = int.TryParse(values[1], out int age) ? age : 0;
+    ///     IsAlive = bool.TryParse(values[2], out bool alive) && alive;
+    /// }
+    /// </code>
+    /// </example>
+    string ToCsv();
+
+    /// <summary>
+    /// Populates the object from an array of CSV values.
+    /// </summary>
+    /// <param name="values">The CSV values to deserialize from.</param>
+    void FromCsv(string[] values);
+}
+
+
+
+
 /// <summary>
 /// Provides static methods for saving and loading text and data files, as well as accessing common application directories.
 /// </summary>
@@ -1314,6 +1352,46 @@ public static class ShapeFileManager
             Console.Error.WriteLine($"[{ex.GetType().Name}] Failed to read from {file.FullName}: {ex.Message}");
             return false;
         }
+    }
+    #endregion
+    
+    #region Csv
+    /// <summary>
+    /// Saves the object implementing <see cref="ICsvSerializable"/> to a CSV file at the specified path.
+    /// </summary>
+    /// <param name="content">The object to serialize and save as CSV.</param>
+    /// <param name="filePath">The file path where the CSV will be saved.</param>
+    public static void SaveToCsv(this ICsvSerializable content, string filePath)
+    {
+        SaveText(content.ToCsv(), filePath);
+    }
+
+    /// <summary>
+    /// Loads data from a CSV file into the object implementing <see cref="ICsvSerializable"/>.
+    /// </summary>
+    /// <param name="content">The object to populate from the CSV file.</param>
+    /// <param name="filePath">The file path from which to load the CSV data.</param>
+    /// <returns>True if loading was successful; otherwise, false.</returns>
+    public static bool LoadFromCsv(this ICsvSerializable content, string filePath)
+    {
+        string csvText = LoadText(filePath);
+        if (string.IsNullOrWhiteSpace(csvText)) return false;
+        
+        string[] csv = ParseCsv(csvText);
+        if(csv.Length <= 0) return false;
+        
+        content.FromCsv(csv);
+        return true;
+    }
+
+    /// <summary>
+    /// Parses a CSV string into an array of values, splitting on commas and line breaks.
+    /// </summary>
+    /// <param name="csvText">The CSV text to parse.</param>
+    /// <returns>An array of parsed CSV values.</returns>
+    public static string[] ParseCsv(string csvText)
+    {
+        return string.IsNullOrWhiteSpace(csvText) ? [] : csvText.Split([',', '\n', '\r'], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
     }
     #endregion
 }

--- a/ShapeEngine/StaticLib/ShapeFileManager.cs
+++ b/ShapeEngine/StaticLib/ShapeFileManager.cs
@@ -1,5 +1,6 @@
 ﻿
 using System.Text;
+using ShapeEngine.Core.GameDef;
 
 namespace ShapeEngine.StaticLib;
 
@@ -392,6 +393,65 @@ public static class ShapeFileManager
     /// <param name="absolutePath">The absolute directory path.</param>
     /// <returns>True if the directory exists; otherwise, false.</returns>
     public static bool DirectoryExists(string absolutePath) => Directory.Exists(absolutePath);
+
+    /// <summary>
+    /// Copies the contents of the source directory to the destination directory.
+    /// </summary>
+    /// <param name="sourceDirectoryPath">The absolute path of the source directory.</param>
+    /// <param name="destinationDirectoryPath">The absolute path of the destination directory.</param>
+    /// <param name="overwrite">If true, existing files in the destination will be overwritten.</param>
+    /// <returns>True if the copy operation succeeded; otherwise, false.</returns>
+    public static bool CopyDirectory(string sourceDirectoryPath, string destinationDirectoryPath, bool overwrite)
+    {
+        if (string.IsNullOrWhiteSpace(sourceDirectoryPath) || string.IsNullOrWhiteSpace(destinationDirectoryPath))
+        {
+            Game.Instance.Logger.LogWarning($"ShapeFileManager CopyDirectory: sourceDirectoryPath {sourceDirectoryPath} and/or destinationDirectoryPath {destinationDirectoryPath} is null or empty.");
+            return false;
+        }
+
+        if (Path.HasExtension(sourceDirectoryPath) || Path.HasExtension(destinationDirectoryPath))
+        {
+            Game.Instance.Logger.LogWarning($"ShapeFileManager CopyDirectory: sourceDirectoryPath {sourceDirectoryPath} and/or destinationDirectoryPath {destinationDirectoryPath} appears to be a file path, not a directory path.");
+            return false;
+        }
+
+        if (!Directory.Exists(sourceDirectoryPath))
+        {
+            Game.Instance.Logger.LogWarning($"ShapeFileManager CopyDirectory: Source directory at {sourceDirectoryPath} does not exist.");
+            return false;
+        }
+        
+        try
+        {
+            string[] allFiles = Directory.GetFiles(sourceDirectoryPath, "*", SearchOption.AllDirectories);
+            if (allFiles.Length <= 0)
+            {
+                Game.Instance.Logger.LogInfo($"ShapeFileManager CopyDirectory: No files found in source directory at {sourceDirectoryPath} to copy.");
+                return false;
+            }
+            
+            if (!Directory.Exists(destinationDirectoryPath))
+            {
+                Game.Instance.Logger.LogInfo($"ShapeFileManager CopyDirectory: Creating destination directory at {destinationDirectoryPath}");
+                Directory.CreateDirectory(destinationDirectoryPath);
+            }
+
+            foreach (string file in allFiles)
+            {
+                string relativePath = Path.GetRelativePath(sourceDirectoryPath, file);
+                string destFile = Path.Combine(destinationDirectoryPath, relativePath);
+                Directory.CreateDirectory(Path.GetDirectoryName(destFile)!);
+                File.Copy(file, destFile, overwrite);
+            }
+
+            return true;
+        }
+        catch (Exception ex)
+        {
+            Game.Instance.Logger.LogError($"[{ex.GetType().Name}] Failed to copy directory from {sourceDirectoryPath} to {destinationDirectoryPath}: {ex.Message}");
+            return false;
+        }
+    }
     #endregion
 
     #region Load/Process Directory

--- a/ShapeEngine/StaticLib/ShapeFileManager.cs
+++ b/ShapeEngine/StaticLib/ShapeFileManager.cs
@@ -58,7 +58,7 @@ public static class ShapeFileManager
     /// <param name="absolutePath">The absolute path of the file to create.</param>
     /// <param name="overrideIfExists">If true and the file exists, it will be deleted and recreated (WARNING: all contents will be lost).</param>
     /// <returns>The FileInfo of the created or existing file, or null if the operation failed.</returns>
-    public static FileInfo? CreateFile(string absolutePath, bool overrideIfExists = false)
+    public static FileInfo? CreateFile(string absolutePath, bool overrideIfExists)
     {
         if (string.IsNullOrWhiteSpace(absolutePath)) return null;
 
@@ -93,7 +93,7 @@ public static class ShapeFileManager
     /// <param name="text">The text content to write to the file.</param>
     /// <param name="overrideIfExists">If true and the file exists, it will be deleted and recreated with the new content.</param>
     /// <returns>The FileInfo of the created or existing file, or null if the operation failed.</returns>
-    public static FileInfo? CreateFile(string absolutePath, string text, bool overrideIfExists = false)
+    public static FileInfo? CreateFile(string absolutePath, string text, bool overrideIfExists)
     {
         if (string.IsNullOrWhiteSpace(absolutePath)) return null;
 
@@ -810,6 +810,24 @@ public static class ShapeFileManager
         catch (Exception ex)
         {
             Console.Error.WriteLine($"[{ex.GetType().Name}] Failed to save {fileName} to {absolutePath}: {ex.Message}");
+            return false;
+        }
+    }
+    public static bool SaveText(string text, string absolutePath, Encoding? encoding = null, bool append = false, bool createDirectory = true)
+    {
+        if (string.IsNullOrWhiteSpace(absolutePath)) return false;
+    
+        try
+        {
+            if (createDirectory) Directory.CreateDirectory(absolutePath);
+
+            using var writer = new StreamWriter(absolutePath, append, encoding ?? Encoding.Default);
+            writer.Write(text);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"[{ex.GetType().Name}] Failed to save {absolutePath}: {ex.Message}");
             return false;
         }
     }


### PR DESCRIPTION
 I have added a simple savegame and savegame backup system to the game class. The game class creates a save directory in the constructor (based on the supplied game settings) and now it also creates a `savegame (./ApplicationName/Savegames/)` and `backup (./ApplicationName/Backups)` directory that can easily be used.

I have added functions to save/ load text with a relative path within the savegame directory, functions to save/load text to/from a save game slot, a function to automatically get the path for a given slot, and to load/save the slot settings.

I have also added functions to create/apply backups of the entire save game folder. It will copy all contents of the save game directory to the backup directory based on a backup number. You can use new functions to save/load all backup information (current backup number, number of backups created, max backups allowed). 

All of this is completely optional, you can use the save game and backup directory however you want. This new functions are just for convenience to make it easier to just save/ load stuff and to create backups.

I have added a simple interface for serializing/deserializing csv data called `ICsvSerializable` and
I have added some functions to the `ShapeFileManager` class to use `ICsvSerializable` for saveing and loading.