### PR TITLE
5.0 release polish

### DIFF
--- a/Examples/GameloopExamples.cs
+++ b/Examples/GameloopExamples.cs
@@ -269,52 +269,52 @@ public class GameloopExamples : Game
         contentManager = new ContentManager("Resources");
         contentManager.AddContentPack(contentPackAll, "Resources");
         
-        if(contentManager.TryLoadFont("Resources/Fonts/Gruppo-Regular.ttf", out var gruppoRegularFont, 100))
+        if(contentManager.TryLoadFont("Resources/Fonts/Gruppo-Regular.ttf", out var gruppoRegularFont, 250))
         {
             fonts.Add(FontIDs.GruppoRegular, gruppoRegularFont);
             fontNames.Add("Gruppo Regular");
         }
-        if(contentManager.TryLoadFont("Resources/Fonts/IndieFlower-Regular.ttf", out var indieFlowerRegularFont, 100))
+        if(contentManager.TryLoadFont("Resources/Fonts/IndieFlower-Regular.ttf", out var indieFlowerRegularFont, 250))
         {
             fonts.Add(FontIDs.IndieFlowerRegular, indieFlowerRegularFont);
             fontNames.Add("Indie Flower Regular");
         }
-        if(contentManager.TryLoadFont("Resources/Fonts/Orbit-Regular.ttf", out var orbitRegularFont, 100))
+        if(contentManager.TryLoadFont("Resources/Fonts/Orbit-Regular.ttf", out var orbitRegularFont, 250))
         {
             fonts.Add(FontIDs.OrbitRegular, orbitRegularFont);
             fontNames.Add("Orbit Regular");
         }
-        if(contentManager.TryLoadFont("Resources/Fonts/Orbitron-Bold.ttf", out var orbitronBoldFont, 100))
+        if(contentManager.TryLoadFont("Resources/Fonts/Orbitron-Bold.ttf", out var orbitronBoldFont, 250))
         {
             fonts.Add(FontIDs.OrbitronBold, orbitronBoldFont);
             fontNames.Add("Orbitron Bold");
         }
-        if(contentManager.TryLoadFont("Resources/Fonts/Orbitron-Regular.ttf", out var orbitronRegularFont, 100))
+        if(contentManager.TryLoadFont("Resources/Fonts/Orbitron-Regular.ttf", out var orbitronRegularFont, 250))
         {
             fonts.Add(FontIDs.OrbitronRegular, orbitronRegularFont);
             fontNames.Add("Orbitron Regular");
         }
-        if(contentManager.TryLoadFont("Resources/Fonts/Prompt-LightItalic.ttf", out var promptLightItalicFont, 100))
+        if(contentManager.TryLoadFont("Resources/Fonts/Prompt-LightItalic.ttf", out var promptLightItalicFont, 250))
         {
             fonts.Add(FontIDs.PromptLightItalic, promptLightItalicFont);
             fontNames.Add("Prompt Light Italic");
         }
-        if(contentManager.TryLoadFont("Resources/Fonts/Prompt-Regular.ttf", out var promptRegularFont, 100))
+        if(contentManager.TryLoadFont("Resources/Fonts/Prompt-Regular.ttf", out var promptRegularFont, 250))
         {
             fonts.Add(FontIDs.PromptRegular, promptRegularFont);
             fontNames.Add("Prompt Regular");
         }
-        if(contentManager.TryLoadFont("Resources/Fonts/Prompt-Thin.ttf", out var promptThinFont, 100))
+        if(contentManager.TryLoadFont("Resources/Fonts/Prompt-Thin.ttf", out var promptThinFont, 250))
         {
             fonts.Add(FontIDs.PromptThin, promptThinFont);
             fontNames.Add("Prompt Thin");
         }
-        if(contentManager.TryLoadFont("Resources/Fonts/Teko-Medium.ttf", out var tekoMediumFont, 100))
+        if(contentManager.TryLoadFont("Resources/Fonts/Teko-Medium.ttf", out var tekoMediumFont, 250))
         {
             fonts.Add(FontIDs.TekoMedium, tekoMediumFont);
             fontNames.Add("Teko Medium");
         }
-        if(contentManager.TryLoadFont("Resources/Fonts/JetBrainsMono.ttf", out var jetBrainsFont, 100))
+        if(contentManager.TryLoadFont("Resources/Fonts/JetBrainsMono.ttf", out var jetBrainsFont, 250))
         {
             fonts.Add(FontIDs.JetBrains, jetBrainsFont);
             fontNames.Add("Jet Brains Mono");

--- a/Examples/Scenes/ExampleScenes/PolylineInflationExample.cs
+++ b/Examples/Scenes/ExampleScenes/PolylineInflationExample.cs
@@ -17,10 +17,11 @@ namespace Examples.Scenes.ExampleScenes
     public class PolylineInflationExample : ExampleScene
     {
         private const float MaxOffset = 1000;
-        Polyline polyline = new();
-        int dragIndex = -1;
-        float offsetDelta = 0f;
-        float lerpOffsetDelta = 0f;
+        private Polyline polyline = new();
+        private TriMesh triangulationResult = new();
+        private int dragIndex = -1;
+        private float offsetDelta = 0f;
+        private float lerpOffsetDelta = 0f;
         private Font font;
 
         private InputAction createPoint;
@@ -131,6 +132,28 @@ namespace Examples.Scenes.ExampleScenes
             var createState = createPoint.State;
             var deleteState = deletePoint.State;
             
+            Polygons? inflationResult = null;
+            if (lerpOffsetDelta > 10f && polyline.Count > 1)
+            {
+                inflationResult = new();
+                polyline.InflatePolyline(inflationResult, lerpOffsetDelta, 2f, false, ShapeClipperEndType.Square, false);
+
+                triangulationResult.Clear();
+                
+                ShapeClipperTriangulation2D.CreatePolygonTriangulation(inflationResult, false, triangulationResult);
+                triangulationResult.Draw(Colors.Special.ChangeBrightness(-0.3f));
+                
+                ShapeClipperTriangulation2D.CreatePolygonOutlineTriangulation(inflationResult, relativeSize, 4f, false, false, triangulationResult);
+                triangulationResult.Draw(Colors.Special);
+                
+                // foreach (var polygon in inflationResult)
+                // {
+                //     polygon.Draw(Colors.Special.ChangeBrightness(-0.3f));
+                //     polygon.DrawLines(relativeSize, Colors.Special);
+                // }
+            }
+            
+            
             for (int i = 0; i < polyline.Count; i++)
             {
                 var p = polyline[i];
@@ -199,6 +222,9 @@ namespace Examples.Scenes.ExampleScenes
 
             if (dragIndex > -1) polyline[dragIndex] = mousePos;
 
+            
+
+            
             var segments = polyline.GetEdges();
             for (int i = 0; i < segments.Count; i++)
             {
@@ -230,18 +256,7 @@ namespace Examples.Scenes.ExampleScenes
                 circle.Draw(Colors.Warm);
             }
 
-            Polygons? inflationResult = null;
-            if (lerpOffsetDelta > 10f && polyline.Count > 1)
-            {
-                inflationResult = new();
-                polyline.InflatePolyline(inflationResult, lerpOffsetDelta, 2f, false, ShapeClipperEndType.Round);
-                // inflatedPolygons = ShapeClipper.Inflate(polyline, lerpOffsetDelta).ToPolygons();
-                foreach (var polygon in inflationResult)
-                {
-                    polygon.DrawLines(relativeSize, Colors.Special);
-                }
-            }
-
+            
 
             if (collisionSegmentValid)
             {

--- a/Examples/Scenes/ExampleScenes/ShapeIntersectionExample.cs
+++ b/Examples/Scenes/ExampleScenes/ShapeIntersectionExample.cs
@@ -1633,9 +1633,21 @@ public class ShapeIntersectionExample : ExampleScene
                     staticSeg.Draw(LineThickness, Colors.Light);
                 }
 
-                if (closestPointResult.OtherSegmentIndex >= 0 && movingShape.GetSegment(closestPointResult.OtherSegmentIndex, out var movingSeg))
+                var otherIndex = closestPointResult.OtherSegmentIndex;
+                if (otherIndex >= 0)
                 {
-                    movingSeg.Draw(LineThickness, Colors.Light);
+                    if (projectionActive && projection != null)
+                    {
+                        if (projection.Count > otherIndex)
+                        {
+                            var closestSegment = projection.GetSegment(otherIndex);
+                            closestSegment.Draw(LineThickness, Colors.Light);
+                        }
+                    }
+                    else if (movingShape.GetSegment(otherIndex, out var movingSeg))
+                    {
+                        movingSeg.Draw(LineThickness, Colors.Light);
+                    }
                 }
                 
                 var segment = new Segment(closestPointResult.Self.Point, closestPointResult.Other.Point);

--- a/Examples/Scenes/MainScene.cs
+++ b/Examples/Scenes/MainScene.cs
@@ -83,7 +83,7 @@ namespace Examples.Scenes
             navigator = new ControlNodeNavigator();
             navigator.AddNode(buttonContainer);
             
-            titleFont = new(GameloopExamples.Instance.FontDefault, 10f, Colors.Text);
+            titleFont = new(GameloopExamples.Instance.GetFont(FontIDs.JetBrainsLarge), 10f, Colors.Text);
             var action = GameloopExamples.Instance.InputActionUICancel;
             quitLabel = new(action, "Quit", GameloopExamples.Instance.FontDefault, Colors.PcWarm);
             

--- a/ShapeEngine/Content/ContentLoader.cs
+++ b/ShapeEngine/Content/ContentLoader.cs
@@ -295,6 +295,7 @@ public static class ContentLoader
         TryLoadFont(filePath, out var font, fontSize, textureFilter);
         return font;
     }
+ 
     /// <summary>
     /// Loads a fragment shader from a file.
     /// </summary>
@@ -318,6 +319,7 @@ public static class ContentLoader
         TryLoadFragmentShader(filePath, out var shader);
         return shader;
     }
+    
     /// <summary>
     /// Loads a vertex shader from a file.
     /// </summary>
@@ -341,6 +343,7 @@ public static class ContentLoader
         TryLoadVertexShader(filePath, out var shader);
         return shader;
     }
+    
     /// <summary>
     /// Loads a texture from a file.
     /// </summary>
@@ -364,6 +367,7 @@ public static class ContentLoader
         TryLoadTexture(filePath, out var texture);
         return texture;
     }
+    
     /// <summary>
     /// Loads an image from a file.
     /// </summary>
@@ -387,6 +391,7 @@ public static class ContentLoader
         TryLoadImage(filePath, out var image);
         return image;
     }
+    
     /// <summary>
     /// Loads a wave sound from a file.
     /// </summary>
@@ -410,6 +415,7 @@ public static class ContentLoader
         TryLoadWave(filePath, out var wave);
         return wave;
     }
+    
     /// <summary>
     /// Loads a sound from a file.
     /// </summary>
@@ -433,6 +439,7 @@ public static class ContentLoader
         TryLoadSound(filePath, out var sound);
         return sound;
     }
+    
     /// <summary>
     /// Loads a music stream from a file.
     /// </summary>
@@ -456,6 +463,7 @@ public static class ContentLoader
         TryLoadMusic(filePath, out var music);
         return music;
     }
+    
     /// <summary>
     /// Loads a text file as a string.
     /// This should not be used for game save data,
@@ -532,6 +540,7 @@ public static class ContentLoader
             return false;
         }
     }
+
     /// <summary>
     /// Attempts to load a fragment shader from the specified file path.
     /// Automatically resolves resource paths for macOS application bundles.
@@ -574,6 +583,7 @@ public static class ContentLoader
             return false;
         }
     }
+    
     /// <summary>
     /// Attempts to load a vertex shader from the specified file path.
     /// Automatically resolves resource paths for macOS application bundles.
@@ -616,6 +626,7 @@ public static class ContentLoader
             return false;
         }
     }
+    
     /// <summary>
     /// Attempts to load a texture from the specified file path.
     /// Automatically resolves resource paths for macOS application bundles.
@@ -658,6 +669,7 @@ public static class ContentLoader
             return false;
         }
     }
+    
     /// <summary>
     /// Attempts to load an image from the specified file path.
     /// Automatically resolves resource paths for macOS application bundles.
@@ -700,6 +712,7 @@ public static class ContentLoader
             return false;
         }
     }
+    
     /// <summary>
     /// Attempts to load a wave sound from the specified file path.
     /// Automatically resolves resource paths for macOS application bundles.
@@ -742,6 +755,7 @@ public static class ContentLoader
             return false;
         }
     }
+    
     /// <summary>
     /// Attempts to load a sound from the specified file path.
     /// Automatically resolves resource paths for macOS application bundles.
@@ -784,6 +798,7 @@ public static class ContentLoader
             return false;
         }
     }
+    
     /// <summary>
     /// Attempts to load a music stream from the specified file path.
     /// Automatically resolves resource paths for macOS application bundles.
@@ -826,6 +841,7 @@ public static class ContentLoader
             return false;
         }
     }
+    
     /// <summary>
     /// Attempts to load a text file as a string.
     /// Automatically resolves resource paths for macOS application bundles.
@@ -923,6 +939,7 @@ public static class ContentLoader
             return false;
         }
     }
+  
     /// <summary>
     /// Attempts to load an image from raw content data in memory.
     /// </summary>
@@ -975,12 +992,13 @@ public static class ContentLoader
     /// <param name="data">The raw font data as a byte array.</param>
     /// <param name="font">The loaded Font object if successful; otherwise, a default Font.</param>
     /// <param name="fontSize">The size of the font to load. Default is 100.</param>
+    /// <param name="textureFilter">The texture filter to apply to the font texture. Default is Trilinear.</param>
     /// <returns>True if the font was loaded successfully; otherwise, false.</returns>
     /// <remarks>
     /// Valid extensions for <see cref="ContentType.Font"/> can be managed via <see cref="AddValidFileExtension"/>,
     /// <see cref="RemoveValidFileExtension"/>,and <see cref="SetValidFileExtensions"/>.
     /// </remarks>
-    public static bool TryLoadFontFromMemory(string extension, byte[] data, out Font font, int fontSize = 100)
+    public static bool TryLoadFontFromMemory(string extension, byte[] data, out Font font, int fontSize = 100, TextureFilter textureFilter = TextureFilter.Trilinear)
     {
         if (data.Length <= 0)
         {
@@ -1004,6 +1022,7 @@ public static class ContentLoader
         try
         {
             font = Raylib.LoadFontFromMemory(extension, data, fontSize, [], GLYPH_COUNT);
+            Raylib.SetTextureFilter(font.Texture, textureFilter);
             return true;
         }
         catch (Exception ex)
@@ -1058,6 +1077,7 @@ public static class ContentLoader
             return false;
         }
     }
+  
     /// <summary>
     /// Attempts to load a sound from raw content data in memory.
     /// </summary>
@@ -1102,6 +1122,7 @@ public static class ContentLoader
             return false;
         }
     }
+    
     /// <summary>
     /// Attempts to load a music stream from raw content data in memory.
     /// </summary>
@@ -1203,6 +1224,7 @@ public static class ContentLoader
             return false;
         }
     }
+  
     /// <summary>
     /// Attempts to load a text string from raw content data in memory.
     /// </summary>
@@ -1268,10 +1290,7 @@ public static class ContentLoader
     /// <returns>The loaded Font object.</returns>
     public static Font LoadFontFromMemory(string extension, byte[] data, int fontSize = 100, TextureFilter textureFilter = TextureFilter.Trilinear)
     {
-        if (TryLoadFontFromMemory(extension, data, out var font, fontSize))
-        {
-            Raylib.SetTextureFilter(font.Texture, textureFilter);
-        }
+        TryLoadFontFromMemory(extension, data, out var font, fontSize, textureFilter);
         return font;
     }
 
@@ -1366,7 +1385,7 @@ public static class ContentLoader
 
         foreach (string path in fontPaths)
         {
-            if (!TryLoadFont(path, out var font)) continue;
+            if (!TryLoadFont(path, out var font, fontSize, textureFilter)) continue;
             string relativePath = Path.GetRelativePath(directoryPath, path);
             fontDict[relativePath] = font;
         }

--- a/ShapeEngine/Content/ContentLoader.cs
+++ b/ShapeEngine/Content/ContentLoader.cs
@@ -1264,10 +1264,14 @@ public static class ContentLoader
     /// <param name="extension">The file extension (e.g. ".ttf").</param>
     /// <param name="data">The raw font data as a byte array.</param>
     /// <param name="fontSize">The size of the font to load. Default is 100.</param>
+    /// <param name="textureFilter">The texture filter to use for the loaded font texture.</param>
     /// <returns>The loaded Font object.</returns>
-    public static Font LoadFontFromMemory(string extension, byte[] data, int fontSize = 100)
+    public static Font LoadFontFromMemory(string extension, byte[] data, int fontSize = 100, TextureFilter textureFilter = TextureFilter.Trilinear)
     {
-        TryLoadFontFromMemory(extension, data, out var font, fontSize);
+        if (TryLoadFontFromMemory(extension, data, out var font, fontSize))
+        {
+            Raylib.SetTextureFilter(font.Texture, textureFilter);
+        }
         return font;
     }
 

--- a/ShapeEngine/Content/ContentManager.cs
+++ b/ShapeEngine/Content/ContentManager.cs
@@ -118,6 +118,7 @@ public sealed class ContentManager
         Game.Instance.Logger.LogWarning($"Content pack with root '{root}' is already loaded.");
         return false;
     }
+ 
     /// <summary>
     /// Removes a content pack from the manager by its root path.
     /// </summary>
@@ -135,6 +136,7 @@ public sealed class ContentManager
         Game.Instance.Logger.LogWarning($"No content pack with root '{root}' found.");
         return false;
     }
+ 
     /// <summary>
     /// Removes a content pack from the manager by its instance.
     /// </summary>
@@ -153,6 +155,7 @@ public sealed class ContentManager
         Game.Instance.Logger.LogWarning("Content pack not found.");
         return false;
     }
+
     /// <summary>
     /// Removes all content packs from the manager.
     /// </summary>
@@ -162,6 +165,7 @@ public sealed class ContentManager
         if (clear) UnloadAllContentPacks();
         contentPacks.Clear();
     }
+
     /// <summary>
     /// Gets a list of all content packs managed by this ContentManager.
     /// </summary>
@@ -169,6 +173,7 @@ public sealed class ContentManager
     {
         return contentPacks.Values.ToList();
     }
+
     /// <summary>
     /// Gets a list of all loaded content packs managed by this ContentManager.
     /// Only content packs with <c>IsLoaded</c> set to true are included.
@@ -177,6 +182,7 @@ public sealed class ContentManager
     {
         return contentPacks.Values.Where(x => x.IsLoaded).ToList();
     }
+ 
     /// <summary>
     /// Checks if a content pack with the specified root path exists in the manager.
     /// </summary>
@@ -256,6 +262,7 @@ public sealed class ContentManager
         texture = loadedTexture;
         return true;
     }
+ 
     /// <summary>
     /// Attempts to load a fragment shader from the specified file path.
     /// Checks the cache, content packs, and file system in order.
@@ -309,6 +316,7 @@ public sealed class ContentManager
         shader = loadedShader;
         return true;
     }
+  
     /// <summary>
     /// Attempts to load a vertex shader from the specified file path.
     /// Checks the cache, content packs, and file system in order.
@@ -361,6 +369,7 @@ public sealed class ContentManager
         shader = loadedShader;
         return true;
     }
+  
     /// <summary>
     /// Attempts to load an image from the specified file path.
     /// Checks the cache, content packs, and file system in order.
@@ -414,6 +423,7 @@ public sealed class ContentManager
         image = loadedImage;
         return true;
     }
+ 
     /// <summary>
     /// Attempts to load a font from the specified file path with the given font size.
     /// Checks the cache, content packs, and file system in order.
@@ -421,8 +431,9 @@ public sealed class ContentManager
     /// <param name="filePath">The file path to the font to load.</param>
     /// <param name="font">The loaded <see cref="Font"/> if successful; otherwise, default.</param>
     /// <param name="fontSize">The size of the font to load. Defaults to 100.</param>
+    /// <param name="textureFilter">The texture filter to use for the loaded font texture.</param>
     /// <returns>True if the font was loaded successfully; otherwise, false.</returns>
-    public bool TryLoadFont(string filePath, out Font font, int fontSize = 100)
+    public bool TryLoadFont(string filePath, out Font font, int fontSize = 100, TextureFilter textureFilter = TextureFilter.Trilinear)
     {
         font = default;
 
@@ -440,7 +451,7 @@ public sealed class ContentManager
 
         if (FindContentPack(relativePath, out var pack, out string packFilePath) && pack != null)
         {
-            if (pack.TryLoadFont(packFilePath, out var packFont, fontSize))
+            if (pack.TryLoadFont(packFilePath, out var packFont, fontSize, textureFilter))
             {
                 Game.Instance.Logger.LogInfo($"Font '{relativePath}' loaded from content pack {pack.SourceFilePath} with font size: {fontSize}.");
                 font = packFont;
@@ -453,7 +464,7 @@ public sealed class ContentManager
         // 2. Try root pack if available
         if (contentPacks.TryGetValue(RootDirectory, out var rootPack))
         {
-            if (rootPack.TryLoadFont(relativePath, out var packFont, fontSize))
+            if (rootPack.TryLoadFont(relativePath, out var packFont, fontSize, textureFilter))
             {
                 Game.Instance.Logger.LogInfo($"Font '{relativePath}' loaded from root content pack  {rootPack.SourceFilePath} with font size: {fontSize}.");
                 font = packFont;
@@ -465,7 +476,7 @@ public sealed class ContentManager
 
         // 3. Try loading from disk
         string contentPath = RootDirectory != string.Empty ? Path.Combine(RootDirectory, relativePath) : relativePath;
-        if (!ContentLoader.TryLoadFont(contentPath, out var loadedFont, fontSize))
+        if (!ContentLoader.TryLoadFont(contentPath, out var loadedFont, fontSize, textureFilter))
         {
             return false;
         }

--- a/ShapeEngine/Content/ContentPack.cs
+++ b/ShapeEngine/Content/ContentPack.cs
@@ -1680,11 +1680,12 @@ public sealed class ContentPack
     /// <param name="filePath">The relative path of the font file within the content pack.</param>
     /// <param name="font">The loaded <see cref="Font"/> instance if successful; otherwise, a default value.</param>
     /// <param name="fontSize">The desired font size. Default is 100.</param>
+    /// <param name="textureFilter">The texture filter to use for the loaded font texture.</param>
     /// <remarks>
     /// ContentPack <see cref="IsLoaded"/> must be true before calling this method, otherwise it will fail and return false.
     /// Use <see cref="CreateCache"/> or <see cref="CreateIndex"/> to load the content pack first.
     /// </remarks>
-    public bool TryLoadFont(string filePath, out Font font, int fontSize = 100)
+    public bool TryLoadFont(string filePath, out Font font, int fontSize = 100, TextureFilter textureFilter = TextureFilter.Trilinear)
     {
         if (!IsLoaded)
         {
@@ -1702,7 +1703,7 @@ public sealed class ContentPack
         }
         
         string extension = Path.GetExtension(filePath);
-        font = ContentLoader.LoadFontFromMemory(extension, data, fontSize);
+        font = ContentLoader.LoadFontFromMemory(extension, data, fontSize, textureFilter);
         return true;
     }
     /// <summary>

--- a/ShapeEngine/Content/ContentPack.cs
+++ b/ShapeEngine/Content/ContentPack.cs
@@ -1500,15 +1500,19 @@ public sealed class ContentPack
     /// </summary>
     /// <param name="filePath">The relative path of the font file within the content pack.</param>
     /// <param name="fontSize">The desired font size. Default is 100.</param>
+    /// <param name="textureFilter">The texture filter to apply to the font texture. Default is Trilinear.</param>
     /// <returns>The loaded <see cref="Font"/> instance.</returns>
     /// <remarks>
     /// ContentPack <see cref="IsLoaded"/> has to be true before calling this method,
     /// otherwise it will fail and return a default value.
     /// Use <see cref="CreateCache"/> or <see cref="CreateIndex"/> to load the content pack first.
     /// </remarks>
-    public Font LoadFont(string filePath, int fontSize = 100)
+    public Font LoadFont(string filePath, int fontSize = 100, TextureFilter textureFilter = TextureFilter.Trilinear)
     {
-        TryLoadFont(filePath, out var font, fontSize);
+        if (TryLoadFont(filePath, out var font, fontSize))
+        {
+            Raylib.SetTextureFilter(font.Texture, textureFilter);
+        }
         return font;
     }
 
@@ -1642,6 +1646,7 @@ public sealed class ContentPack
         texture = ContentLoader.LoadTextureFromMemory(extension, data);
         return true;
     }
+    
     /// <summary>
     /// Attempts to load an <see cref="Image"/> from the content pack using the specified file path.
     /// Returns true if the image is successfully loaded; otherwise, false.
@@ -1673,6 +1678,7 @@ public sealed class ContentPack
         image = ContentLoader.LoadImageFromMemory(extension, data);
         return true;
     }
+    
     /// <summary>
     /// Attempts to load a <see cref="Font"/> from the content pack using the specified file path and font size.
     /// Returns true if the font is successfully loaded; otherwise, false.
@@ -1703,9 +1709,9 @@ public sealed class ContentPack
         }
         
         string extension = Path.GetExtension(filePath);
-        font = ContentLoader.LoadFontFromMemory(extension, data, fontSize, textureFilter);
-        return true;
+        return ContentLoader.TryLoadFontFromMemory(extension, data, out font, fontSize, textureFilter);
     }
+    
     /// <summary>
     /// Attempts to load a <see cref="Wave"/> from the content pack using the specified file path.
     /// Returns true if the wave is successfully loaded; otherwise, false.
@@ -1737,6 +1743,7 @@ public sealed class ContentPack
         wave =  ContentLoader.LoadWaveFromMemory(extension, data);
         return true;
     }
+  
     /// <summary>
     /// Attempts to load a <see cref="Sound"/> from the content pack using the specified file path.
     /// Returns true if the sound is successfully loaded; otherwise, false.
@@ -1801,6 +1808,7 @@ public sealed class ContentPack
         music = ContentLoader.LoadMusicFromMemory(extension, data);
         return true;
     }
+ 
     /// <summary>
     /// Attempts to load a fragment <see cref="Shader"/> from the content pack using the specified file path.
     /// Returns true if the shader is successfully loaded; otherwise, false.
@@ -1938,6 +1946,7 @@ public sealed class ContentPack
         success = true;
         return result;
     }
+ 
     /// <summary>
     /// Loads all <see cref="Image"/> assets from the content pack.
     /// Returns a dictionary mapping file paths to loaded images.
@@ -1979,6 +1988,7 @@ public sealed class ContentPack
             success = true;
             return result;
         }
+    
     /// <summary>
     /// Loads all <see cref="Font"/> assets from the content pack.
     /// Returns a dictionary mapping file paths to loaded fonts.
@@ -1986,12 +1996,13 @@ public sealed class ContentPack
     /// </summary>
     /// <param name="success">True if fonts were loaded; otherwise, false.</param>
     /// <param name="fontSize">The desired font size. Default is 100.</param>
+    /// <param name="textureFilter">The texture filter to apply to the font texture. Default is Trilinear.</param>
     /// <returns>Dictionary of file paths and their corresponding <see cref="Font"/> instances.</returns>
     /// <remarks>
     /// ContentPack <see cref="IsLoaded"/> must be true before calling this method, otherwise it will fail and <paramref name="success"/> will be false.
     /// Use <see cref="CreateCache"/> or <see cref="CreateIndex"/> to load the content pack first.
     /// </remarks>
-    public Dictionary<string, Font> LoadAllFonts(out bool success, int fontSize = 100)
+    public Dictionary<string, Font> LoadAllFonts(out bool success, int fontSize = 100, TextureFilter textureFilter = TextureFilter.Trilinear)
     {
         success = false;
         var result = new Dictionary<string, Font>();
@@ -2006,7 +2017,7 @@ public sealed class ContentPack
         {
             string ext = Path.GetExtension(file);
             if (!ContentLoader.IsValidExtension(ext, ContentLoader.ContentType.Font)) continue;
-            if (TryLoadFont(file, out var font, fontSize))
+            if (TryLoadFont(file, out var font, fontSize, textureFilter))
             {
                 result[file] = font;
             }
@@ -2021,6 +2032,7 @@ public sealed class ContentPack
         success = true;
         return result;
     }
+    
     /// <summary>
     /// Loads all <see cref="Wave"/> assets from the content pack.
     /// Returns a dictionary mapping file paths to loaded waves.
@@ -2062,6 +2074,7 @@ public sealed class ContentPack
         success = true;
         return result;
     }
+    
     /// <summary>
     /// Loads all <see cref="Sound"/> assets from the content pack.
     /// Returns a dictionary mapping file paths to loaded sounds.
@@ -2103,6 +2116,7 @@ public sealed class ContentPack
         success = true;
         return result;
     }
+    
     /// <summary>
     /// Loads all <see cref="Music"/> assets from the content pack.
     /// Returns a dictionary mapping file paths to loaded music instances.
@@ -2144,6 +2158,7 @@ public sealed class ContentPack
         success = true;
         return result;
     }
+    
     /// <summary>
     /// Loads all fragment <see cref="Shader"/> assets from the content pack.
     /// Returns a dictionary mapping file paths to loaded fragment shaders.
@@ -2185,6 +2200,7 @@ public sealed class ContentPack
         success = true;
         return result;
     }
+    
     /// <summary>
     /// Loads all vertex <see cref="Shader"/> assets from the content pack.
     /// Returns a dictionary mapping file paths to loaded vertex shaders.
@@ -2226,6 +2242,7 @@ public sealed class ContentPack
         success = true;
         return result;
     }
+    
     /// <summary>
     /// Loads all text files from the content pack.
     /// Returns a dictionary mapping file paths to their loaded text content.

--- a/ShapeEngine/ShapeClipper/ShapeClipper2D.cs
+++ b/ShapeEngine/ShapeClipper/ShapeClipper2D.cs
@@ -252,11 +252,12 @@ public static class ShapeClipper2D
     /// <param name="miterLimit">The maximum miter length factor used for joins.</param>
     /// <param name="beveled">Whether non-miter joins should use beveled corners.</param>
     /// <param name="endType">The end-cap style to use for the open polyline.</param>
-    public static void InflatePolyline(this IReadOnlyList<Vector2> polyline, Polygons result,  float delta, float miterLimit, bool beveled, ShapeClipperEndType endType = ShapeClipperEndType.Butt)
+    /// <param name="removeHoles">Whether to remove all polygons that are considered holes (wind clockwise) from the result.</param>
+    public static void InflatePolyline(this IReadOnlyList<Vector2> polyline, Polygons result,  float delta, float miterLimit, bool beveled, ShapeClipperEndType endType = ShapeClipperEndType.Butt, bool removeHoles = true)
     {
         if (delta < 0f) delta *= -1f;
         OffsetEngine.OffsetPolyline(polyline, delta, miterLimit, beveled, endType, paths64Buffer);
-        paths64Buffer.ToPolygons(result, true);
+        paths64Buffer.ToPolygons(result, removeHoles);
     }
   
     /// <summary>
@@ -267,10 +268,11 @@ public static class ShapeClipper2D
     /// <param name="delta">The offset distance in world units.</param>
     /// <param name="miterLimit">The maximum miter length factor used for joins.</param>
     /// <param name="beveled">Whether non-miter joins should use beveled corners.</param>
-    public static void InflatePolygon(this IReadOnlyList<Vector2> polygon, Polygons result, float delta, float miterLimit, bool beveled)
+    /// <param name="removeHoles">Whether to remove all polygons that are considered holes (wind clockwise) from the result.</param>
+    public static void InflatePolygon(this IReadOnlyList<Vector2> polygon, Polygons result, float delta, float miterLimit, bool beveled, bool removeHoles = true)
     {
         OffsetEngine.OffsetPolygon(polygon, delta, miterLimit, beveled, paths64Buffer);
-        paths64Buffer.ToPolygons(result, true);
+        paths64Buffer.ToPolygons(result, removeHoles);
     }
     
     #endregion

--- a/ShapeEngine/ShapeClipper/ShapeClipperOffset.cs
+++ b/ShapeEngine/ShapeClipper/ShapeClipperOffset.cs
@@ -96,9 +96,9 @@ public class ShapeClipperOffset
 
         if (offset == 0f)
         {
-            var path = new Path64();
-            ShapeClipperConversion2D.ToPath64(polygonCCW, path);
-            result.Add(path);
+            // var path = new Path64();
+            // ShapeClipperConversion2D.ToPath64(polygonCCW, path);
+            // result.Add(path);
             return;
         }
 
@@ -128,6 +128,7 @@ public class ShapeClipperOffset
 
         if (offset == 0f)
         {
+            // ShapeClipperConversion2D.ToPaths64(polygonWithHoles, result);
             return;
         }
 

--- a/ShapeEngine/ShapeClipper/ShapeClipperOffset.cs
+++ b/ShapeEngine/ShapeClipper/ShapeClipperOffset.cs
@@ -19,6 +19,7 @@ public class ShapeClipperOffset
     /// </summary>
     public DecimalPrecision Scale;
     private readonly Path64 bufferPath64 = new(256);
+    private readonly Paths64PooledBuffer paths64ConversionBuffer = new(8);
     
     /// <summary>
     /// Gets or sets the miter limit used by the underlying offset engine.
@@ -105,6 +106,38 @@ public class ShapeClipperOffset
     }
 
     /// <summary>
+    /// Offsets a polygon with holes and writes the resulting paths into <paramref name="result"/>.
+    /// </summary>
+    /// <param name="polygonWithHoles">
+    /// A collection of polygon contours to offset, where the first contour is typically the outer boundary and subsequent contours represent holes.
+    /// </param>
+    /// <param name="offset">The offset distance in world units. Positive values expand the polygon and negative values shrink it.</param>
+    /// <param name="miterLimit">The miter limit to use when selecting join behavior for sharp corners.</param>
+    /// <param name="beveled">Whether non-miter joins should use beveled corners instead of square corners.</param>
+    /// <param name="result">The destination collection that will be cleared and populated with the generated offset paths.</param>
+    /// <remarks>
+    /// If <paramref name="polygonWithHoles"/> is empty, or <paramref name="offset"/> is zero, no output is produced.
+    /// Each contour is converted to Clipper's integer coordinate space before the offset is applied.
+    /// </remarks>
+    public void OffsetPolygon(IReadOnlyList<IReadOnlyList<Vector2>> polygonWithHoles, float offset, float miterLimit, bool beveled, Paths64 result)
+    {
+        if (result == null) throw new ArgumentNullException(nameof(result));
+        result.Clear();
+
+        if (polygonWithHoles.Count <= 0) return;
+
+        if (offset == 0f)
+        {
+            return;
+        }
+
+        paths64ConversionBuffer.PrepareBuffer(polygonWithHoles.Count);
+        ShapeClipperConversion2D.ToPaths64(polygonWithHoles, paths64ConversionBuffer.Buffer);
+        
+        OffsetPaths64(paths64ConversionBuffer.Buffer, offset, miterLimit, beveled, result);
+    }
+    
+    /// <summary>
     /// Offsets an open polyline and writes the resulting stroked outline paths into <paramref name="result"/>.
     /// </summary>
     /// <param name="polyline">The polyline vertices to offset.</param>
@@ -152,7 +185,7 @@ public class ShapeClipperOffset
 
         OffsetPaths64(paths, offset, miterLimit, beveled, result);
     }
-
+    
     /// <summary>
     /// Offsets a collection of open Clipper paths and writes the resulting stroked outlines into <paramref name="result"/>.
     /// </summary>

--- a/ShapeEngine/ShapeClipper/ShapeClipperTriangulation2D.cs
+++ b/ShapeEngine/ShapeClipper/ShapeClipperTriangulation2D.cs
@@ -227,6 +227,54 @@ public static class ShapeClipperTriangulation2D
     }
     
     /// <summary>
+    /// Triangulates the stroked outline of a polygon-with-holes input into a <see cref="TriMesh"/>.
+    /// </summary>
+    /// <param name="polygonWithHoles">The outer polygon followed by any hole polygons, expressed as <see cref="Vector2"/> vertex lists.</param>
+    /// <param name="thickness">The outline thickness in world units.</param>
+    /// <param name="miterLimit">The maximum miter length factor used for sharp joins.</param>
+    /// <param name="beveled">Whether joins that exceed the miter limit should use beveled corners.</param>
+    /// <param name="useDelaunay">Whether Delaunay refinement should be applied during triangulation.</param>
+    /// <param name="result">The destination mesh that receives the generated geometry.</param>
+    /// <remarks>
+    /// The outline is created by offsetting the polygon set outward and inward, subtracting the inner result from the outer result,
+    /// and triangulating the remaining ring paths.
+    /// </remarks>
+    public static void CreatePolygonOutlineTriangulation(IReadOnlyList<IReadOnlyList<Vector2>> polygonWithHoles, float thickness, float miterLimit, bool beveled, bool useDelaunay, TriMesh result)
+    {
+        if (result == null) throw new ArgumentNullException(nameof(result));
+        result.Clear();
+
+        if (polygonWithHoles.Count <= 0 || thickness <= 0f) return;
+
+        ShapeClipper2D.OffsetEngine.OffsetPolygon(polygonWithHoles, +thickness, miterLimit, beveled, tmpOuter);
+        ShapeClipper2D.OffsetEngine.OffsetPolygon(polygonWithHoles, -thickness, miterLimit, beveled, tmpInner);
+        if (tmpOuter.Count == 0) return;
+        
+        tmpRing.Clear();
+        ShapeClipper2D.ClipEngine.Execute(tmpOuter, tmpInner, ShapeClipperClipType.Difference, tmpRing);
+        
+        if (tmpRing.Count == 0) return;
+    
+        result.TriangulatePaths64ToMesh(tmpRing, useDelaunay);
+    }
+    
+    /// <summary>
+    /// Triangulates the stroked outline of a polygon-with-holes input into a <see cref="Triangulation"/>.
+    /// </summary>
+    /// <param name="polygonWithHoles">The outer polygon followed by any hole polygons, expressed as <see cref="Vector2"/> vertex lists.</param>
+    /// <param name="thickness">The outline thickness in world units.</param>
+    /// <param name="miterLimit">The maximum miter length factor used for sharp joins.</param>
+    /// <param name="beveled">Whether joins that exceed the miter limit should use beveled corners.</param>
+    /// <param name="useDelaunay">Whether Delaunay refinement should be applied during triangulation.</param>
+    /// <param name="result">The destination triangulation that receives the generated triangles.</param>
+    public static void CreatePolygonOutlineTriangulation(IReadOnlyList<IReadOnlyList<Vector2>> polygonWithHoles, float thickness, float miterLimit, bool beveled, bool useDelaunay, Triangulation result)
+    {
+        triMeshBuffer.Clear();
+        CreatePolygonOutlineTriangulation(polygonWithHoles, thickness, miterLimit, beveled, useDelaunay, triMeshBuffer);
+        triMeshBuffer.ToTriangulation(result);
+    }
+    
+    /// <summary>
     /// Triangulates the stroked outline of a polygon into a <see cref="TriMesh"/>.
     /// </summary>
     /// <param name="polygonCCW">The polygon vertices, expected in counterclockwise order.</param>


### PR DESCRIPTION
This is a small PR fixing some issues before releasing the 5.0 version of Shape Engine.

- PolylineInflationExample now uses CreatePolygonTriangulation and CreatePolygonOutlineTriangulation functions to properly draw the inflated polyline with holes. This also added new function overloads to ShapeClipperTriangulation2d and ShapeClipperOffset. 
- ShapeClipper2D InflatePolyline and InflatePolygon removeHoles = true parameter added.
- Font loading in ContentLoader, ContentPack and ContentManager was improved with optional TextureFilter parameter. GameloopExamples now loads all fonts with 250 size instead of 100.
- ShapeIntersectionExample now properly displays closest segment when projection mode is active.