### PR TITLE
ControlNode Selection Issues

### DIFF
--- a/Examples/Scenes/ExampleScenes/ControlNodeExampleScene.cs
+++ b/Examples/Scenes/ExampleScenes/ControlNodeExampleScene.cs
@@ -59,8 +59,6 @@ namespace Examples.Scenes.ExampleScenes
     }
     internal class ControlNodeButton : ControlNode
     {
-        private float inputCooldownTimer = 0f;
-        private const float inputCooldown = 0.1f;
         public ControlNodeButton(string text, AnchorPoint anchor, Vector2 stretch)
         {
             this.Anchor = anchor;
@@ -115,18 +113,6 @@ namespace Examples.Scenes.ExampleScenes
             var rightState = GameloopExamples.Instance.InputActionUIRight.Consume(out _);
             var leftState = GameloopExamples.Instance.InputActionUILeft.Consume(out _);
             
-            if (inputCooldownTimer > 0f)
-            {
-                if (upState is { Consumed: false, Released: true } ||
-                    downState is { Consumed: false, Released: true } ||
-                    rightState is { Consumed: false, Released: true } ||
-                    leftState is { Consumed: false, Released: true })
-                {
-                    inputCooldownTimer = 0f;
-                }
-                else return new();
-            }
-            
             var hor = 0;
             var vert = 0;
             if (leftState is { Consumed: false, Down: true }) hor = -1;
@@ -141,7 +127,6 @@ namespace Examples.Scenes.ExampleScenes
         {
             if (value)
             {
-                inputCooldownTimer = inputCooldown;
                 ContainerStretch =  1.25f;
             }
             else ContainerStretch = 1f;
@@ -179,16 +164,7 @@ namespace Examples.Scenes.ExampleScenes
             
         }
 
-        protected override void OnUpdate(float dt, Vector2 mousePos, bool mousePosValid)
-        {
-            if (inputCooldownTimer > 0)
-            {
-                inputCooldownTimer -= dt;
-            }
-        }
     }
-    
-    
     
     
     public class ControlNodeExampleScene : ExampleScene
@@ -364,7 +340,7 @@ namespace Examples.Scenes.ExampleScenes
             
             container.UpdateRect(ui.Area);
             container.Update(time.Delta, ui.MousePos);
-            navigator.Update();
+            navigator.Update(time.Delta);
         }
 
         protected override void OnDrawUIExample(ScreenInfo ui)

--- a/Examples/Scenes/MainScene.cs
+++ b/Examples/Scenes/MainScene.cs
@@ -185,7 +185,7 @@ namespace Examples.Scenes
             
             buttonContainer.UpdateRect(ui.Area);
             buttonContainer.Update(time.Delta, ui.MousePos);
-            navigator.Update();
+            navigator.Update(time.Delta);
         }
         protected override void OnDrawUI(ScreenInfo ui)
         {

--- a/Examples/UIElements/ExampleSelectionButton.cs
+++ b/Examples/UIElements/ExampleSelectionButton.cs
@@ -9,8 +9,6 @@ namespace Examples.UIElements
 {
     public class ExampleSelectionButton : ControlNode
     {
-        private float inputCooldownTimer = 0f;
-        private const float inputCooldown = 0.1f;
         public ExampleScene? Scene { get; private set; } = null;
         private TextFont textFont;
         public bool Hidden => Scene == null;
@@ -88,27 +86,8 @@ namespace Examples.UIElements
             
             var downState = GameloopExamples.Instance.InputActionUIDown.Consume(out _);
             var upState = GameloopExamples.Instance.InputActionUIUp.Consume(out _);
-            // var leftState = GAMELOOP.InputActionUILeft.Consume();
-            // var rightState = GAMELOOP.InputActionUIRight.Consume();
-            // Console.WriteLine($"Button {Scene.Title} - Down: {downState.Consumed}, Up: {upState.Consumed}, Left: {leftState.Consumed}, Right: {rightState.Consumed}");
             
-            if (inputCooldownTimer > 0f)
-            {
-                if (downState is {Consumed:false, Released:true} ||
-                    upState is {Consumed:false, Released:true})
-                    // leftState is {Consumed:false, Released:true} ||
-                    // rightState is {Consumed:false, Released:true})
-                {
-                    inputCooldownTimer = 0f;
-                }
-                else return new();
-            }
-            
-            // var hor = 0;
             var vert = 0;
-            // if (leftState is {Consumed:false, Down:true}) hor = -1;
-            // else if (rightState is {Consumed:false, Down:true}) hor = 1;
-            
             if (upState is {Consumed:false, Down:true}) vert = -1;
             else if (downState is {Consumed:false, Down:true}) vert = 1;
             return new(0, vert);
@@ -118,7 +97,6 @@ namespace Examples.UIElements
         {
             if (value)
             {
-                inputCooldownTimer = inputCooldown;
                 ContainerStretch =  1.25f;
             }
             else ContainerStretch = 1f;
@@ -141,10 +119,6 @@ namespace Examples.UIElements
         protected override void OnUpdate(float dt, Vector2 mousePos, bool mousePosValid)
         {
             base.OnUpdate(dt, mousePos, mousePosValid);
-            if (inputCooldownTimer > 0)
-            {
-                inputCooldownTimer -= dt;
-            }
 
             if (pressDelayTimer > 0)
             {

--- a/Examples/UIElements/ExampleSelectionButton.cs
+++ b/Examples/UIElements/ExampleSelectionButton.cs
@@ -123,23 +123,18 @@ namespace Examples.UIElements
             }
             else ContainerStretch = 1f;
         }
-        protected override void PressedWasChanged(bool value)
+
+        protected override void PressWasReleased()
         {
             if (Scene == null) return;
-            if (!value)
+            if (PressDelay > 0f)
             {
-                // Console.WriteLine($"Button Pressed - Scene {Scene.Title}");
-                // GAMELOOP.GoToScene(Scene);
-                if (PressDelay > 0f)
-                {
-                    pressDelayTimer = PressDelay;
-                }
-                else
-                {
-                    mouseInsideAnimationTimer = 0f;
-                    GameloopExamples.Instance.GoToScene(Scene);
-                }
-                
+                pressDelayTimer = PressDelay;
+            }
+            else
+            {
+                mouseInsideAnimationTimer = 0f;
+                GameloopExamples.Instance.GoToScene(Scene);
             }
         }
 
@@ -179,26 +174,21 @@ namespace Examples.UIElements
             {
                 var amount = Rect.Size.Min() * 0.25f;
                 var outside = Rect.ChangeSize(amount, new AnchorPoint(0.5f, 0.5f));
-                // outside.DrawLines(2f, Colors.Medium);
                 
                 var animationFactor = mouseInsideAnimationTimer / mouseInsideAnimationDuration;
                 var lineThickness = outside.Size.Min() * 0.04f;
-                // var spacing = lineThickness * ShapeMath.LerpFloat(4f, 5f, ShapeTween.PingPong(animationFactor));
-                // var info = new LineDrawingInfo(lineThickness, Colors.Dark, LineCapType.Capped, 6);
-                // outside.DrawStriped(spacing, 35f, info);
                 var cornerLength = outside.Size.Min() * ShapeMath.LerpFloat(0.15f, 0.35f, ShapeTween.PingPong(animationFactor));
                 outside.DrawCorners(lineThickness, Colors.Highlight, cornerLength);
-                // outside.LeftSegment.Draw(lineThickness, Colors.Highlight);
             }
             
-            if (Selected)
-            {
-                textFont.ColorRgba = Colors.Highlight;
-                textFont.DrawTextWrapNone(text, r, new(0f));
-            }
-            else if (Pressed)
+            if (Pressed)
             {
                 textFont.ColorRgba = Colors.Special;
+                textFont.DrawTextWrapNone(text, r, new(0f));
+            }
+            else if (Selected)
+            {
+                textFont.ColorRgba = Colors.Highlight;
                 textFont.DrawTextWrapNone(text, r, new(0f));
             }
             else

--- a/ShapeEngine/UI/ControlNode.cs
+++ b/ShapeEngine/UI/ControlNode.cs
@@ -5,11 +5,7 @@ using ShapeEngine.Geometry.RectDef;
 namespace ShapeEngine.UI;
 
 //ISSUE:
-// - When button is selected and holding pressed, selecting other button with mouse will keep pressed button stuck in pressed even when releasing!
-// - Extra check has to be added to not allow navigation while button is pressed (should be done internally)
-// - GetButtonPressedState & GetButtonReleaseState has to check for Selected but GetMouseButtonPressedState & GetMouseButtonReleaseState does not have to check for Selected or MouseInside!
 // - Add Navigation input timer to ControlNode? Whenever GetNavigationDirection reports a direction and change is valid (selection changes) start timer?
-// - If pressed is true selected is also true - Should this stay this way or should there only be one state (None, Selected, Pressed, Release) + MouseInside?
 // - Should I add GetUpDirection, GetDownDirection, GetLeftDirection, GetRightDirection or should I keep GetNavigationDirection?
 
 
@@ -109,6 +105,18 @@ public abstract class ControlNode
     /// Parameters: Invoker, Value
     /// </summary>
     public event Action<ControlNode, bool>? OnPressedChanged;
+    
+    /// <summary>
+    /// Occurs when a press is successfully released and should be treated as confirmed.
+    /// Parameters: Invoker
+    /// </summary>
+    public event Action<ControlNode>? OnPressedReleased;
+
+    /// <summary>
+    /// Occurs when an active press is cancelled.
+    /// Parameters: Invoker
+    /// </summary>
+    public event Action<ControlNode>? OnPressedCancelled;
     
     /// <summary>
     /// Occurs when the down state changes.
@@ -262,6 +270,13 @@ public abstract class ControlNode
             prevNavigable = Navigable;
             prevIsVisibleInHierarchy = IsVisibleInHierarchy;
             displayed = value;
+            
+            if (!displayed)
+            {
+                CancelInputState();
+            }
+
+            
             ResolveOnDisplayedChanged();
             foreach (var child in children)
             {
@@ -754,6 +769,9 @@ public abstract class ControlNode
     public bool Deselect()
     {
         if (SelectionFilter == SelectFilter.None) return false;
+        
+        CancelInputState();
+        
         Selected = false;
         navigationSelected = false;
         return true;
@@ -780,6 +798,9 @@ public abstract class ControlNode
     {
         if (SelectionFilter is SelectFilter.Mouse or SelectFilter.None) return false;
         if (InputFilter is InputFilter.None or InputFilter.MouseOnly) return false;
+        
+        CancelInputState();
+        
         Selected = false;
         navigationSelected = false;
         return true;
@@ -801,6 +822,9 @@ public abstract class ControlNode
     {
         if (SelectionFilter is SelectFilter.Navigation or SelectFilter.None) return;
         if (navigationSelected) return;
+        
+        CancelInputState();
+        
         Selected = false;
     }
     
@@ -944,53 +968,80 @@ public abstract class ControlNode
             if (InputFilter != InputFilter.None)
             {
                 var pressed = Pressed;
+                var down = false;
+
                 if (InputFilter == InputFilter.MouseOnly)
                 {
-                    if (GetMouseButtonPressedState())
+                    var mousePressed = GetMouseButtonPressedState();
+                    var mouseReleased = GetMouseButtonReleasedState();
+                    var mouseDown = GetMouseButtonDownState();
+
+                    if (mousePressed && MouseInside)
                     {
-                        if (MouseInside) pressed = true;
+                        pressed = true;
                     }
-                    else if (GetMouseButtonReleasedState())
+                    else if (mouseReleased && Pressed)
                     {
-                        pressed = false;
+                        if (MouseInside) ReleaseInputState();
+                        else CancelInputState();
+
+                        pressed = Pressed;
                     }
-                    
+
+                    down = MouseInside && mouseDown;
                 } 
                 else if (InputFilter == InputFilter.MouseNever)
                 {
-                    if (GetButtonPressedState()) pressed = true;
-                    else if (GetButtonReleasedState()) pressed = false;
+                    var buttonPressed = GetButtonPressedState();
+                    var buttonReleased = GetButtonReleasedState();
+                    var buttonDown = GetButtonDownState();
+
+                    if (buttonPressed && Selected)
+                    {
+                        pressed = true;
+                    }
+                    else if (buttonReleased && Pressed)
+                    {
+                        if (Selected) ReleaseInputState();
+                        else CancelInputState();
+
+                        pressed = Pressed;
+                    }
+
+                    down = buttonDown;
                 }
                 else if (InputFilter == InputFilter.All)
                 {
-                    if (GetMouseButtonPressedState() || GetButtonPressedState())
-                    {
-                        pressed = (GetMouseButtonPressedState() && MouseInside) || GetButtonPressedState();
-                    }
-                    else if (GetMouseButtonReleasedState() || GetButtonReleasedState())
-                    {
-                        pressed = false;
-                    }
-                }
+                    var mousePressed = GetMouseButtonPressedState();
+                    var mouseReleased = GetMouseButtonReleasedState();
+                    var mouseDown = GetMouseButtonDownState();
 
+                    var buttonPressed = GetButtonPressedState();
+                    var buttonReleased = GetButtonReleasedState();
+                    var buttonDown = GetButtonDownState();
+
+                    if ((mousePressed && MouseInside) || (buttonPressed && Selected))
+                    {
+                        pressed = true;
+                    }
+                    else if ((mouseReleased || buttonReleased) && Pressed)
+                    {
+                        var validMouseRelease = mouseReleased && MouseInside;
+                        var validButtonRelease = buttonReleased && Selected;
+
+                        if (validMouseRelease || validButtonRelease) ReleaseInputState();
+                        else CancelInputState();
+
+                        pressed = Pressed;
+                    }
+
+                    down = (MouseInside && mouseDown) || buttonDown;
+                }
+                
                 if (Pressed != pressed)
                 {
                     Pressed = pressed;
                     ResolvePressedChanged();
-                }
-                
-                var down = false;
-                if (InputFilter == InputFilter.MouseOnly)
-                {
-                    down = MouseInside && GetMouseButtonDownState();
-                } 
-                else if (InputFilter == InputFilter.MouseNever)
-                {
-                    down = GetButtonDownState();
-                }
-                else if (InputFilter == InputFilter.All)
-                {
-                    down = (MouseInside && GetMouseButtonDownState()) || GetButtonDownState();
                 }
 
                 if (IsDown != down)
@@ -998,7 +1049,6 @@ public abstract class ControlNode
                     IsDown = down;
                     ResolveIsDownChanged();
                 }
-            
             }
         }
         
@@ -1226,6 +1276,16 @@ public abstract class ControlNode
     protected virtual void PressedWasChanged(bool value) { }
  
     /// <summary>
+    /// Called when a press is successfully released and should be treated as confirmed.
+    /// </summary>
+    protected virtual void PressWasReleased() { }
+
+    /// <summary>
+    /// Called when an active press is cancelled.
+    /// </summary>
+    protected virtual void PressWasCancelled() { }
+    
+    /// <summary>
     /// Called when the IsDown state changes.
     /// </summary>
     /// <param name="value">The new IsDown state.</param>
@@ -1315,6 +1375,11 @@ public abstract class ControlNode
     /// </summary>
     private void ResolveActiveChanged()
     {
+        if (!active)
+        {
+            CancelInputState();
+        }
+        
         ActiveWasChanged(active);
         OnActiveChanged?.Invoke(this, active);
         ResolveOnNavigableChanged();
@@ -1326,6 +1391,11 @@ public abstract class ControlNode
     /// </summary>
     private void ResolveVisibleChanged()
     {
+        if (!visible)
+        {
+            CancelInputState();
+        }
+        
         VisibleWasChanged(visible);
         OnVisibleChanged?.Invoke(this, visible);
         ResolveOnNavigableChanged();
@@ -1337,6 +1407,11 @@ public abstract class ControlNode
     /// </summary>
     private void ResolveParentVisibleChanged()
     {
+        if (!parentVisible)
+        {
+            CancelInputState();
+        }
+        
         ParentVisibleWasChanged(parentVisible);
         OnParentVisibleChanged?.Invoke(this, parentVisible);
         ResolveOnNavigableChanged();
@@ -1348,6 +1423,11 @@ public abstract class ControlNode
     /// </summary>
     private void ResolveParentActiveChanged()
     {
+        if (!parentActive)
+        {
+            CancelInputState();
+        }
+        
         ParentActiveWasChanged(parentActive);
         OnParentActiveChanged?.Invoke(this, parentActive);
         ResolveOnNavigableChanged();
@@ -1426,12 +1506,30 @@ public abstract class ControlNode
     }
     
     /// <summary>
+    /// Resolves a successful press release.
+    /// </summary>
+    private void ResolvePressedReleased()
+    {
+        PressWasReleased();
+        OnPressedReleased?.Invoke(this);
+    }
+
+    /// <summary>
+    /// Resolves a cancelled press.
+    /// </summary>
+    private void ResolvePressedCancelled()
+    {
+        PressWasCancelled();
+        OnPressedCancelled?.Invoke(this);
+    }
+    
+    /// <summary>
     /// Resolves changes to the IsDown state and triggers related events.
     /// </summary>
     private void ResolveIsDownChanged()
     {
-        IsDownWasChanged(Pressed);
-        OnIsDownChanged?.Invoke(this, Pressed);
+        IsDownWasChanged(IsDown);
+        OnIsDownChanged?.Invoke(this, IsDown);
     }
     
     /// <summary>
@@ -1478,6 +1576,58 @@ public abstract class ControlNode
         NavigableWasChanged(Navigable);
         OnNavigableChanged?.Invoke(this, Navigable);
     }
+    
+    /// <summary>
+    /// Clears transient input state owned by this node.
+    /// </summary>
+    private void CancelInputState()
+    {
+        var wasPressed = Pressed;
+
+        if (Pressed)
+        {
+            Pressed = false;
+            ResolvePressedChanged();
+        }
+
+        if (IsDown)
+        {
+            IsDown = false;
+            ResolveIsDownChanged();
+        }
+
+        if (wasPressed)
+        {
+            ResolvePressedCancelled();
+        }
+    }
+    
+    /// <summary>
+    /// Releases transient input state owned by this node.
+    /// This represents a successful/confirmed press release.
+    /// </summary>
+    private void ReleaseInputState()
+    {
+        var wasPressed = Pressed;
+
+        if (Pressed)
+        {
+            Pressed = false;
+            ResolvePressedChanged();
+        }
+
+        if (IsDown)
+        {
+            IsDown = false;
+            ResolveIsDownChanged();
+        }
+
+        if (wasPressed)
+        {
+            ResolvePressedReleased();
+        }
+    }
+
     #endregion
     
 }

--- a/ShapeEngine/UI/ControlNode.cs
+++ b/ShapeEngine/UI/ControlNode.cs
@@ -1003,7 +1003,7 @@ public abstract class ControlNode
                         pressed = Pressed;
                     }
 
-                    down = buttonDown;
+                    down = buttonDown && Selected;
                 }
                 else if (InputFilter == InputFilter.All)
                 {
@@ -1030,7 +1030,7 @@ public abstract class ControlNode
                         pressed = Pressed;
                     }
 
-                    down = (MouseInside && mouseDown) || buttonDown;
+                    down = (MouseInside && mouseDown) || (buttonDown && Selected);
                 }
                 
                 if (Pressed != pressed)

--- a/ShapeEngine/UI/ControlNode.cs
+++ b/ShapeEngine/UI/ControlNode.cs
@@ -4,6 +4,15 @@ using ShapeEngine.Geometry.RectDef;
 
 namespace ShapeEngine.UI;
 
+//ISSUE:
+// - When button is selected and holding pressed, selecting other button with mouse will keep pressed button stuck in pressed even when releasing!
+// - Extra check has to be added to not allow navigation while button is pressed (should be done internally)
+// - GetButtonPressedState & GetButtonReleaseState has to check for Selected but GetMouseButtonPressedState & GetMouseButtonReleaseState does not have to check for Selected or MouseInside!
+// - Add Navigation input timer to ControlNode? Whenever GetNavigationDirection reports a direction and change is valid (selection changes) start timer?
+// - If pressed is true selected is also true - Should this stay this way or should there only be one state (None, Selected, Pressed, Release) + MouseInside?
+// - Should I add GetUpDirection, GetDownDirection, GetLeftDirection, GetRightDirection or should I keep GetNavigationDirection?
+
+
 /// <summary>
 /// Represents an abstract base class for UI control nodes, providing core functionality for hierarchy, state, events, and input handling.
 /// </summary>

--- a/ShapeEngine/UI/ControlNode.cs
+++ b/ShapeEngine/UI/ControlNode.cs
@@ -4,11 +4,6 @@ using ShapeEngine.Geometry.RectDef;
 
 namespace ShapeEngine.UI;
 
-//ISSUE:
-// - Add Navigation input timer to ControlNode? Whenever GetNavigationDirection reports a direction and change is valid (selection changes) start timer?
-// - Should I add GetUpDirection, GetDownDirection, GetLeftDirection, GetRightDirection or should I keep GetNavigationDirection?
-
-
 /// <summary>
 /// Represents an abstract base class for UI control nodes, providing core functionality for hierarchy, state, events, and input handling.
 /// </summary>

--- a/ShapeEngine/UI/ControlNodeContainer.cs
+++ b/ShapeEngine/UI/ControlNodeContainer.cs
@@ -95,7 +95,8 @@ public class ControlNodeContainer : ControlNode
                 displayIndex = value;
             }
             
-
+            CompileDisplayedNodes();
+            RefreshChildRects();
         }
     }
 
@@ -141,6 +142,11 @@ public class ControlNodeContainer : ControlNode
     /// <param name="mousePosValid">Indicates if the mouse position is valid.</param>
     protected override void OnUpdate(float dt, Vector2 mousePos, bool mousePosValid)
     {
+        UpdateLayoutConstants();
+    }
+
+    private void UpdateLayoutConstants()
+    {
         if (!Grid.IsValid) return;
         if(dirty) CompileDisplayedNodes();
 
@@ -179,8 +185,21 @@ public class ControlNodeContainer : ControlNode
         direction = Grid.Placement.ToVector2();
         alignment = Grid.Placement.Invert().ToAlignement();
         curOffset = new(0f, 0f);
-
-
+    }
+    
+    private void RefreshChildRects()
+    {
+        UpdateLayoutConstants();
+        if (DisplayedChildren == null) return;
+        curOffset = new(0f, 0f);
+        foreach (var child in DisplayedChildren)
+        {
+            child.UpdateRect(SetChildRect(child, Rect));
+            if (child is ControlNodeContainer container)
+            {
+                container.RefreshChildRects();
+            }
+        }
     }
     /// <summary>
     /// Sets the rectangle for a child node based on the current layout.

--- a/ShapeEngine/UI/ControlNodeContainer.cs
+++ b/ShapeEngine/UI/ControlNodeContainer.cs
@@ -12,6 +12,8 @@ namespace ShapeEngine.UI;
 /// </remarks>
 public class ControlNodeContainer : ControlNode
 {
+    #region Events
+    
     /// <summary>
     /// Occurs when the first node in the container is selected.
     /// <list type="bullet">
@@ -20,6 +22,7 @@ public class ControlNodeContainer : ControlNode
     /// </list>
     /// </summary>
     public event Action<ControlNode, ControlNode>? OnFirstNodeSelected;
+  
     /// <summary>
     /// Occurs when the last node in the container is selected.
     /// <list type="bullet">
@@ -28,6 +31,7 @@ public class ControlNodeContainer : ControlNode
     /// </list>
     /// </summary>
     public event Action<ControlNode, ControlNode>? OnLastNodeSelected;
+    
     /// <summary>
     /// Occurs when any node in the container is selected.
     /// <list type="bullet">
@@ -37,6 +41,9 @@ public class ControlNodeContainer : ControlNode
     /// </summary>
     public event Action<ControlNode, ControlNode>? OnNodeSelected;
 
+    #endregion
+    
+    #region Public Members
     private Grid grid = new();
 
     /// <summary>
@@ -62,10 +69,12 @@ public class ControlNodeContainer : ControlNode
     /// If false, the display index is incremented/decremented by displayCount as long as 0 or childCount is not reached.
     /// </summary>
     public bool AlwaysKeepFilled = true;
+    
     /// <summary>
     /// Gets the number of elements to display based on the grid configuration.
     /// </summary>
     private int DisplayCount => grid.Count;
+    
     /// <summary>
     /// Gets or sets the index of the first displayed child node.
     /// </summary>
@@ -101,6 +110,7 @@ public class ControlNodeContainer : ControlNode
     }
 
     private int navigationStep = 1;
+    
     /// <summary>
     /// Gets or sets the navigation step size for moving between nodes.
     /// </summary>
@@ -114,22 +124,32 @@ public class ControlNodeContainer : ControlNode
             navigationStep = value;
         }
     }
+    
     /// <summary>
     /// Gets or sets the gap between elements in the container as a <see cref="Vector2"/>.
     /// </summary>
     public Vector2 Gap { get; set; }
 
+    #endregion
+    
     #region Private Members
+    
     private int displayIndex;
     
     private bool dirty;
     
     private Vector2 curOffset;
+   
     private Size gapSize = new();
+    
     private Vector2 startPos;
+    
     private Size elementSize = new();
+    
     private Vector2 direction;
+    
     private AnchorPoint alignment = new();
+    
     #endregion
     
     #region Override
@@ -201,6 +221,7 @@ public class ControlNodeContainer : ControlNode
             }
         }
     }
+  
     /// <summary>
     /// Sets the rectangle for a child node based on the current layout.
     /// </summary>
@@ -249,6 +270,7 @@ public class ControlNodeContainer : ControlNode
             return r;
         }
     }
+    
     /// <summary>
     /// Handles logic when a child node is added to the container.
     /// </summary>
@@ -260,6 +282,7 @@ public class ControlNodeContainer : ControlNode
         newChild.OnVisibleInHierarchyChanged += OnChildVisibleInHierarchyChanged;
         newChild.OnNavigated += OnChildNavigated;
     }
+    
     /// <summary>
     /// Handles logic when a child node is removed from the container.
     /// </summary>
@@ -350,16 +373,19 @@ public class ControlNodeContainer : ControlNode
     /// </summary>
     /// <param name="node">The selected node.</param>
     protected virtual void FirstNodeWasSelected(ControlNode node) { }
+ 
     /// <summary>
     /// Called when the last node is selected. Override to provide custom logic.
     /// </summary>
     /// <param name="node">The selected node.</param>
     protected virtual void LastNodeWasSelected(ControlNode node) { }
+    
     /// <summary>
     /// Called when any node is selected. Override to provide custom logic.
     /// </summary>
     /// <param name="node">The selected node.</param>
     protected virtual void NodeWasSelected(ControlNode node) { }
+    
     /// <summary>
     /// Determines if the specified node is the first displayed node.
     /// </summary>
@@ -378,6 +404,7 @@ public class ControlNodeContainer : ControlNode
 
         return false;
     }
+    
     /// <summary>
     /// Determines if the specified node is the last displayed node.
     /// </summary>
@@ -399,10 +426,12 @@ public class ControlNodeContainer : ControlNode
     #endregion
 
     #region Public
+    
     /// <summary>
     /// Moves to the next item in the container.
     /// </summary>
     public void NextItem() => DisplayIndex += 1;
+   
     /// <summary>
     /// Moves to the previous item in the container.
     /// </summary>
@@ -412,10 +441,12 @@ public class ControlNodeContainer : ControlNode
     /// Gets the maximum number of pages based on the display count and child count.
     /// </summary>
     public int MaxPages => DisplayCount <= 0 ? 1 : (int)MathF.Ceiling(ChildCount / (float)DisplayCount);
+    
     /// <summary>
     /// Gets the current page number.
     /// </summary>
     public int CurPage => DisplayCount <= 0 ? 1 : ((DisplayIndex + DisplayCount - 1) / DisplayCount) + 1;
+    
     /// <summary>
     /// Moves to the next page.
     /// </summary>
@@ -428,6 +459,7 @@ public class ControlNodeContainer : ControlNode
         
         else DisplayIndex += DisplayCount;
     }
+    
     /// <summary>
     /// Moves to the previous page.
     /// </summary>
@@ -439,6 +471,7 @@ public class ControlNodeContainer : ControlNode
         if(wrapAround && CurPage <= 1) LastPage();
         else DisplayIndex -= DisplayCount;
     }
+    
     /// <summary>
     /// Moves the display by a specified number of pages.
     /// </summary>
@@ -454,14 +487,23 @@ public class ControlNodeContainer : ControlNode
     /// Moves to the first page.
     /// </summary>
     public void FirstPage() => DisplayIndex = 0;
+    
     /// <summary>
     /// Moves to the last page.
     /// </summary>
     public void LastPage() => DisplayIndex = ChildCount - DisplayCount;
 
+    /// <summary>
+    /// Returns true if the specified child is currently displayed.
+    /// </summary>
+    /// <param name="child">The child to check.</param>
+    /// <returns>True if the child is displayed; otherwise, false.</returns>
+    public bool IsDisplayed(ControlNode child) => DisplayedChildren != null && DisplayedChildren.Contains(child);
+
     #endregion
     
     #region Private
+   
     /// <summary>
     /// Compiles the list of currently displayed child nodes based on visibility and display index.
     /// </summary>
@@ -507,6 +549,7 @@ public class ControlNodeContainer : ControlNode
     {
         dirty = true;
     }
+  
     /// <summary>
     /// Handles changes in a child's selection state.
     /// </summary>
@@ -516,6 +559,7 @@ public class ControlNodeContainer : ControlNode
     {
         if(selected) ResolveOnNodeSelected(child);
     }
+    
     /// <summary>
     /// Resolves the event when the first node is selected.
     /// </summary>
@@ -525,6 +569,7 @@ public class ControlNodeContainer : ControlNode
         FirstNodeWasSelected(node);
         OnFirstNodeSelected?.Invoke(this, node);
     }
+    
     /// <summary>
     /// Resolves the event when the last node is selected.
     /// </summary>
@@ -534,6 +579,7 @@ public class ControlNodeContainer : ControlNode
         LastNodeWasSelected(node);
         OnLastNodeSelected?.Invoke(this, node);
     }
+    
     /// <summary>
     /// Resolves the event when any node is selected.
     /// </summary>
@@ -547,5 +593,6 @@ public class ControlNodeContainer : ControlNode
         OnNodeSelected?.Invoke(this, node);
         
     }
+    
     #endregion
 }

--- a/ShapeEngine/UI/ControlNodeNavigator.cs
+++ b/ShapeEngine/UI/ControlNodeNavigator.cs
@@ -310,6 +310,9 @@ public class ControlNodeNavigator
         if (!IsNavigating || selectedNode == null || !dir.IsValid) return false;
 
         var currentNode = selectedNode;
+        
+        // Always notify the current node of the navigation attempt.
+        // This is required for container scrolling to work even if focus doesn't change.
         currentNode.NavigatedTo(dir);
         
         var nextNode = explicitNextNode ?? GetNextNode(dir);
@@ -325,10 +328,14 @@ public class ControlNodeNavigator
                 throw new WarningException(
                     "Control Node Navigation Selected return false when it should have returned true!");
             }
+   
+            // Successfully navigated to a new node
+            ResolveOnNavigated(dir);
+            return true;
         }
 
-        ResolveOnNavigated(dir);
-        return true;
+        // No navigation occurred
+        return false;
     }
     
     private bool CanNavigate()

--- a/ShapeEngine/UI/ControlNodeNavigator.cs
+++ b/ShapeEngine/UI/ControlNodeNavigator.cs
@@ -46,9 +46,27 @@ public class ControlNodeNavigator
     private bool dirty;
     private ControlNode? selectedNode;
 
+    private Direction currentRepeatDir = new();
+    private float repeatTimer = 0f;
+
     #endregion
 
     #region Getter & Setter
+
+    /// <summary>
+    /// Gets or sets whether navigation repeat is enabled.
+    /// </summary>
+    public bool NavigationRepeatEnabled { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets the delay before navigation starts repeating when a direction is held.
+    /// </summary>
+    public float NavigationRepeatDelay { get; set; } = 0.35f;
+
+    /// <summary>
+    /// Gets or sets the interval between navigation repeats when a direction is held.
+    /// </summary>
+    public float NavigationRepeatInterval { get; set; } = 0.1f;
 
     /// <summary>
     /// Gets the currently selected control node.
@@ -65,6 +83,10 @@ public class ControlNodeNavigator
         if (selectedNode == newNode) return;
         var prev = selectedNode;
         selectedNode = newNode;
+
+        currentRepeatDir = new();
+        repeatTimer = 0f;
+
         ResolveOnSelectedControlNodeChanged(prev, selectedNode);
     }
 
@@ -181,10 +203,18 @@ public class ControlNodeNavigator
     /// <summary>
     /// Updates the navigation state, handling pending navigation and selection changes.
     /// </summary>
-    public void Update()
+    /// <remarks> This function is deprecated and will be removed in a future update!
+    /// Use <see cref="Update(float)"/> instead.</remarks>
+    public void Update() => Update(0f);
+
+    /// <summary>
+    /// Updates the navigation state, handling pending navigation and selection changes.
+    /// </summary>
+    /// <param name="dt">The delta time since the last update.</param>
+    public void Update(float dt)
     {
         if (!IsNavigating) return;
-        
+
         if (selectedNode == null)
         {
             var navigable = GetNavigableNodes();
@@ -199,7 +229,7 @@ public class ControlNodeNavigator
             }
             else return;
         }
-        
+
         if (navigationPending)
         {
             navigationPending = false;
@@ -208,15 +238,58 @@ public class ControlNodeNavigator
             var nextNode = nextNodeToSelect;
             nextNodeToSelect = null;
 
-            TryNavigate(dir, nextNode);
+            if (TryNavigate(dir, nextNode))
+            {
+                currentRepeatDir = dir;
+                repeatTimer = NavigationRepeatDelay;
+            }
         }
         else
         {
             var dir = selectedNode.GetNavigationDirection();
             if (dir.IsValid)
             {
-                navigationPending = true;
-                prevDir = dir;
+                if (NavigationRepeatEnabled)
+                {
+                    if (dir != currentRepeatDir)
+                    {
+                        if (TryNavigate(dir))
+                        {
+                            currentRepeatDir = dir;
+                            repeatTimer = NavigationRepeatDelay;
+                        }
+                        else
+                        {
+                            currentRepeatDir = dir;
+                            repeatTimer = NavigationRepeatDelay;
+                        }
+                    }
+                    else
+                    {
+                        repeatTimer -= dt;
+                        if (repeatTimer <= 0)
+                        {
+                            if (TryNavigate(dir))
+                            {
+                                currentRepeatDir = dir;
+                                repeatTimer = NavigationRepeatInterval;
+                            }
+                            else
+                            {
+                                repeatTimer = NavigationRepeatInterval;
+                            }
+                        }
+                    }
+                }
+                else
+                {
+                    TryNavigate(dir);
+                }
+            }
+            else
+            {
+                currentRepeatDir = new();
+                repeatTimer = 0f;
             }
         }
     }

--- a/ShapeEngine/UI/ControlNodeNavigator.cs
+++ b/ShapeEngine/UI/ControlNodeNavigator.cs
@@ -458,6 +458,7 @@ public class ControlNodeNavigator
         node.OnChildAdded += OnControlNodeChildAdded;
         node.OnChildRemoved += OnControlNodeChildRemoved;
         node.OnSelectedChanged += OnNodeSelectionChanged;
+        node.OnPressedReleased += OnNodePressedReleased;
         
         ResolveOnControlNodeAdded(node);
 
@@ -473,8 +474,12 @@ public class ControlNodeNavigator
         node.OnChildAdded -= OnControlNodeChildAdded;
         node.OnChildRemoved -= OnControlNodeChildRemoved;
         node.OnSelectedChanged -= OnNodeSelectionChanged;
+        node.OnPressedReleased -= OnNodePressedReleased;
+        
         if (node == selectedNode) SetSelectedNode(null);
+        
         ResolveOnControlNodeRemoved(node);
+        
         foreach (var child in node.GetChildrenEnumerable)
         {
             HandleNodeRemoval(child);
@@ -493,34 +498,99 @@ public class ControlNodeNavigator
         HandleNodeRemoval(child);
     }
     
+    private void OnNodePressedReleased(ControlNode node)
+    {
+        // Only treat it as a "mouse click selects" when the mouse is actually over that node.
+        // Keyboard/gamepad "accept" releases should keep normal navigation behavior.
+        if (!node.MouseInside) return;
+
+        // If the node can't be selected, do nothing.
+        if (!node.IsActiveInHierarchy || !node.IsVisibleInHierarchy) return;
+        if (node.SelectionFilter is SelectFilter.None or SelectFilter.Navigation) return;
+
+        // Force transfer selection to the clicked/hovered node.
+        // This intentionally overrides the "hover shouldn't steal navigation focus" rule in OnNodeSelectionChanged.
+        if (selectedNode != null && selectedNode != node)
+        {
+            if (IsNavigating) selectedNode.NavigationDeselect();
+            else selectedNode.Deselect();
+        }
+
+        SetSelectedNode(node);
+
+        if (IsNavigating)
+        {
+            // Keep navigator state consistent: selected node should be navigation-selected.
+            node.NavigationSelect();
+        }
+        else
+        {
+            node.Select();
+        }
+    }
+    
     private void OnNodeSelectionChanged(ControlNode node, bool value)
     {
         if (!value) return;
+        
+        // Only react to nodes that are currently eligible for navigator focus
         if (!node.Navigable) return;
+        
+        // If we're not in navigation mode, don't enforce any "hover can't steal focus" rules.
+        // (Mouse click selection is handled elsewhere via OnPressedReleased.)
+        if (!IsNavigating) return;
         
         if (selectedNode == null)
         {
             SetSelectedNode(node);
-            node.NavigationSelect();
+            
+            if (selectedNode == null || !selectedNode.NavigationSelect())
+            {
+                throw new WarningException(
+                    "Control Node Navigation Selected returned false when it should have returned true!");
+            }
+            
+            // node.NavigationSelect();
             return;
         }
         
-        if (node != selectedNode)
+        // If the currently navigation-selected node is also selected, do nothing.
+        if (node == selectedNode) return;
+        
+        // Hover-selection should not steal navigation focus within the same container
+        if (node.MouseInside && node.Parent == selectedNode.Parent)
         {
-            //if navigation selection changed and a node is currently hovered by the mouse,
-            //the mouse selected node will be ignored in favor of the current selected node (if both have the same parent)
-            if (node.MouseInside && node.Parent == selectedNode.Parent)
-            {
-                node.Deselect();
-                SetSelectedNode(selectedNode);
-                selectedNode.NavigationSelect();
-                return;
-            }
-            
-            selectedNode.Deselect();
-            SetSelectedNode(node);
-            selectedNode.NavigationSelect();
+            node.Deselect();               // undo hover-based selection
+            selectedNode.NavigationSelect(); // re-assert navigation selection state
+            return;
         }
+        
+        // Otherwise, treat it as a legitimate navigation selection change
+        selectedNode.NavigationDeselect();
+        SetSelectedNode(node);
+        
+        if (selectedNode == null || !selectedNode.NavigationSelect())
+        {
+            throw new WarningException(
+                "Control Node Navigation Selected returned false when it should have returned true!");
+        }
+        
+        // if (node != selectedNode)
+        // {
+        //     //if navigation selection changed and a node is currently hovered by the mouse,
+        //     //the mouse selected node will be ignored in favor of the current selected node (if both have the same parent)
+        //     if (node.MouseInside && node.Parent == selectedNode.Parent)
+        //     {
+        //         node.Deselect();
+        //         // SetSelectedNode(selectedNode);
+        //         selectedNode.NavigationSelect();
+        //         return;
+        //     }
+        //     
+        //     selectedNode.Deselect();
+        //     SetSelectedNode(node);
+        //     selectedNode.NavigationSelect();
+        // }
     }
     
     private void OnControlNodeNavigableChanged(ControlNode node, bool navigable)

--- a/ShapeEngine/UI/ControlNodeNavigator.cs
+++ b/ShapeEngine/UI/ControlNodeNavigator.cs
@@ -4,13 +4,6 @@ using ShapeEngine.Core.Structs;
 
 namespace ShapeEngine.UI;
 
-//ISSUE: When navigating a scrollable container:
-// - and reaching the end (and no other items are selectable) selection will jump to the top instead of just not moving
-// - and reaching the top (and no other items are selectable) selection will jump to the second item instead of just not moving
-// (will keep alternating between the top and second item)
-// - if item is selected by mouse after reaching an end and container scrolls, selection will jump to the mouse selected item
-// instead of the new available item!
-
 /// <summary>
 /// Provides navigation and selection logic for a set of <see cref="ControlNode"/> instances, supporting keyboard/gamepad navigation and selection events.
 /// </summary>
@@ -101,7 +94,7 @@ public class ControlNodeNavigator
     /// Gets whether navigation is currently active.
     /// </summary>
     public bool IsNavigating { get; private set; }
-
+    
     #endregion
 
     #region Public
@@ -371,7 +364,10 @@ public class ControlNodeNavigator
         if (index < 0) return null;
 
         index += 1;
-        if (index >= navigable.Count) index = 0;
+        if (index >= navigable.Count)
+        {
+            index = 0;
+        }
         return navigable[index];
     }
     
@@ -383,7 +379,10 @@ public class ControlNodeNavigator
         if (index < 0) return null;
 
         index -= 1;
-        if (index < 0) index = navigable.Count - 1;
+        if (index < 0)
+        {
+            index = navigable.Count - 1;
+        }
         return navigable[index];
     }
     
@@ -405,11 +404,6 @@ public class ControlNodeNavigator
             var dif = node.GetNavigationOrigin(dir) - origin;
             var neighborDistanceSquared = GetNeighborDistance(dif, dir);
             
-            if (node.Parent != null && node.Parent == selectedNode.Parent)
-            {
-                neighborDistanceSquared *= 0.1f;
-            }
-
             if (neighborDistanceSquared >= minDisSq) continue;
             minDisSq = neighborDistanceSquared;
             newNode = node;
@@ -513,6 +507,16 @@ public class ControlNodeNavigator
         
         if (node != selectedNode)
         {
+            //if navigation selection changed and a node is currently hovered by the mouse,
+            //the mouse selected node will be ignored in favor of the current selected node (if both have the same parent)
+            if (node.MouseInside && node.Parent == selectedNode.Parent)
+            {
+                node.Deselect();
+                SetSelectedNode(selectedNode);
+                selectedNode.NavigationSelect();
+                return;
+            }
+            
             selectedNode.Deselect();
             SetSelectedNode(node);
             selectedNode.NavigationSelect();

--- a/ShapeEngine/UI/ControlNodeNavigator.cs
+++ b/ShapeEngine/UI/ControlNodeNavigator.cs
@@ -4,6 +4,13 @@ using ShapeEngine.Core.Structs;
 
 namespace ShapeEngine.UI;
 
+//ISSUE: When navigating a scrollable container:
+// - and reaching the end (and no other items are selectable) selection will jump to the top instead of just not moving
+// - and reaching the top (and no other items are selectable) selection will jump to the second item instead of just not moving
+// (will keep alternating between the top and second item)
+// - if item is selected by mouse after reaching an end and container scrolls, selection will jump to the mouse selected item
+// instead of the new available item!
+
 /// <summary>
 /// Provides navigation and selection logic for a set of <see cref="ControlNode"/> instances, supporting keyboard/gamepad navigation and selection events.
 /// </summary>
@@ -258,11 +265,6 @@ public class ControlNodeNavigator
                             currentRepeatDir = dir;
                             repeatTimer = NavigationRepeatDelay;
                         }
-                        else
-                        {
-                            currentRepeatDir = dir;
-                            repeatTimer = NavigationRepeatDelay;
-                        }
                     }
                     else
                     {
@@ -272,10 +274,6 @@ public class ControlNodeNavigator
                             if (TryNavigate(dir))
                             {
                                 currentRepeatDir = dir;
-                                repeatTimer = NavigationRepeatInterval;
-                            }
-                            else
-                            {
                                 repeatTimer = NavigationRepeatInterval;
                             }
                         }
@@ -319,20 +317,21 @@ public class ControlNodeNavigator
         if (!IsNavigating || selectedNode == null || !dir.IsValid) return false;
 
         var currentNode = selectedNode;
+        currentNode.NavigatedTo(dir);
+        
         var nextNode = explicitNextNode ?? GetNextNode(dir);
 
-        if (nextNode == null || nextNode == currentNode) return false;
-        if (!CheckNextNode(nextNode, dir)) return false;
-
-        currentNode.NavigatedTo(dir);
-        currentNode.NavigationDeselect();
-
-        SetSelectedNode(nextNode);
-
-        if (selectedNode == null || !selectedNode.NavigationSelect())
+        if (nextNode != null && nextNode != currentNode && CheckNextNode(nextNode, dir))
         {
-            throw new WarningException(
-                "Control Node Navigation Selected return false when it should have returned true!");
+            currentNode.NavigationDeselect();
+
+            SetSelectedNode(nextNode);
+
+            if (selectedNode == null || !selectedNode.NavigationSelect())
+            {
+                throw new WarningException(
+                    "Control Node Navigation Selected return false when it should have returned true!");
+            }
         }
 
         ResolveOnNavigated(dir);
@@ -405,6 +404,12 @@ public class ControlNodeNavigator
             
             var dif = node.GetNavigationOrigin(dir) - origin;
             var neighborDistanceSquared = GetNeighborDistance(dif, dir);
+            
+            if (node.Parent != null && node.Parent == selectedNode.Parent)
+            {
+                neighborDistanceSquared *= 0.1f;
+            }
+
             if (neighborDistanceSquared >= minDisSq) continue;
             minDisSq = neighborDistanceSquared;
             newNode = node;

--- a/ShapeEngine/UI/ControlNodeNavigator.cs
+++ b/ShapeEngine/UI/ControlNodeNavigator.cs
@@ -86,6 +86,7 @@ public class ControlNodeNavigator
         selectedNode?.NavigationSelect();
         ResolveOnNavigationStarted();
     }
+    
     /// <summary>
     /// Ends navigation mode, disabling selection and navigation of control nodes.
     /// </summary>
@@ -108,6 +109,7 @@ public class ControlNodeNavigator
             RemoveNode(node);
         }
     }
+  
     /// <summary>
     /// Adds a control node to the navigator.
     /// </summary>
@@ -120,6 +122,7 @@ public class ControlNodeNavigator
         HandleNodeAddition(node);
         return true;
     }
+    
     /// <summary>
     /// Removes a control node from the navigator.
     /// </summary>
@@ -143,7 +146,7 @@ public class ControlNodeNavigator
     /// <param name="grid">The grid describing navigation layout and direction.</param>
     public void SelectNext(Grid grid)
     {
-        if (!IsNavigating || selectedNode == null || !grid.IsValid) return;
+        if (!CanNavigate() || !grid.IsValid) return;
         var dir = grid.GetNextDirection();
         if (grid.IsGrid)
         {
@@ -151,7 +154,7 @@ public class ControlNodeNavigator
             if (next == null || next == selectedNode) return;
             nextNodeToSelect = next;
         }
-        selectedNode.NavigatedTo(dir);
+        // selectedNode!.NavigatedTo(dir);
         navigationPending = true;
         prevDir = dir;
     }
@@ -162,7 +165,7 @@ public class ControlNodeNavigator
     /// <param name="grid">The grid describing navigation layout and direction.</param>
     public void SelectPrevious(Grid grid)
     {
-        if (!IsNavigating || selectedNode == null || !grid.IsValid) return;
+        if (!CanNavigate() || !grid.IsValid) return;
         var dir = grid.GetPreviousDirection();
         if (grid.IsGrid)
         {
@@ -170,7 +173,7 @@ public class ControlNodeNavigator
             if (prev == null || prev == selectedNode) return;
             nextNodeToSelect = prev;
         }
-        selectedNode.NavigatedTo(dir);
+        // selectedNode!.NavigatedTo(dir);
         navigationPending = true;
         prevDir = dir;
     }
@@ -181,6 +184,7 @@ public class ControlNodeNavigator
     public void Update()
     {
         if (!IsNavigating) return;
+        
         if (selectedNode == null)
         {
             var navigable = GetNavigableNodes();
@@ -195,26 +199,22 @@ public class ControlNodeNavigator
             }
             else return;
         }
+        
         if (navigationPending)
         {
             navigationPending = false;
+
             var dir = prevDir;
-            var nextNode = nextNodeToSelect ?? GetNextNode(dir);
+            var nextNode = nextNodeToSelect;
             nextNodeToSelect = null;
-            if (nextNode != null && CheckNextNode(nextNode, dir))
-            {
-                selectedNode.NavigationDeselect();
-                SetSelectedNode(nextNode);
-                selectedNode.NavigationSelect();
-                ResolveOnNavigated(dir);
-            }
+
+            TryNavigate(dir, nextNode);
         }
         else
         {
             var dir = selectedNode.GetNavigationDirection();
             if (dir.IsValid)
             {
-                selectedNode.NavigatedTo(dir);
                 navigationPending = true;
                 prevDir = dir;
             }
@@ -241,7 +241,36 @@ public class ControlNodeNavigator
         }
     }
     
+    private bool TryNavigate(Direction dir, ControlNode? explicitNextNode = null)
+    {
+        if (!IsNavigating || selectedNode == null || !dir.IsValid) return false;
+
+        var currentNode = selectedNode;
+        var nextNode = explicitNextNode ?? GetNextNode(dir);
+
+        if (nextNode == null || nextNode == currentNode) return false;
+        if (!CheckNextNode(nextNode, dir)) return false;
+
+        currentNode.NavigatedTo(dir);
+        currentNode.NavigationDeselect();
+
+        SetSelectedNode(nextNode);
+
+        if (selectedNode == null || !selectedNode.NavigationSelect())
+        {
+            throw new WarningException(
+                "Control Node Navigation Selected return false when it should have returned true!");
+        }
+
+        ResolveOnNavigated(dir);
+        return true;
+    }
     
+    private bool CanNavigate()
+    {
+        return IsNavigating && selectedNode != null;
+    }
+   
     private ControlNode? GetClosestNode(ControlNode node)
     {
         var navigable = GetNavigableNodes();
@@ -261,6 +290,7 @@ public class ControlNodeNavigator
         }
         return closestNode;
     }
+    
     private ControlNode? GetNextNode()
     {
         if (selectedNode == null) return null;
@@ -272,6 +302,7 @@ public class ControlNodeNavigator
         if (index >= navigable.Count) index = 0;
         return navigable[index];
     }
+    
     private ControlNode? GetPrevNode()
     {
         if (selectedNode == null) return null;
@@ -283,6 +314,7 @@ public class ControlNodeNavigator
         if (index < 0) index = navigable.Count - 1;
         return navigable[index];
     }
+    
     private ControlNode? GetNextNode(Direction dir)
     {
         if (!dir.IsValid) return null;
@@ -306,6 +338,7 @@ public class ControlNodeNavigator
         }
         return newNode;
     }
+    
     private float GetNeighborDistance(Vector2 dif, Direction dir)
     {
         if (dir.IsLeft) return dif.X < 0 ? dif.LengthSquared() : float.MaxValue;
@@ -320,11 +353,13 @@ public class ControlNodeNavigator
         
         return float.MaxValue;
     }
+    
     private List<ControlNode> GetNavigableNodes()
     {
         if(dirty) CompileNavigableControlNodes();
         return navigableNodes;
     }
+    
     private void CompileNavigableControlNodes()
     {
         dirty = false;
@@ -338,6 +373,7 @@ public class ControlNodeNavigator
 
         if (result.Count > 0) navigableNodes.AddRange(result);
     }
+    
     private void HandleNodeAddition(ControlNode node)
     {
         if (node.Selected)
@@ -358,6 +394,7 @@ public class ControlNodeNavigator
             HandleNodeAddition(child);
         }
     }
+    
     private void HandleNodeRemoval(ControlNode node)
     {
         node.OnNavigableChanged -= OnControlNodeNavigableChanged;
@@ -371,16 +408,19 @@ public class ControlNodeNavigator
             HandleNodeRemoval(child);
         }
     }
+    
     private void OnControlNodeChildAdded(ControlNode node, ControlNode child)
     {
         dirty = true;
         HandleNodeAddition(child);
     }
+    
     private void OnControlNodeChildRemoved(ControlNode node, ControlNode child)
     {
         dirty = true;
         HandleNodeRemoval(child);
     }
+    
     private void OnNodeSelectionChanged(ControlNode node, bool value)
     {
         if (!value) return;
@@ -400,6 +440,7 @@ public class ControlNodeNavigator
             selectedNode.NavigationSelect();
         }
     }
+    
     private void OnControlNodeNavigableChanged(ControlNode node, bool navigable)
     {
         dirty = true;


### PR DESCRIPTION
- [x] When button is selected and holding pressed, selecting other button with mouse will keep pressed button stuck in pressed even when releasing!
- [x] Extra check has to be added to not allow navigation while button is pressed (should be done internally)
- [x] GetButtonPressedState & GetButtonReleaseState has to check for Selected but GetMouseButtonPressedState & GetMouseButtonReleaseState does not have to check for Selected or MouseInside!
- [x] Add Navigation input timer to ControlNode? Whenever GetNavigationDirection reports a direction and change is valid (selection changes) start timer?
- [ ] If pressed is true selected is also true - Should this stay this way or should there only be one state (None, Selected, Pressed, Release) + MouseInside?
- [ ] Should I add GetUpDirection, GetDownDirection, GetLeftDirection, GetRightDirection or should I keep GetNavigationDirection?