### PR TITLE
PhysicsObject physics state update fix

### DIFF
--- a/Examples/Program.cs
+++ b/Examples/Program.cs
@@ -1,13 +1,16 @@
-﻿using ShapeEngine.Core;
+﻿using Raylib_cs;
+using ShapeEngine.Core;
 using ShapeEngine.Core.Structs;
 using ShapeEngine.Input;
+using ShapeEngine.Screen;
 
 namespace Examples;
 public static class Program
 {
     public static void Main(string[] args)
     {
-        var gameSettings = GameSettings.StretchMode("Shape Engine Examples");
+        // var gameSettings = GameSettings.StretchMode("Shape Engine Examples");
+        var gameSettings = new GameSettings(Dimensions.GetInvalidDimension(), 60, TextureFilter.Bilinear, ShaderSupportType.Multi, false);
         
         var windowSettings = new WindowSettings
         {
@@ -18,10 +21,10 @@ public static class Program
             WindowMinSize = new(480, 270),
             WindowSize = new(960, 540),
             Monitor = 0,
-            Vsync = VsyncMode.Disabled,
+            Vsync = VsyncMode.Double,
             FrameRateLimit = 60,
             UnfocusedFrameRateLimit = 30,
-            AdaptiveFpsLimiterSettings = AdaptiveFpsLimiter.Settings.Default,
+            AdaptiveFpsLimiterSettings = AdaptiveFpsLimiter.Settings.Disabled,
             WindowOpacity = 1f,
             MouseEnabled = true,
             MouseVisible = false,

--- a/Examples/Scenes/ExampleScenes/EndlessSpaceCollision.cs
+++ b/Examples/Scenes/ExampleScenes/EndlessSpaceCollision.cs
@@ -617,7 +617,11 @@ public class EndlessSpaceCollision : ExampleScene
         }
         
         spatialHash.SetBounds(universe);
-        CollisionHandler?.Update(time.Delta);
+        
+        //!!!: Very problematic - collision handler is always updated automatically by the scene (in fixed and open mode)!!!
+        // - currently (even in open mode) the collision handler is updated twice per frame...
+        Console.WriteLine($"Collision Handler Endless Space Update frame: {time.TotalFrames} - time fixed mode: {time.FixedMode} - time fixed steps: {time.FixedStep} - delta: {time.Delta}");
+        CollisionHandler?.Update(time.Delta); 
 
         // var removed = 0;
         for (int i = asteroids.Count - 1; i >= 0; i--)

--- a/ShapeEngine/Core/GameDef/Game.cs
+++ b/ShapeEngine/Core/GameDef/Game.cs
@@ -120,7 +120,7 @@ public partial class Game
     /// Contains timing data such as elapsed time, delta time, and frame count
     /// for the main game loop that runs at variable framerates.
     /// </remarks>
-    public GameTime Time { get; private set; } = new GameTime();
+    public GameTime Time { get; private set; }
 
     /// <summary>
     /// Gets the game time information for the fixed update loop.
@@ -129,7 +129,7 @@ public partial class Game
     /// Contains timing data for the physics update loop that runs at a fixed timestep.
     /// Only relevant when FixedPhysicsEnabled is true.
     /// </remarks>
-    public GameTime FixedTime { get; private set; } = new GameTime();
+    public GameTime FixedTime { get; private set; }
 
     /// <summary>
     /// Gets or sets the background color of the game window.
@@ -543,6 +543,9 @@ public partial class Game
             FixedPhysicsTimestep = 1.0 / FixedPhysicsFramerate;
             FixedPhysicsEnabled = true;
         }
+
+        Time = new GameTime(0.0, 0, 0.0, FixedPhysicsEnabled, false);
+        FixedTime = new GameTime(0.0, 0, 0.0, FixedPhysicsEnabled, true);
         
         curCamera = basicCamera;
         curCamera.Activate();

--- a/ShapeEngine/Core/GameDef/GameGameloop.cs
+++ b/ShapeEngine/Core/GameDef/GameGameloop.cs
@@ -161,13 +161,10 @@ public partial class Game
 
             UpdateCursor(dt, GameScreenInfo, GameUiScreenInfo, UIScreenInfo);
 
-            if (FixedPhysicsEnabled)
-            {
-                ResolveUpdate(true);
-                // Use double-precision frameDelta for more accurate fixed-step physics timing
-                AdvanceFixedUpdate(frameDelta);
-            }
-            else ResolveUpdate(false);
+            ResolveUpdate();
+            
+            // Use double-precision frameDelta for more accurate fixed-step physics timing
+            if (FixedPhysicsEnabled) AdvanceFixedUpdate(frameDelta);
 
             DrawToScreen();
 

--- a/ShapeEngine/Core/GameDef/GameResolve.cs
+++ b/ShapeEngine/Core/GameDef/GameResolve.cs
@@ -39,11 +39,11 @@ public partial class Game
         CurScene.ResolveOnButtonReleased(e);
     }
 
-    private void ResolveUpdate(bool fixedFramerateMode)
+    private void ResolveUpdate()
     {
         TriggerCustomEventsOnUpdate(true, Time, GameScreenInfo, GameUiScreenInfo, UIScreenInfo);
         Update(Time, GameScreenInfo, GameUiScreenInfo, UIScreenInfo);
-        CurScene.ResolveUpdate(Time, GameScreenInfo, GameUiScreenInfo, UIScreenInfo, fixedFramerateMode);
+        CurScene.ResolveUpdate(Time, GameScreenInfo, GameUiScreenInfo, UIScreenInfo);
         TriggerCustomEventsOnUpdate(false, Time, GameScreenInfo, GameUiScreenInfo, UIScreenInfo);
     }
     

--- a/ShapeEngine/Core/PhysicsObject.cs
+++ b/ShapeEngine/Core/PhysicsObject.cs
@@ -1,4 +1,5 @@
 using System.Numerics;
+using ShapeEngine.Core.GameDef;
 using ShapeEngine.Core.Structs;
 using ShapeEngine.StaticLib;
 
@@ -131,7 +132,24 @@ public abstract class PhysicsObject : GameObject
     /// <param name="ui">UI screen info.</param>
     public override void Update(GameTime time, ScreenInfo game, ScreenInfo gameUi, ScreenInfo ui)
     {
-        UpdatePhysicsState(time.Delta);
+        if (!time.FixedMode)
+        {
+            UpdatePhysicsState(time.Delta);
+        }
+    }
+
+    /// <summary>
+    /// Called on a fixed timestep to perform deterministic physics updates.
+    /// This method is invoked by the engine's fixed-update loop and should be used
+    /// for simulation steps that require a constant delta time (e.g., physics).
+    /// </summary>
+    /// <param name="fixedTime">The fixed game time containing the delta for this physics step.</param>
+    /// <param name="game">Primary game screen information.</param>
+    /// <param name="gameUi">Game UI screen information.</param>
+    /// <param name="ui">Global UI screen information.</param>
+    public override void FixedUpdate(GameTime fixedTime, ScreenInfo game, ScreenInfo gameUi, ScreenInfo ui)
+    {
+        UpdatePhysicsState(fixedTime.Delta);
     }
 
     /// <summary>

--- a/ShapeEngine/Core/Scene.cs
+++ b/ShapeEngine/Core/Scene.cs
@@ -230,7 +230,7 @@ public abstract class Scene
         }
         else
         {
-            SpawnArea?.Update(time, game, gameUi, ui, false);
+            SpawnArea?.Update(time, game, gameUi, ui);
             CollisionHandler?.Update(time.Delta);
             Pathfinder?.Update(time.Delta);
         }

--- a/ShapeEngine/Core/Scene.cs
+++ b/ShapeEngine/Core/Scene.cs
@@ -222,11 +222,11 @@ public abstract class Scene
         RemovePathfinder();
         OnClose();
     }
-    internal void ResolveUpdate(GameTime time, ScreenInfo game, ScreenInfo gameUi, ScreenInfo ui, bool fixedFramerateMode)
+    internal void ResolveUpdate(GameTime time, ScreenInfo game, ScreenInfo gameUi, ScreenInfo ui)
     {
-        if (fixedFramerateMode)
+        if (time.FixedMode)
         {
-            SpawnArea?.Update(time, game, gameUi, ui, true);
+            SpawnArea?.Update(time, game, gameUi, ui);
         }
         else
         {

--- a/ShapeEngine/Core/SpawnArea.cs
+++ b/ShapeEngine/Core/SpawnArea.cs
@@ -514,10 +514,9 @@ namespace ShapeEngine.Core
         /// <param name="game">The screen information for the game area.</param>
         /// <param name="gameUi">The screen information for the game UI area.</param>
         /// <param name="ui">The screen information for the UI area.</param>
-        /// <param name="fixedFramerateMode">If this update is called in the open frame rate or fixed frame rate mode.</param>
-        public virtual void Update(GameTime time, ScreenInfo game, ScreenInfo gameUi, ScreenInfo ui, bool fixedFramerateMode)
+        public virtual void Update(GameTime time, ScreenInfo game, ScreenInfo gameUi, ScreenInfo ui)
         {
-            if (fixedFramerateMode)
+            if (time.FixedMode)
             {
                 if (clearAreaActive && HasValidBounds())
                 {

--- a/ShapeEngine/Core/Structs/GameTime.cs
+++ b/ShapeEngine/Core/Structs/GameTime.cs
@@ -22,7 +22,21 @@ public readonly struct GameTime
     /// Seconds since last frame
     /// </summary>
     public readonly double ElapsedSeconds;
+    
+    /// <summary>
+    /// Indicates whether the game loop is operating in fixed-timestep mode.
+    /// </summary>
+    public readonly bool FixedMode;
 
+    /// <summary>
+    /// Indicates whether this GameTime instance represents a fixed-step update.
+    /// </summary>
+    /// <remarks>
+    /// Use to distinguish individual fixed-step updates from variable-step updates.
+    /// This is distinct from <c>FixedMode</c>, which denotes the game loop's operating mode.
+    /// </remarks>
+    public readonly bool FixedStep;
+    
     /// <summary>
     /// Initializes a new instance of the GameTime struct with default values.
     /// </summary>
@@ -34,6 +48,8 @@ public readonly struct GameTime
         TotalSeconds = 0;
         TotalFrames = 0;
         ElapsedSeconds = 0;
+        FixedMode = false;
+        FixedStep = false;
     }
     /// <summary>
     /// Initializes a new instance of the GameTime struct with specified values.
@@ -41,11 +57,15 @@ public readonly struct GameTime
     /// <param name="totalSeconds">The total seconds elapsed since the start of the application.</param>
     /// <param name="totalFrames">The total number of frames processed since the start of the application.</param>
     /// <param name="elapsedSeconds">The seconds elapsed since the last frame.</param>
-    public GameTime(double totalSeconds, int totalFrames, double elapsedSeconds)
+    /// <param name="fixedMode">Indicates whether the game loop is in fixed-timestep mode.</param>
+    /// <param name="fixedStep">Indicates whether this instance represents a fixed-step update.</param>
+    public GameTime(double totalSeconds, int totalFrames, double elapsedSeconds, bool fixedMode, bool fixedStep)
     {
         this.TotalSeconds = totalSeconds;
         this.TotalFrames = totalFrames;
         this.ElapsedSeconds = elapsedSeconds;
+        this.FixedMode = fixedMode;
+        this.FixedStep = fixedStep;
     }
 
     #region Tick
@@ -54,14 +74,14 @@ public readonly struct GameTime
     /// </summary>
     /// <param name="dt">The time delta in seconds to advance the game time by.</param>
     /// <returns>A new GameTime instance with updated total seconds, incremented frame count, and the provided delta as elapsed seconds.</returns>
-    public GameTime Tick(double dt) => new(TotalSeconds + dt, TotalFrames + 1, dt);
+    public GameTime Tick(double dt) => new(TotalSeconds + dt, TotalFrames + 1, dt, FixedMode, FixedStep);
 
     /// <summary>
     /// Advances the game time by the specified time delta using a float value.
     /// </summary>
     /// <param name="dt">The time delta in seconds (as float) to advance the game time by.</param>
     /// <returns>A new GameTime instance with updated total seconds, incremented frame count, and the provided delta as elapsed seconds.</returns>
-    public GameTime TickF(float dt) => new(TotalSeconds + dt, TotalFrames + 1, dt);
+    public GameTime TickF(float dt) => new(TotalSeconds + dt, TotalFrames + 1, dt, FixedMode, FixedStep);
     #endregion
     
     #region Conversion

--- a/ShapeEngine/Geometry/CollisionSystem/CollisionObject.cs
+++ b/ShapeEngine/Geometry/CollisionSystem/CollisionObject.cs
@@ -329,18 +329,38 @@ public abstract class CollisionObject : PhysicsObject
     /// </remarks>
     public override void Update(GameTime time, ScreenInfo game, ScreenInfo gameUi, ScreenInfo ui)
     {
+        if (!time.FixedMode)
+        {
+            var trans = Transform;
+            base.Update(time, game, gameUi, ui); // updates physics state
+            foreach (var collider in Colliders)
+            {
+                if (collider.Parent != this)
+                {
+                    throw new WarningException("Collision Object tried to update collider with different parent!");
+                }
+                collider.UpdateShape(time.Delta, trans);
+                OnColliderUpdated(collider);
+            }
+            OnColliderUpdateFinished();
+        }
+    }
+
+    public override void FixedUpdate(GameTime fixedTime, ScreenInfo game, ScreenInfo gameUi, ScreenInfo ui)
+    {
         var trans = Transform;
-        base.Update(time, game, gameUi, ui); // updates physics state
+        base.FixedUpdate(fixedTime, game, gameUi, ui); // updates physics state
         foreach (var collider in Colliders)
         {
             if (collider.Parent != this)
             {
                 throw new WarningException("Collision Object tried to update collider with different parent!");
             }
-            collider.UpdateShape(time.Delta, trans);
+            collider.UpdateShape(fixedTime.Delta, trans);
             OnColliderUpdated(collider);
         }
         OnColliderUpdateFinished();
+        
     }
 
     /// <summary>


### PR DESCRIPTION
Previously the `PhysicsObject` and `CollisionObject` would update their state in the open update function even if fixed physics framerate is enabled. The `PhysicsObject` would update the internal physics state in the normal `Update()` function instead of the `FixedUpdate()` function and the `CollisionObject` would update all the colliders in the `Update()` function instead of the `FixedUpdate()` function. 

This PR introduces new `FixedMode` and `FixedStep` properties in the `GameTime` class, so that every function always knows if the fixed framerate system is enabled and if the current `GameTime` instance holds fixed or open timing information.

This PR also includes some fixes in some of the Example scenes that do not properly make use of `FixedUpdate()`. For instance because of this I found out that the `EndlessSpaceExampleScene` updates the collision handler twice in each frame instead of only once!

- [ ] New `FixedMode`/`FixedStep` `GameTime` properties added.
- [ ] Update loop refactored to use new `GameTime` properties.
- [ ] ExampleScenes fixed/updated.