### PR TITLE
Mouse On Screen Detection Broken on MacOS

### DIFF
--- a/Examples/Scenes/ExampleScenes/PolylineInflationExample.cs
+++ b/Examples/Scenes/ExampleScenes/PolylineInflationExample.cs
@@ -102,7 +102,7 @@ namespace Examples.Scenes.ExampleScenes
             offsetDelta = ShapeMath.Clamp(offsetDelta, 0f, MaxOffset);
 
 
-            if (Input.Keyboard.IsDown(ShapeKeyboardButton.H))
+            if (Input.Keyboard.IsDown(ShapeKeyboardButton.T))
             {
                 collisionSegmentValid = true;
                 collisionSegment = collisionSegment.SetStart(mousePosGame);

--- a/ShapeEngine/Core/GameWindow.cs
+++ b/ShapeEngine/Core/GameWindow.cs
@@ -677,6 +677,7 @@ public sealed class GameWindow
 
         // Only use Raylib.IsCursorOnScreen() - avoid ScreenArea check to prevent false positives on Windows
         // screenArea.ContainsPoint(Raylib.GetMousePosition()) -> old safeguard for macOS
+        
         bool initialMouseOnScreen = Raylib.IsWindowFocused() && Raylib.IsCursorOnScreen();
         MouseOnScreen = initialMouseOnScreen;
 
@@ -1347,7 +1348,12 @@ public sealed class GameWindow
         // Mouse is only "on screen" if cursor is within window bounds AND window is focused
         // Use ONLY Raylib.IsCursorOnScreen() - don't fallback to ScreenArea check because
         // MousePosition can get clamped at window edges on Windows, causing false positives
-        bool currentMouseOnScreen = isWindowFocused && Raylib.IsCursorOnScreen();
+        
+        //On MacOS on launching the app, Raylib.IsCursorOnScreen() returns false even when the mouse is on the screen,
+        //so we need to check the mouse position against the screen area as a fallback.
+        bool containsScreenCursor = Game.IsOSX() ? ScreenArea.ContainsPoint(Raylib.GetMousePosition()) : false;
+        bool isCursorOnScreen = Raylib.IsCursorOnScreen() || containsScreenCursor;
+        bool currentMouseOnScreen = isWindowFocused && isCursorOnScreen;
         
         // Update MouseOnScreen property and cursor state
         MouseOnScreen = currentMouseOnScreen;

--- a/ShapeEngine/Input/InputExtensions.cs
+++ b/ShapeEngine/Input/InputExtensions.cs
@@ -62,6 +62,7 @@ public static class InputExtensions
     /// <returns>The input state for the specified mouse button.</returns>
     public static InputState GetInputState(this ShapeMouseButton button, uint accessTag = InputSystem.AllAccessTag)
     {
+        //ISSUE: Does not work anymore?!...
         if (InputSystem.Locked && !InputSystem.HasAccess(accessTag)) return new();
         return Game.Instance.Input.Mouse.GetButtonState(button);
     }

--- a/ShapeEngine/Input/InputExtensions.cs
+++ b/ShapeEngine/Input/InputExtensions.cs
@@ -62,7 +62,6 @@ public static class InputExtensions
     /// <returns>The input state for the specified mouse button.</returns>
     public static InputState GetInputState(this ShapeMouseButton button, uint accessTag = InputSystem.AllAccessTag)
     {
-        //ISSUE: Does not work anymore?!...
         if (InputSystem.Locked && !InputSystem.HasAccess(accessTag)) return new();
         return Game.Instance.Input.Mouse.GetButtonState(button);
     }


### PR DESCRIPTION
The issue was detecting when the mouse is on the screen was not working correctly on macOS after startup. Cursor would have to leave the screen once and come back to have working behavior. I have fixed it again with the fix that I removed in a recent refactoring of GameWindow.